### PR TITLE
Fix input component not setting the passed value prop

### DIFF
--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -83,8 +83,17 @@ export default class Input extends Component {
     this.handleDecreaseValue = ::this.handleDecreaseValue;
 
     this.state = {
-      value: props.type === 'number' ? Number(props.value) || '' : props.value || '',
+      value: this.parsePropsValue(),
     };
+  }
+
+  parsePropsValue() {
+    const { input: { value }, type } = this.props;
+    if (type === 'number') {
+      return this.toNumber(value);
+    }
+
+    return value || '';
   }
 
   componentWillUpdate(props, state) {


### PR DESCRIPTION
### Description
The passed value to the input component was always undefined as it was picked directly from `props` instead of `props.input`.