### PR TITLE
Update/status bullet: remove large size variation and custom label styling

### DIFF
--- a/components/statusBullet/StatusBullet.js
+++ b/components/statusBullet/StatusBullet.js
@@ -9,7 +9,7 @@ class StatusBullet extends PureComponent {
     children: PropTypes.any,
     className: PropTypes.string,
     color: PropTypes.oneOf(['mint', 'violet', 'ruby', 'gold', 'aqua', 'neutral']),
-    size: PropTypes.oneOf(['small', 'medium', 'large']),
+    size: PropTypes.oneOf(['small', 'medium']),
   };
 
   static defaultProps = {

--- a/components/statusBullet/StatusBullet.js
+++ b/components/statusBullet/StatusBullet.js
@@ -24,7 +24,7 @@ class StatusBullet extends PureComponent {
 
     return (
       <Box className={classNames} data-teamleader-ui="status-bullet" element="span" {...others}>
-        {children && <span className={theme['label']}>{children}</span>}
+        {children}
       </Box>
     );
   }

--- a/components/statusBullet/theme.css
+++ b/components/statusBullet/theme.css
@@ -4,8 +4,7 @@
 
 :root {
   --small-bullet-size: 6px;
-  --medium-bullet-size: 6px;
-  --large-bullet-size: 9px;
+  --medium-bullet-size: 9px;
 }
 
 .bullet {
@@ -55,16 +54,6 @@
 .aqua::before {
   background-color: var(--color-aqua-light);
   border-color: var(--color-aqua-dark);
-}
-
-.large {
-  font-size: calc(2.0 * var(--unit));
-  line-height: calc(2.4 * var(--unit));
-
-  &:before {
-    height: var(--large-bullet-size);
-    width: var(--large-bullet-size);
-  }
 }
 
 .medium {

--- a/components/statusBullet/theme.css
+++ b/components/statusBullet/theme.css
@@ -8,15 +8,13 @@
 }
 
 .bullet {
-  display: inline-block;
-  position: relative;
-  vertical-align: middle;
+  display: inline-flex;
+  align-items: center;
 
   &:before {
     border-radius: 50%;
     border: 2px solid;
     content: '';
-    display: inline-block;
     margin: 0 var(--spacer-smaller);
   }
 }

--- a/components/statusBullet/theme.css
+++ b/components/statusBullet/theme.css
@@ -9,7 +9,6 @@
 
 .bullet {
   display: inline-block;
-  font-family: var(--font-family-regular);
   position: relative;
   vertical-align: middle;
 
@@ -20,10 +19,6 @@
     display: inline-block;
     margin: 0 var(--spacer-smaller);
   }
-}
-
-.label {
-  display: inline-block;
 }
 
 .mint::before {
@@ -56,22 +51,12 @@
   border-color: var(--color-aqua-dark);
 }
 
-.medium {
-  font-size: calc(1.6 * var(--unit));
-  line-height: calc(1.8 * var(--unit));
-
-  &:before {
-    height: var(--medium-bullet-size);
-    width: var(--medium-bullet-size);
-  }
+.medium:before {
+  height: var(--medium-bullet-size);
+  width: var(--medium-bullet-size);
 }
 
-.small {
-  font-size: calc(1.4 * var(--unit));
-  line-height: calc(1.8 * var(--unit));
-
-  &:before {
-    height: var(--small-bullet-size);
-    width: var(--small-bullet-size);
-  }
+.small:before {
+  height: var(--small-bullet-size);
+  width: var(--small-bullet-size);
 }

--- a/stories/statusBullet.js
+++ b/stories/statusBullet.js
@@ -3,7 +3,17 @@ import { storiesOf } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
 import { withInfo } from '@storybook/addon-info';
 import styles from '@sambego/storybook-styles';
-import { Box, StatusBullet, TextBody } from '../components';
+import {
+  Box,
+  StatusBullet,
+  Heading1,
+  Heading2,
+  Heading3,
+  Heading4,
+  TextBody,
+  TextDisplay,
+  TextSmall,
+} from '../components';
 import { baseStyles, centerStyles } from '../.storybook/styles';
 
 const colors = ['mint', 'violet', 'ruby', 'gold', 'aqua', 'neutral'];
@@ -29,5 +39,30 @@ storiesOf('Status Bullets', module)
           <TextBody element="span">{size}</TextBody>
         </StatusBullet>
       ))}
