### PR TITLE
Excessive margin on Tab Elements fix

### DIFF
--- a/components/tab/IconTab.js
+++ b/components/tab/IconTab.js
@@ -51,7 +51,6 @@ class IconTab extends PureComponent {
       <Box
         data-teamleader-ui="icon-tab"
         className={classNames}
-        marginHorizontal={3}
         paddingHorizontal={3}
         paddingVertical={4}
         ref={node => {

--- a/components/tab/TabGroup.js
+++ b/components/tab/TabGroup.js
@@ -19,6 +19,7 @@ class TabGroup extends PureComponent {
     const { children, className, inverted, ...others } = this.props;
 
     const classNames = cx(
+      theme['tab-group'],
       {
         [theme['inverted']]: inverted,
       },

--- a/components/tab/TitleTab.js
+++ b/components/tab/TitleTab.js
@@ -52,7 +52,6 @@ class TitleTab extends PureComponent {
       <Box
         data-teamleader-ui="title-tab"
         className={classNames}
-        marginHorizontal={3}
         paddingHorizontal={3}
         paddingVertical={4}
         ref={node => {

--- a/components/tab/theme.css
+++ b/components/tab/theme.css
@@ -1,5 +1,16 @@
 @import '@teamleader/ui-colors';
 @import '@teamleader/ui-animations';
+@import '@teamleader/ui-utilities';
+
+.tab-group {
+  & > * {
+    margin-left: var(--spacer-small);
+  }
+
+  & > *:last-child {
+    margin-right: var(--spacer-small);
+  }
+}
 
 .title-tab,
 .icon-tab {

--- a/components/tab/theme.css
+++ b/components/tab/theme.css
@@ -5,10 +5,10 @@
 .tab-group {
   & > * {
     margin-left: var(--spacer-small);
-  }
 
-  & > *:last-child {
-    margin-right: var(--spacer-small);
+    &:last-child{
+      margin-right: var(--spacer-small);
+    }
   }
 }
 

--- a/stories/tab.js
+++ b/stories/tab.js
@@ -125,8 +125,8 @@ storiesOf('Tab', module)
   ));
 
 const TitleTabContainer = () => (
-  <TabGroup>
-    <Island style={{ display: 'flex' }}>
+  <Island>
+    <TabGroup display={'flex'}>
       {store.get('items').map((item, key) => {
         const optionalProps = item.count
           ? { counter: React.createElement(TitleCounter, { count: item.count, color: 'mint' }) }
@@ -145,13 +145,13 @@ const TitleTabContainer = () => (
           </TitleTab>
         );
       })}
-    </Island>
-  </TabGroup>
+    </TabGroup>
+  </Island>
 );
 
 const InvertedTitleTabContainer = () => (
-  <TabGroup inverted>
-    <Island style={{ display: 'flex', background: '#2a3b4d' }}>
+  <Island style={{ background: '#2a3b4d' }}>
+    <TabGroup inverted display={'flex'}>
       {store.get('invertedItems').map((invertedItem, key) => {
         const optionalProps = invertedItem.count
           ? { counter: React.createElement(TitleCounter, { count: invertedItem.count }) }
@@ -170,13 +170,13 @@ const InvertedTitleTabContainer = () => (
           </TitleTab>
         );
       })}
-    </Island>
-  </TabGroup>
+    </TabGroup>
+  </Island>
 );
 
 const IconTabContainer = () => (
-  <TabGroup>
-    <Island style={{ display: 'flex' }}>
+  <Island>
+    <TabGroup display={'flex'}>
       {store.get('items').map((item, key) => {
         const optionalProps = item.count
           ? { counter: React.createElement(IconCounter, { count: item.count, color: 'mint' }) }
@@ -197,13 +197,13 @@ const IconTabContainer = () => (
           </IconTab>
         );
       })}
-    </Island>
-  </TabGroup>
+    </TabGroup>
+  </Island>
 );
 
 const InvertedIconTabContainer = () => (
-  <TabGroup inverted>
-    <Island style={{ display: 'flex', background: '#2a3b4d' }}>
+  <Island style={{ background: '#2a3b4d' }}>
+    <TabGroup inverted display={'flex'}>
       {store.get('invertedItems').map((invertedItem, key) => {
         const optionalProps = invertedItem.count
           ? { counter: React.createElement(IconCounter, { count: invertedItem.count }) }
@@ -224,6 +224,6 @@ const InvertedIconTabContainer = () => (
           </IconTab>
         );
       })}
-    </Island>
-  </TabGroup>
+    </TabGroup>
+  </Island>
 );


### PR DESCRIPTION
### Added
- Class for TabGroup

### Changed
- Removed the margin off each element and added CSS to the TabGroup which adds margin-left to each child and margin-right to the last child. This is how it was intended by design, I just didn't implement it correctly before.
- Changed the story in order for TabGroup to not have Island as child but Tab-elements