### PR TITLE
Remove named export in component files

### DIFF
--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -124,4 +124,3 @@ class Button extends PureComponent {
 }
 
 export default Button;
-export { Button };

--- a/components/button/IconButton.js
+++ b/components/button/IconButton.js
@@ -72,4 +72,3 @@ class IconButton extends Component {
 }
 
 export default IconButton;
-export { IconButton };

--- a/components/button/LinkButton.js
+++ b/components/button/LinkButton.js
@@ -82,4 +82,3 @@ class LinkButton extends PureComponent {
 }
 
 export default LinkButton;
-export { LinkButton };

--- a/components/checkbox/Checkbox.js
+++ b/components/checkbox/Checkbox.js
@@ -138,4 +138,3 @@ class Checkbox extends PureComponent {
 }
 
 export default Checkbox;
-export { Checkbox };

--- a/components/dialog/Dialog.js
+++ b/components/dialog/Dialog.js
@@ -95,4 +95,3 @@ class Dialog extends PureComponent {
 }
 
 export default Dialog;
-export { Dialog };

--- a/components/menu/MenuDivider.js
+++ b/components/menu/MenuDivider.js
@@ -4,4 +4,3 @@ import theme from './theme.css';
 const MenuDivider = () => <hr data-teamleader-ui="menu-divider" className={theme['divider']} />;
 
 export default MenuDivider;
-export { MenuDivider };

--- a/components/menu/index.js
+++ b/components/menu/index.js
@@ -1,5 +1,5 @@
 import { IconButton } from '../button';
-import { MenuDivider } from './MenuDivider';
+import MenuDivider from './MenuDivider';
 import { menuItemFactory } from './MenuItem';
 import { menuFactory } from './Menu';
 import { iconMenuFactory } from './IconMenu';

--- a/components/overlay/Overlay.js
+++ b/components/overlay/Overlay.js
@@ -119,4 +119,3 @@ class Overlay extends PureComponent {
 }
 
 export default Overlay;
-export { Overlay };

--- a/components/overlay/index.js
+++ b/components/overlay/index.js
@@ -1,4 +1,4 @@
-import { Overlay } from './Overlay';
+import Overlay from './Overlay';
 
 export default Overlay;
 export { Overlay };

--- a/components/radio/RadioButton.js
+++ b/components/radio/RadioButton.js
@@ -143,4 +143,3 @@ class RadioButton extends PureComponent {
 }
 
 export default RadioButton;
-export { RadioButton };

--- a/components/radio/RadioGroup.js
+++ b/components/radio/RadioGroup.js
@@ -54,4 +54,3 @@ class RadioGroup extends PureComponent {
 }
 
 export default RadioGroup;
-export { RadioGroup };

--- a/components/radio/index.js
+++ b/components/radio/index.js
@@ -1,5 +1,5 @@
-import { RadioButton } from './RadioButton';
-import { RadioGroup } from './RadioGroup';
+import RadioButton from './RadioButton';
+import RadioGroup from './RadioGroup';
 
 export default RadioButton;
 export { RadioButton, RadioGroup };

--- a/components/toggle/Toggle.js
+++ b/components/toggle/Toggle.js
@@ -137,4 +137,3 @@ class Toggle extends PureComponent {
 }
 
 export default Toggle;
-export { Toggle };


### PR DESCRIPTION
### Description
This PR removes the named export from component files.

### Breaking changes
None, if you import our components from `@teamleader/ui`.

**Note:** Please update your code if you're importing components straight from  component file (`@teamleader/ui/component/Component.js`).
