### PR TITLE
Fix falsy values (e.g. `""`, `0`) not triggering the `onChange` handler

### DIFF
--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -88,7 +88,7 @@ export default class Input extends Component {
   }
 
   componentWillUpdate(props, state) {
-    if (props.input && props.input.onChange && state.value) {
+    if (props.input && props.input.onChange && state.value !== undefined) {
       props.input.onChange(state.value);
     }
   }


### PR DESCRIPTION
### Description
Now when clearing an input field the onChange handler will be triggered appropriately.