### PR TITLE
Update/avatar: size adjustments

### DIFF
--- a/components/avatar/theme.css
+++ b/components/avatar/theme.css
@@ -6,9 +6,9 @@
   --overflow-padding-horizontal: 8px;
   --stacked-avatars-overlap-margin: -4px;
 
-  --tiny-size: 21px;
-  --small-size: 32px;
-  --medium-size: 44px;
+  --tiny-size: 24px;
+  --small-size: 36px;
+  --medium-size: 48px;
 }
 
 /* Avatar */


### PR DESCRIPTION
The old sizes were applicable when there was a 2px border around the avatars. We removed that border a while ago...