### PR TITLE
📦 Upgrade to React 16.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "lodash.omit": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "prop-types": "^15.5.9",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "react-resize-detector": "^1.1.0",
     "react-transition-group": "^2.2.1"
   },


### PR DESCRIPTION
### Description
Upgrade to React 16.2 so we can use the `Fragment` tag
