### PR TITLE
Npm package update: ui-typography 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@teamleader/ui-colors": "0.0.7",
     "@teamleader/ui-icons": "^0.2.0",
     "@teamleader/ui-illustrations": "0.0.4",
-    "@teamleader/ui-typography": "0.1.1",
+    "@teamleader/ui-typography": "0.1.2",
     "@teamleader/ui-utilities": "0.0.5",
     "classnames": "^2.2.5",
     "lodash.omit": "^4.5.0",


### PR DESCRIPTION
### Description
This PR Fixes the `extra bold` Heading4 in Safari.

#### Screenshot before this PR
![schermafdruk 2018-03-27 17 06 54](https://user-images.githubusercontent.com/5336831/37976210-455d199c-31e1-11e8-829e-8843711f4f02.png)

#### Screenshot after this PR
![schermafdruk 2018-03-27 17 09 16](https://user-images.githubusercontent.com/5336831/37976334-8fc5dcee-31e1-11e8-807d-d14a3f513701.png)

### Breaking changes
None.
