### PR TITLE
Make sure there is no text decoration on the links in the pagination

### DIFF
--- a/components/pagination/theme.css
+++ b/components/pagination/theme.css
@@ -43,6 +43,7 @@
 
   > * {
     transition: none;
+    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
### Fixed
* Make sure there is no text decoration on the links in the pagination when using `<a>` as link component