### PR TITLE
🐛Center item alignment for banners

### DIFF
--- a/components/banner/theme.css
+++ b/components/banner/theme.css
@@ -7,7 +7,7 @@
 
 .inner {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   position: relative;
 }
 


### PR DESCRIPTION
### Description
In the storybook a banner looks aligned with an icon, but once you use a 24x24 icon it's not anymore. 

#### Screenshot before this PR
https://puu.sh/zz0Vc/c029f597ce.png

#### Screenshot after this PR
https://puu.sh/zz1eV/d00d8f5553.png

### Breaking changes
None
