### PR TITLE
🔥 Remove inheriting of color for button on hover

### DIFF
--- a/components/button/theme.css
+++ b/components/button/theme.css
@@ -65,7 +65,6 @@
     &:hover {
       z-index: 1;
       text-decoration: none;
-      color: inherit;
     }
 
     &:active {


### PR DESCRIPTION
### Description
I don't really remember why I added `color: inherit` in [this PR](https://github.com/teamleadercrm/ui/pull/234), I definitely did it for a reason, so it might make the buttons on `/integrations.php` look bad on core, but then it needs to be fixed in a different way. 

#### Screenshot before this PR
![screen shot 2018-04-11 at 13 47 23](https://user-images.githubusercontent.com/9056632/38614854-ed4a5f62-3d8e-11e8-8632-459b2cb0edf7.jpg)


#### Screenshot after this PR
![screen shot 2018-04-11 at 13 47 35](https://user-images.githubusercontent.com/9056632/38614857-f279473c-3d8e-11e8-82d1-27dc4ccd965a.jpg)
