### PR TITLE
StatusLabel propTypes fix

### DIFF
--- a/components/statusLabel/StatusLabel.js
+++ b/components/statusLabel/StatusLabel.js
@@ -16,7 +16,7 @@ const SIZES = {
 
 class StatusLabel extends PureComponent {
   static propTypes = {
-    children: PropTypes.node.isRequired,
+    children: PropTypes.any.isRequired,
     className: PropTypes.string,
     color: PropTypes.oneOf(['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua']),
     size: PropTypes.oneOf(Object.keys(SIZES)),


### PR DESCRIPTION
### Description
StatusLabel is allowed to receive arrays since React16. This gave a warning because the PropTypes were set to receive children as a node which were required.
