### PR TITLE
Storybook: hide all unneeded PropTables

### DIFF
--- a/stories/avatars.js
+++ b/stories/avatars.js
@@ -32,7 +32,10 @@ const sizes = ['tiny', 'small', 'medium'];
 const TooltippedAvatar = Tooltip(Avatar);
 
 storiesOf('Avatars', module)
-  .addDecorator((story, context) => withInfo({TableComponent: PropTable})(story)(context))
+  .addDecorator((story, context) => withInfo({
+    propTablesExclude: [Bullet, Counter],
+    TableComponent: PropTable,
+  })(story)(context))
   .addDecorator(checkA11y)
   .addDecorator(withKnobs)
   .add('sizes', () => (


### PR DESCRIPTION
### Description
For every component story, hide all the PropTables we don't need.

#### Screenshot before this PR
[add screenshot here]

#### Screenshot after this PR
[add screenshot here]

### Breaking changes
None
