### PR TITLE
Update/banner: move color handling to island and section

### DIFF
--- a/components/banner/Banner.js
+++ b/components/banner/Banner.js
@@ -31,12 +31,7 @@ class Banner extends PureComponent {
 
   getCloseButtonColor() {
     const { color } = this.props;
-
-    if (color === 'white') {
-      return 'neutral';
-    }
-
-    return color;
+    return color === 'white' ? 'neutral' : color;
   }
 
   render() {

--- a/components/banner/Banner.js
+++ b/components/banner/Banner.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Island from '../island';
 import Section from '../section';
 import { IconButton } from '../button';
-import cx from 'classnames';
 import theme from './theme.css';
 import { IconCloseMediumOutline } from '@teamleader/ui-icons';
 
@@ -41,13 +40,11 @@ class Banner extends PureComponent {
   }
 
   render() {
-    const { children, className, color, icon, onClose, fullWidth, ...others } = this.props;
-
-    const classNames = cx(theme[color], className);
+    const { children, className, icon, onClose, fullWidth, ...others } = this.props;
     const Element = fullWidth ? Section : Island;
 
     return (
-      <Element data-teamleader-ui="banner" color={color} className={classNames} {...others}>
+      <Element data-teamleader-ui="banner" className={className} {...others}>
         <div className={theme['inner']}>
           {icon && <span className={theme['icon']}>{icon}</span>}
           <span className={theme['content']}>{children}</span>

--- a/components/banner/theme.css
+++ b/components/banner/theme.css
@@ -21,28 +21,3 @@
   top: -3px;
   right: -3px;
 }
-
-.white,
-.neutral {
-  color: var(--color-teal-darkest);
-}
-
-.mint {
-  color: var(--color-mint-darkest);
-}
-
-.violet {
-  color: var(--color-violet-darkest);
-}
-
-.ruby {
-  color: var(--color-ruby-darkest);
-}
-
-.gold {
-  color: var(--color-gold-darkest);
-}
-
-.aqua {
-  color: var(--color-aqua-darkest);
-}

--- a/components/island/theme.css
+++ b/components/island/theme.css
@@ -9,6 +9,7 @@
 .white {
   background-color: var(--color-white);
   border-color: var(--color-neutral);
+  color: var(--color-teal-darkest);
 
   &.dark {
     border-color: var(--color-neutral-dark);
@@ -18,6 +19,7 @@
 .neutral {
   background-color: var(--color-neutral-light);
   border-color: var(--color-neutral);
+  color: var(--color-teal-darkest);
 
   &.dark {
     border-color: var(--color-neutral-dark);
@@ -27,24 +29,29 @@
 .mint {
   background-color: var(--color-mint-lightest);
   border-color: var(--color-mint);
+  color: var(--color-mint-darkest);
 }
 
 .violet {
   background-color: var(--color-violet-lightest);
   border-color: var(--color-violet);
+  color: var(--color-violet-darkest);
 }
 
 .ruby {
   background-color: var(--color-ruby-lightest);
   border-color: var(--color-ruby);
+  color: var(--color-ruby-darkest);
 }
 
 .gold {
   background-color: var(--color-gold-lightest);
   border-color: var(--color-gold);
+  color: var(--color-gold-darkest);
 }
 
 .aqua {
   background-color: var(--color-aqua-lightest);
   border-color: var(--color-aqua);
+  color: var(--color-aqua-darkest);
 }

--- a/components/section/theme.css
+++ b/components/section/theme.css
@@ -8,6 +8,7 @@
 .white {
   background-color: var(--color-white);
   border-color: var(--color-neutral);
+  color: var(--color-teal-darkest);
 
   &.dark {
     border-color: var(--color-neutral-dark);
@@ -17,6 +18,7 @@
 .neutral {
   background-color: var(--color-neutral-light);
   border-color: var(--color-neutral);
+  color: var(--color-teal-darkest);
 
   &.dark {
     border-color: var(--color-neutral-dark);
@@ -26,25 +28,30 @@
 .mint {
   background-color: var(--color-mint-lightest);
   border-color: var(--color-mint);
+  color: var(--color-mint-darkest);
 }
 
 .violet {
   background-color: var(--color-violet-lightest);
   border-color: var(--color-violet);
+  color: var(--color-violet-darkest);
 }
 
 .ruby {
   background-color: var(--color-ruby-lightest);
   border-color: var(--color-ruby);
+  color: var(--color-ruby-darkest);
 }
 
 .gold {
   background-color: var(--color-gold-lightest);
   border-color: var(--color-gold);
+  color: var(--color-gold-darkest);
 }
 
 .aqua {
   background-color: var(--color-aqua-lightest);
   border-color: var(--color-aqua);
+  color: var(--color-aqua-darkest);
 }
 

--- a/stories/section.js
+++ b/stories/section.js
@@ -17,12 +17,12 @@ storiesOf('Section', module)
     <Box padding={5}>
       {colors.map((color, key) => (
         <Section color={color} key={key} marginTop={4}>
-          <TextBody>I am a {color} island</TextBody>
+          <TextBody>I am a {color} section</TextBody>
         </Section>
       ))}
-      <Section dark marginTop={4}><TextBody>I am a dark white island</TextBody></Section>
+      <Section dark marginTop={4}><TextBody>I am a dark white section</TextBody></Section>
       <Section color="neutral" dark marginTop={4}>
-        <TextBody>I am a dark neutral island</TextBody>
+        <TextBody>I am a dark neutral section</TextBody>
       </Section>
     </Box>
   ))


### PR DESCRIPTION
### Description
Because the color of the children in Sections and Islands wasn't adapting to the color prop, we moved this responsibility from Banner to Island and Section.

#### Screenshot before this PR
![schermafdruk 2018-01-23 11 32 11](https://user-images.githubusercontent.com/5336831/35271064-396b3100-0031-11e8-90c0-5f06817583c6.png)
![schermafdruk 2018-01-23 11 32 43](https://user-images.githubusercontent.com/5336831/35271066-3b9510ea-0031-11e8-816e-26136e8e6535.png)
![schermafdruk 2018-01-23 11 28 53](https://user-images.githubusercontent.com/5336831/35271072-3fabb378-0031-11e8-890d-3ff659aab541.png)

#### Screenshot after this PR
![schermafdruk 2018-01-23 11 27 41](https://user-images.githubusercontent.com/5336831/35270898-bb5a9f6c-0030-11e8-81c4-7f18e7445898.png)
![schermafdruk 2018-01-23 11 28 34](https://user-images.githubusercontent.com/5336831/35270904-bd9e72ee-0030-11e8-8a92-77e99a41f9e4.png)
![schermafdruk 2018-01-23 11 28 53](https://user-images.githubusercontent.com/5336831/35270907-c01938f6-0030-11e8-8098-58443a91ba6e.png)

### Breaking changes
None.
