### PR TITLE
Tag: add the children prop so we can show a Tooltip

### DIFF
--- a/components/tag/Tag.js
+++ b/components/tag/Tag.js
@@ -11,7 +11,7 @@ class Tag extends PureComponent {
     children: PropTypes.any,
     className: PropTypes.string,
     inverse: PropTypes.bool,
-    label: PropTypes.string.isRequired,
+    label: PropTypes.string,
     onLabelClick: PropTypes.func,
     onRemoveClick: PropTypes.func,
     size: PropTypes.oneOf(['small', 'medium', 'large']),

--- a/components/tag/Tag.js
+++ b/components/tag/Tag.js
@@ -44,9 +44,7 @@ class Tag extends PureComponent {
             {children}
           </Button>
         ) : (
-          <span className={theme['label']}>
-            {children}
-          </span>
+          <span className={theme['label']}>{children}</span>
         )}
 
         {onRemoveClick && (

--- a/components/tag/Tag.js
+++ b/components/tag/Tag.js
@@ -8,6 +8,7 @@ import { IconCloseMediumOutline, IconCloseSmallOutline } from '@teamleader/ui-ic
 
 class Tag extends PureComponent {
   static propTypes = {
+    children: PropTypes.any,
     className: PropTypes.string,
     inverse: PropTypes.bool,
     label: PropTypes.string.isRequired,
@@ -22,7 +23,7 @@ class Tag extends PureComponent {
   };
 
   render() {
-    const { className, inverse, label, onLabelClick, onRemoveClick, size, ...others } = this.props;
+    const { children, className, inverse, label, onLabelClick, onRemoveClick, size, ...others } = this.props;
 
     const classNames = cx(
       theme['tag'],
@@ -42,9 +43,13 @@ class Tag extends PureComponent {
         {onLabelClick ? (
           <Button className={theme['label-button']} onClick={onLabelClick} level="outline" inverse={inverse}>
             {label}
+            {children}
           </Button>
         ) : (
-          <span className={theme['label']}>{label}</span>
+          <span className={theme['label']}>
+            {label}
+            {children}
+          </span>
         )}
 
         {onRemoveClick && (

--- a/components/tag/Tag.js
+++ b/components/tag/Tag.js
@@ -8,10 +8,9 @@ import { IconCloseMediumOutline, IconCloseSmallOutline } from '@teamleader/ui-ic
 
 class Tag extends PureComponent {
   static propTypes = {
-    children: PropTypes.any,
+    children: PropTypes.any.isRequired,
     className: PropTypes.string,
     inverse: PropTypes.bool,
-    label: PropTypes.string,
     onLabelClick: PropTypes.func,
     onRemoveClick: PropTypes.func,
     size: PropTypes.oneOf(['small', 'medium', 'large']),
@@ -23,7 +22,7 @@ class Tag extends PureComponent {
   };
 
   render() {
-    const { children, className, inverse, label, onLabelClick, onRemoveClick, size, ...others } = this.props;
+    const { children, className, inverse, onLabelClick, onRemoveClick, size, ...others } = this.props;
 
     const classNames = cx(
       theme['tag'],
@@ -42,12 +41,10 @@ class Tag extends PureComponent {
       <Box className={classNames} data-teamleader-ui="tag" {...others}>
         {onLabelClick ? (
           <Button className={theme['label-button']} onClick={onLabelClick} level="outline" inverse={inverse}>
-            {label}
             {children}
           </Button>
         ) : (
           <span className={theme['label']}>
-            {label}
             {children}
           </span>
         )}

--- a/stories/tag.js
+++ b/stories/tag.js
@@ -20,7 +20,9 @@ storiesOf('Tags', module)
   .add('size', () => (
     <Box>
       {sizes.map((size, index) => (
-        <Tag key={index} label={`${size} tag`} marginHorizontal={3} size={size} inverse={boolean('Inverse', false)}/>
+        <Tag key={index} marginHorizontal={3} size={size} inverse={boolean('Inverse', false)}>
+          {`${size} tag`}
+        </Tag>
       ))}
     </Box>
   ))
@@ -30,11 +32,12 @@ storiesOf('Tags', module)
         <Tag
           inverse={boolean('Inverse', false)}
           key={index}
-          label={`${size} tag`}
           marginHorizontal={3}
           onLabelClick={action('Tag label clicked')}
           size={size}
-        />
+        >
+          {`${size} tag`}
+        </Tag>
       ))}
     </Box>
   ))
@@ -44,11 +47,12 @@ storiesOf('Tags', module)
         <Tag
           inverse={boolean('Inverse', false)}
           key={index}
-          label={`${size} tag`}
           marginHorizontal={3}
           onRemoveClick={action('Tag removed')}
           size={size}
-        />
+        >
+          {`${size} tag`}
+        </Tag>
       ))}
     </Box>
   ))
@@ -58,12 +62,13 @@ storiesOf('Tags', module)
         <Tag
           inverse={boolean('Inverse', false)}
           key={index}
-          label={`${size} tag`}
           marginHorizontal={3}
           onLabelClick={action('Tag label clicked')}
           onRemoveClick={action('Tag removed')}
           size={size}
-        />
+        >
+          {`${size} tag`}
+        </Tag>
       ))}
     </Box>
   ))

--- a/stories/tag.js
+++ b/stories/tag.js
@@ -5,10 +5,12 @@ import { withInfo } from '@storybook/addon-info';
 import { withKnobs, boolean } from '@storybook/addon-knobs/react';
 import { action } from '@storybook/addon-actions';
 import styles from '@sambego/storybook-styles';
-import { Box, Tag } from '../components';
+import { Box, Tag, TextBody, Tooltip } from '../components';
 import { baseStyles, centerStyles } from '../.storybook/styles';
 
 const sizes = ['small', 'medium', 'large'];
+
+const TooltippedTag = Tooltip(Tag);
 
 storiesOf('Tags', module)
   .addDecorator((story, context) => withInfo('common info')(story)(context))
@@ -64,4 +66,9 @@ storiesOf('Tags', module)
         />
       ))}
     </Box>
+  ))
+  .add('with tooltip', () => (
+    <TooltippedTag inverse={boolean('Inverse', false)} tooltip={<TextBody>I am the tooltip</TextBody>}>
+      Tag with tooltip
+    </TooltippedTag>
   ));


### PR DESCRIPTION
### Description
In order to be able using a Tag to trigger a Tooltip, we need to add the `children` prop in the Tag component.

### Breaking changes
**Label** has been removed. Use `children` instead.