+    </Box>
+  ))
+  .add('with custom labels', () => (
+    <Box>
+      <StatusBullet margin={4}>
+        <Heading1>Heading 1</Heading1>
+      </StatusBullet>
+      <StatusBullet margin={4}>
+        <Heading2>Heading 2</Heading2>
+      </StatusBullet>
+      <StatusBullet size="small" margin={4}>
+        <Heading3>Heading 3</Heading3>
+      </StatusBullet>
+      <StatusBullet size="small" margin={4}>
+        <Heading4>Heading 4</Heading4>
+      </StatusBullet>
+      <StatusBullet size="small" margin={4}>
+        <TextDisplay>Text Display</TextDisplay>
+      </StatusBullet>
+      <StatusBullet size="small" margin={4}>
+        <TextBody>TextBody</TextBody>
+      </StatusBullet>
+      <StatusBullet size="small" margin={4}>
+        <TextSmall>TextSmall</TextSmall>
+      </StatusBullet>
     </Box>
   ));

--- a/stories/statusBullet.js
+++ b/stories/statusBullet.js
@@ -7,7 +7,7 @@ import { Box, StatusBullet } from '../components';
 import { baseStyles, centerStyles } from '../.storybook/styles';
 
 const colors = ['mint', 'violet', 'ruby', 'gold', 'aqua', 'neutral'];
-const sizes = ['small', 'medium', 'large'];
+const sizes = ['small', 'medium'];
 
 storiesOf('Status Bullets', module)
   .addDecorator((story, context) => withInfo('common info')(story)(context))

--- a/stories/statusBullet.js
+++ b/stories/statusBullet.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
 import { withInfo } from '@storybook/addon-info';
 import styles from '@sambego/storybook-styles';
-import { Box, StatusBullet } from '../components';
+import { Box, StatusBullet, TextBody } from '../components';
 import { baseStyles, centerStyles } from '../.storybook/styles';
 
 const colors = ['mint', 'violet', 'ruby', 'gold', 'aqua', 'neutral'];
@@ -17,7 +17,7 @@ storiesOf('Status Bullets', module)
     <Box>
       {colors.map((color, key) => (
         <StatusBullet color={color} key={key} marginHorizontal={4}>
-          {color}
+          <TextBody>{color}</TextBody>
         </StatusBullet>
       ))}
     </Box>
@@ -26,7 +26,7 @@ storiesOf('Status Bullets', module)
     <Box>
       {sizes.map((size, key) => (
         <StatusBullet size={size} key={key} marginHorizontal={4}>
-          {size}
+          <TextBody element="span">{size}</TextBody>
         </StatusBullet>
       ))}
     </Box>

--- a/stories/statusBullet.js
+++ b/stories/statusBullet.js
@@ -36,7 +36,7 @@ storiesOf('Status Bullets', module)
     <Box>
       {sizes.map((size, key) => (
         <StatusBullet size={size} key={key} marginHorizontal={4}>
-          <TextBody element="span">{size}</TextBody>
+          <TextBody>{size}</TextBody>
         </StatusBullet>
       ))}
     </Box>


### PR DESCRIPTION
### Description
In fact, before this PR, there were only two visually different status bullet `sizes`. Small & Medium sizes were actually rendering the same bullet.

Now we decided that the label is free to choose (any Text/Heading component can be used) and the sizes are reduced to two visually different variations.

#### Screenshot before this PR
![schermafdruk 2018-01-26 11 19 23](https://user-images.githubusercontent.com/5336831/35435383-c9fad3f0-028a-11e8-9001-94ebac191bb1.png)

#### Screenshot after this PR
![schermafdruk 2018-01-26 11 20 01](https://user-images.githubusercontent.com/5336831/35435401-e7090ed0-028a-11e8-85e9-7cfe153d85d8.png)

![schermafdruk 2018-01-26 11 12 50](https://user-images.githubusercontent.com/5336831/35435277-642dd216-028a-11e8-9501-d3ab5d750f95.png)

### Breaking changes
* Size `large` has been removed. We only keep `small` and `medium` size variations
