### PR TITLE
Allow patch updates for our own dependency packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,12 +61,12 @@
     "Kevin Waelkens <kevin.waelkens@teamleader.eu>"
   ],
   "dependencies": {
-    "@teamleader/ui-animations": "0.0.2",
-    "@teamleader/ui-colors": "0.0.7",
+    "@teamleader/ui-animations": "^0.0.2",
+    "@teamleader/ui-colors": "^0.0.7",
     "@teamleader/ui-icons": "^0.2.0",
-    "@teamleader/ui-illustrations": "0.0.4",
-    "@teamleader/ui-typography": "0.1.2",
-    "@teamleader/ui-utilities": "0.0.5",
+    "@teamleader/ui-illustrations": "^0.0.4",
+    "@teamleader/ui-typography": "^0.1.2",
+    "@teamleader/ui-utilities": "^0.0.5",
     "classnames": "^2.2.5",
     "lodash.omit": "^4.5.0",
     "lodash.throttle": "^4.1.1",


### PR DESCRIPTION
### Description
In this PR we've added `^` to the required version of our own dependency packages. This will cause less releases of UI when releasing one of its dependencies.

### Breaking changes
* None
