### PR TITLE
Remove unnecessary margin-left

### DIFF
--- a/components/compactMessage/theme.css
+++ b/components/compactMessage/theme.css
@@ -14,6 +14,5 @@
 }
 
 .button {
-  margin-left: var(--spacer-big);
   align-self: flex-end;
 }


### PR DESCRIPTION
### Description
There was still a margin-left left on the button inside a CompactMessage

#### Screenshot before this PR
https://puu.sh/zCsDH/9aca8c352a.png
