### PR TITLE
Counter: add the children prop so we can show a Tooltip

### DIFF
--- a/components/counter/Counter.js
+++ b/components/counter/Counter.js
@@ -6,6 +6,7 @@ import theme from './theme.css';
 
 class Counter extends PureComponent {
   static propTypes = {
+    children: PropTypes.any,
     className: PropTypes.string,
     color: PropTypes.oneOf(['neutral', 'mint', 'aqua', 'violet', 'teal', 'gold', 'ruby']),
     count: PropTypes.number.isRequired,
@@ -19,13 +20,13 @@ class Counter extends PureComponent {
   };
 
   render() {
-    const { className, color, count, maxCount, size, ...others } = this.props;
+    const { children, className, color, count, maxCount, size, ...others } = this.props;
 
     const classNames = cx(theme['counter'], theme[color], theme[size], className);
 
     return (
       <Box className={classNames} element="span" {...others} data-teamleader-ui="counter">
-        {count > maxCount ? `${maxCount}+` : count}
+        {count > maxCount ? `${maxCount}+` : count} {children}
       </Box>
     );
   }

--- a/stories/counter.js
+++ b/stories/counter.js
@@ -3,11 +3,13 @@ import { storiesOf } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
 import { withInfo } from '@storybook/addon-info';
 import styles from '@sambego/storybook-styles';
-import { Box, Counter } from '../components';
+import { Box, Counter, Tooltip, TextBody } from '../components';
 import { baseStyles, centerStyles } from '../.storybook/styles';
 
 const colors = ['neutral', 'mint', 'aqua', 'violet', 'teal', 'gold', 'ruby'];
 const sizes = ['small', 'medium'];
+
+const TooltippedCounter = Tooltip(Counter);
 
 storiesOf('Counters', module)
   .addDecorator((story, context) => withInfo('common info')(story)(context))
@@ -27,4 +29,9 @@ storiesOf('Counters', module)
     <Box>
       <Counter count={116} color="ruby" maxCount={99} />
     </Box>
+  ))
+  .add('with tooltip', () => (
+    <TooltippedCounter count={116} color="ruby" maxCount={99} tooltip={<TextBody>I am the tooltip</TextBody>}>
+      tasks
+    </TooltippedCounter>
   ));


### PR DESCRIPTION
### Description
In order to be able using a Counter to trigger a Tooltip, we need to add the `children` prop in the `Counter` component.

### Breaking changes
**None**
