### PR TITLE
[Discussion/suggestions] A possible solution for the portal context issue

### DIFF
--- a/components/tooltip/Tooltip.js
+++ b/components/tooltip/Tooltip.js
@@ -62,9 +62,13 @@ const tooltipFactory = () => {
           active: false,
           position: this.props.tooltipPosition,
         };
+      }
 
-        this.tooltipRoot = document.createElement('div');
+      componentDidMount() {
+        this.elementDocument = this.node.ownerDocument;
+        this.tooltipRoot = this.elementDocument.createElement('div');
         this.tooltipRoot.id = 'tooltip-root';
+        this.forceUpdate();
       }
 
       getPosition(element) {
@@ -88,7 +92,7 @@ const tooltipFactory = () => {
       }
 
       activate({ top, left, position }) {
-        document.body.appendChild(this.tooltipRoot);
+        this.elementDocument.body.appendChild(this.tooltipRoot);
         this.setState({ active: true, top, left, position });
       }
 
@@ -160,10 +164,20 @@ const tooltipFactory = () => {
       };
 
       handleTransitionExited = () => {
-        document.body.removeChild(this.tooltipRoot);
+        this.elementDocument.body.removeChild(this.tooltipRoot);
       };
 
       render() {
+        if (!this.elementDocument) {
+          return (
+            <span
+              ref={ref => {
+                this.node = ref;
+              }}
+            />
+          );
+        }
+
         const { active, left, top, position } = this.state;
         const { children, className, tooltip, tooltipColor, tooltipIcon, tooltipSize, ...other } = this.props;
 


### PR DESCRIPTION
In `core` we render components in iframes via `React.createPortal`. Due to this, the components are actually running in a wrong JS context. Their context is the "main" frame, instead of the iframe.

Due to this, the `Tooltip` component for example (probably all components that also use `createPortal`), will render in the wrong place, because it's rendering in the main frame, instead of in the iframe.

I created a quick fix, that solves this problem. I could make a cleaner solution (I guess) with a `PortalWrapper` component or HOC or something like that, but wanted to get some feedback first. Maybe there's a better solution? Maybe the UI package shouldn't care and core should create their own solution (if even possible)?

Also, [Node.ownerDocument](https://developer.mozilla.org/en-US/docs/Web/API/Node/ownerDocument) doesn't work in IE11, but it seems to work, probably because it's polyfilled. 

An example of the tooltip rendering in the wrong position:

![screen shot 2018-04-10 at 10 56 42](https://user-images.githubusercontent.com/330765/38551477-85fcdf7c-3cb9-11e8-8790-dcac45fa6bb5.png)
