### PR TITLE
Updating tab component

### DIFF
--- a/components/tab/theme.css
+++ b/components/tab/theme.css
@@ -28,7 +28,7 @@
   flex-shrink: 0;
 
   &:focus {
-    box-shadow: 0 0 0 2px var(--color-neutral);
+    box-shadow: inset 0 0 0 2px var(--color-neutral);
 
     .counter {
       box-shadow: 0 0 0 2px var(--color-neutral-light);

--- a/components/tab/theme.css
+++ b/components/tab/theme.css
@@ -25,6 +25,7 @@
   background-color: var(--color-neutral-lightest);
   border: none;
   border-radius: 0;
+  flex-shrink: 0;
 
   &:focus {
     box-shadow: 0 0 0 2px var(--color-neutral);

--- a/components/tab/theme.css
+++ b/components/tab/theme.css
@@ -48,6 +48,7 @@
     height: 3px;
     width: 100%;
     bottom: 0;
+    left: 0;
     transition: transform var(--animation-duration) var(--animation-curve-fast-out-slow-in);
     transform: scale(0, 1);
   }


### PR DESCRIPTION
### Changed
- No shrinking allowed because on IE this made the tabs shrink -> undesired behaviour.
- Specifically declaring the left position on the active state because this was shown incorrect on IE
- The box-shadow just was incorrect, it was exceeding its border, that's why I put it inset now.