### PR TITLE
Rethink usage of composes: reset

### DIFF
--- a/components/avatar/theme.css
+++ b/components/avatar/theme.css
@@ -37,6 +37,7 @@
 }
 
 .overflow {
+  composes: reset-font-smoothing;
   align-items: center;
   align-self: center;
   display: flex;

--- a/components/checkbox/theme.css
+++ b/components/checkbox/theme.css
@@ -13,7 +13,6 @@
 }
 
 .checkbox {
-  composes: reset;
   align-items: center;
   display: flex;
   user-select: none;

--- a/components/compactMessage/theme.css
+++ b/components/compactMessage/theme.css
@@ -1,7 +1,6 @@
 @import '@teamleader/ui-utilities';
 
 .compact-message {
-  composes: reset;
   display: flex;
   align-items: center;
 }

--- a/components/counter/theme.css
+++ b/components/counter/theme.css
@@ -8,7 +8,7 @@
 
 .counter {
   border-radius: var(--border-radius);
-  composes: reset;
+  composes: reset-font-smoothing;
   color: var(--color-white);
   display: inline-block;
   font-family: var(--font-family-black);

--- a/components/datagrid/theme.css
+++ b/components/datagrid/theme.css
@@ -23,6 +23,7 @@
 }
 
 .cell {
+  composes: reset-font-smoothing;
   align-items: center;
   border-bottom: 1px solid var(--color-neutral);
   color: var(--color-teal-darkest);

--- a/components/dialog/theme.css
+++ b/components/dialog/theme.css
@@ -20,7 +20,6 @@
 }
 
 .dialog {
-  composes: reset;
   composes: box-shadow-300;
   background-color: var(--dialog-background-color);
   border-radius: var(--dialog-border-radius);

--- a/components/link/theme.css
+++ b/components/link/theme.css
@@ -1,7 +1,9 @@
 @import '@teamleader/ui-colors';
 @import '@teamleader/ui-typography';
+@import '@teamleader/ui-utilities';
 
 .link {
+  composes: reset-font-smoothing;
   cursor: pointer;
 
   &:not(.inherit) {

--- a/components/menu/theme.css
+++ b/components/menu/theme.css
@@ -28,7 +28,7 @@
 }
 
 .menu {
-  composes: reset;
+  composes: reset-font-smoothing;
   display: inline-block;
   position: relative;
 

--- a/components/message/theme.css
+++ b/components/message/theme.css
@@ -2,7 +2,6 @@
 @import '@teamleader/ui-utilities';
 
 .message {
-  composes: reset;
   display: flex;
   align-items: center;
 }

--- a/components/popover/theme.css
+++ b/components/popover/theme.css
@@ -9,7 +9,6 @@
 }
 
 .wrapper {
-  composes: reset;
   align-items: center;
   display: flex;
   height: 100vh;

--- a/components/qTip/theme.css
+++ b/components/qTip/theme.css
@@ -13,7 +13,6 @@
 }
 
 .qtip {
-  composes: reset;
   display: flex;
   align-items: stretch;
   position: relative;

--- a/components/radio/theme.css
+++ b/components/radio/theme.css
@@ -15,7 +15,6 @@
 }
 
 .radiobutton {
-  composes: reset;
   align-items: center;
   display: flex;
   user-select: none;

--- a/components/statusBullet/theme.css
+++ b/components/statusBullet/theme.css
@@ -9,6 +9,7 @@
 }
 
 .bullet {
+  composes: reset-font-smoothing;
   display: inline-block;
   font-family: var(--font-family-regular);
   position: relative;

--- a/components/statusBullet/theme.css
+++ b/components/statusBullet/theme.css
@@ -9,7 +9,6 @@
 }
 
 .bullet {
-  composes: reset-font-smoothing;
   display: inline-block;
   font-family: var(--font-family-regular);
   position: relative;

--- a/components/statusLabel/theme.css
+++ b/components/statusLabel/theme.css
@@ -3,6 +3,7 @@
 @import '@teamleader/ui-utilities';
 
 .label {
+  composes: reset-font-smoothing;
   display: inline-block;
   font-family: var(--font-family-medium);
   vertical-align: middle;

--- a/components/tag/theme.css
+++ b/components/tag/theme.css
@@ -18,6 +18,7 @@
 }
 
 .label {
+  composes: reset-font-smoothing;
   color: var(--color-teal-darkest);
   font-family: var(--font-family-medium);
 }

--- a/components/tag/theme.css
+++ b/components/tag/theme.css
@@ -11,7 +11,6 @@
 }
 
 .tag {
-  composes: reset;
   background-color: color(var(--color-neutral-darkest) a(12%));
   border-radius: var(--tag-border-radius);
   display: inline-flex;

--- a/components/toast/theme.css
+++ b/components/toast/theme.css
@@ -14,7 +14,7 @@
 
 .toast {
   composes: box-shadow-400;
-  composes: reset;
+  composes: reset-box-sizing;
   align-items: center;
   border-radius: var(--toast-border-radius);
   background-color: var(--toast-background-color);

--- a/components/toggle/theme.css
+++ b/components/toggle/theme.css
@@ -21,7 +21,6 @@
 }
 
 .toggle {
-  composes: reset;
   align-items: center;
   display: flex;
   user-select: none;


### PR DESCRIPTION
We don't always want a full **reset** (`reset-box-sizing` & `reset-font-smoothing`) for our components. In most cases the **Box** component is already taking care of the `reset-box-sizing` and **Text** components are taking care of `reset-font-smoothing`.