### PR TITLE
Make the StatusBullet explicitly a content-box.

### DIFF
--- a/components/statusBullet/theme.css
+++ b/components/statusBullet/theme.css
@@ -14,6 +14,7 @@
   &:before {
     border-radius: 50%;
     border: 2px solid;
+    box-sizing: content-box;
     content: '';
     margin: 0 var(--spacer-smaller);
   }


### PR DESCRIPTION
### Fixed
* Set the `box-sizing` of the `StatusBullet` component explicitly to `content-box`, otherwise it's rendered smaller when you use it on a page where every element is made `border-box` (`* { box-sizing: border-box; }`