### PR TITLE
Update/box: add boxSizing prop

### DIFF
--- a/components/box/Box.js
+++ b/components/box/Box.js
@@ -121,7 +121,7 @@ class Box extends PureComponent {
     );
 
     const style = {
-      ...(boxSizing && {boxSizing}),
+      ...(boxSizing && { boxSizing }),
       ...(flex && { flex }),
       ...(flexBasis && { flexBasis }),
       ...(flexGrow && { flexGrow }),

--- a/components/box/Box.js
+++ b/components/box/Box.js
@@ -17,6 +17,7 @@ class Box extends PureComponent {
     ]),
     alignItems: PropTypes.oneOf(['center', 'flex-start', 'flex-end']),
     alignSelf: PropTypes.oneOf(['center', 'flex-start', 'flex-end', 'stretch']),
+    boxSizing: PropTypes.oneOf(['border-box', 'content-box']),
     children: PropTypes.any,
     className: PropTypes.string,
     display: PropTypes.oneOf(['inline', 'inline-block', 'block', 'flex', 'inline-flex']),
@@ -67,6 +68,7 @@ class Box extends PureComponent {
       alignContent,
       alignItems,
       alignSelf,
+      boxSizing,
       children,
       className,
       display,
@@ -119,6 +121,7 @@ class Box extends PureComponent {
     );
 
     const style = {
+      ...(boxSizing && {boxSizing}),
       ...(flex && { flex }),
       ...(flexBasis && { flexBasis }),
       ...(flexGrow && { flexGrow }),


### PR DESCRIPTION
### Description
In order to convert our **DataGrid** `Cell` and `Row`components into a `Box`, we need to add a `boxSizing` prop to **Box** so we can override **our default** `border-box` back to `content-box`.

### Breaking changes
None.
