### PR TITLE
Storybook: remove withInfo() from the icon overview story

### DIFF
--- a/stories/icons.js
+++ b/stories/icons.js
@@ -19,7 +19,6 @@ const itemStyles = {
 };
 
 storiesOf('Icons', module)
-  .addDecorator((story, context) => withInfo('common info')(story)(context))
   .addDecorator(checkA11y)
   .addDecorator(styles({ ...baseStyles }))
   .add('all sizes', () => (


### PR DESCRIPTION
### Description
This PR is a fix for the loading performance issues of the **icon overview in Storybook**. We removed the `withInfo()` and now the overview loads in a blink.

### Breaking changes
None.
