### PR TITLE
Render the Tooltip in the correct document

### DIFF
--- a/components/hoc/DocumentObjectProvider/DocumentObjectProvider.js
+++ b/components/hoc/DocumentObjectProvider/DocumentObjectProvider.js
@@ -1,0 +1,36 @@
+import React, { PureComponent, createContext } from 'react';
+
+export const Context = createContext();
+
+const DocumentObjectProvider = WrappedComponent => {
+  return class extends PureComponent {
+    componentDidMount() {
+      this.forceUpdate(); // force a re-render because we have the document ref now
+    }
+
+    render() {
+      if (!this.documentRef) {
+        return (
+          <span
+            style={{ display: 'none' }}
+            ref={node => {
+              if (!node) {
+                return;
+              }
+
+              this.documentRef = node.ownerDocument;
+            }}
+          />
+        );
+      }
+
+      return (
+        <Context.Provider value={this.documentRef}>
+          <WrappedComponent {...this.props} />
+        </Context.Provider>
+      );
+    }
+  };
+};
+
+export default DocumentObjectProvider;

--- a/components/hoc/DocumentObjectProvider/index.js
+++ b/components/hoc/DocumentObjectProvider/index.js
@@ -1,0 +1,3 @@
+import DocumentObjectProvider, { Context } from './DocumentObjectProvider';
+export default DocumentObjectProvider;
+export { Context };

--- a/components/tooltip/Tooltip.js
+++ b/components/tooltip/Tooltip.js
@@ -28,203 +28,201 @@ const SIZES = {
   },
 };
 
-const tooltipFactory = () => {
-  return ComposedComponent => {
-    class TooltippedComponent extends Component {
-      static propTypes = {
-        children: PropTypes.node,
-        className: PropTypes.string,
-        onClick: PropTypes.func,
-        onMouseEnter: PropTypes.func,
-        onMouseLeave: PropTypes.func,
-        tooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-        tooltipColor: PropTypes.oneOf(['white', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'inverse']),
-        tooltipHideOnClick: PropTypes.bool,
-        tooltipIcon: PropTypes.element,
-        tooltipPosition: PropTypes.oneOf(Object.keys(POSITIONS).map(key => POSITIONS[key])),
-        tooltipShowOnClick: PropTypes.bool,
-        tooltipSize: PropTypes.oneOf(Object.keys(SIZES)),
-        documentObject: PropTypes.object.isRequired,
+const Tooltip = ComposedComponent => {
+  class TooltippedComponent extends Component {
+    static propTypes = {
+      children: PropTypes.node,
+      className: PropTypes.string,
+      onClick: PropTypes.func,
+      onMouseEnter: PropTypes.func,
+      onMouseLeave: PropTypes.func,
+      tooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+      tooltipColor: PropTypes.oneOf(['white', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'inverse']),
+      tooltipHideOnClick: PropTypes.bool,
+      tooltipIcon: PropTypes.element,
+      tooltipPosition: PropTypes.oneOf(Object.keys(POSITIONS).map(key => POSITIONS[key])),
+      tooltipShowOnClick: PropTypes.bool,
+      tooltipSize: PropTypes.oneOf(Object.keys(SIZES)),
+      documentObject: PropTypes.object.isRequired,
+    };
+
+    static defaultProps = {
+      className: '',
+      tooltipColor: 'white',
+      tooltipHideOnClick: true,
+      tooltipIcon: null,
+      tooltipPosition: POSITIONS.TOP,
+      tooltipShowOnClick: false,
+      tooltipSize: 'medium',
+    };
+
+    constructor(props) {
+      super(...arguments);
+
+      this.state = {
+        active: false,
+        position: this.props.tooltipPosition,
       };
 
-      static defaultProps = {
-        className: '',
-        tooltipColor: 'white',
-        tooltipHideOnClick: true,
-        tooltipIcon: null,
-        tooltipPosition: POSITIONS.TOP,
-        tooltipShowOnClick: false,
-        tooltipSize: 'medium',
-      };
+      this.tooltipRoot = props.documentObject.createElement('div');
+      this.tooltipRoot.id = 'tooltip-root';
+    }
 
-      constructor(props) {
-        super(...arguments);
+    getPosition(element) {
+      const { tooltipPosition } = this.props;
 
-        this.state = {
-          active: false,
-          position: this.props.tooltipPosition,
+      if (tooltipPosition === POSITIONS.HORIZONTAL) {
+        const origin = element.getBoundingClientRect();
+        const { width: windowWidth } = getViewport();
+        const toRight = origin.left < windowWidth / 2 - origin.width / 2;
+
+        return toRight ? POSITIONS.RIGHT : POSITIONS.LEFT;
+      } else if (tooltipPosition === POSITIONS.VERTICAL) {
+        const origin = element.getBoundingClientRect();
+        const { height: windowHeight } = getViewport();
+        const toBottom = origin.top < windowHeight / 2 - origin.height / 2;
+
+        return toBottom ? POSITIONS.BOTTOM : POSITIONS.TOP;
+      }
+
+      return tooltipPosition;
+    }
+
+    activate({ top, left, position }) {
+      this.props.documentObject.body.appendChild(this.tooltipRoot);
+      this.setState({ active: true, top, left, position });
+    }
+
+    deactivate() {
+      this.setState({ active: false });
+    }
+
+    calculatePosition(element) {
+      const { top, left, height, width } = element.getBoundingClientRect();
+      const position = this.getPosition(element);
+      const xOffset = window.scrollX || window.pageXOffset;
+      const yOffset = window.scrollY || window.pageYOffset;
+
+      if (position === POSITIONS.BOTTOM) {
+        return {
+          top: top + height + yOffset,
+          left: left + width / 2 + xOffset,
+          position,
         };
-
-        this.tooltipRoot = props.documentObject.createElement('div');
-        this.tooltipRoot.id = 'tooltip-root';
-      }
-
-      getPosition(element) {
-        const { tooltipPosition } = this.props;
-
-        if (tooltipPosition === POSITIONS.HORIZONTAL) {
-          const origin = element.getBoundingClientRect();
-          const { width: windowWidth } = getViewport();
-          const toRight = origin.left < windowWidth / 2 - origin.width / 2;
-
-          return toRight ? POSITIONS.RIGHT : POSITIONS.LEFT;
-        } else if (tooltipPosition === POSITIONS.VERTICAL) {
-          const origin = element.getBoundingClientRect();
-          const { height: windowHeight } = getViewport();
-          const toBottom = origin.top < windowHeight / 2 - origin.height / 2;
-
-          return toBottom ? POSITIONS.BOTTOM : POSITIONS.TOP;
-        }
-
-        return tooltipPosition;
-      }
-
-      activate({ top, left, position }) {
-        this.props.documentObject.body.appendChild(this.tooltipRoot);
-        this.setState({ active: true, top, left, position });
-      }
-
-      deactivate() {
-        this.setState({ active: false });
-      }
-
-      calculatePosition(element) {
-        const { top, left, height, width } = element.getBoundingClientRect();
-        const position = this.getPosition(element);
-        const xOffset = window.scrollX || window.pageXOffset;
-        const yOffset = window.scrollY || window.pageYOffset;
-
-        if (position === POSITIONS.BOTTOM) {
-          return {
-            top: top + height + yOffset,
-            left: left + width / 2 + xOffset,
-            position,
-          };
-        } else if (position === POSITIONS.TOP) {
-          return {
-            top: top + yOffset,
-            left: left + width / 2 + xOffset,
-            position,
-          };
-        } else if (position === POSITIONS.LEFT) {
-          return {
-            top: top + height / 2 + yOffset,
-            left: left + xOffset,
-            position,
-          };
-        } else if (position === POSITIONS.RIGHT) {
-          return {
-            top: top + height / 2 + yOffset,
-            left: left + width + xOffset,
-            position,
-          };
-        }
-      }
-
-      handleMouseEnter = event => {
-        this.activate(this.calculatePosition(event.currentTarget));
-
-        if (this.props.onMouseEnter) {
-          this.props.onMouseEnter(event);
-        }
-      };
-
-      handleMouseLeave = event => {
-        this.deactivate();
-
-        if (this.props.onMouseLeave) {
-          this.props.onMouseLeave(event);
-        }
-      };
-
-      handleClick = event => {
-        if (this.props.tooltipHideOnClick && this.state.active) {
-          this.deactivate();
-        }
-
-        if (this.props.tooltipShowOnClick && !this.state.active) {
-          this.activate(this.calculatePosition(event.currentTarget));
-        }
-
-        if (this.props.onClick) {
-          this.props.onClick(event);
-        }
-      };
-
-      handleTransitionExited = () => {
-        this.props.documentObject.body.removeChild(this.tooltipRoot);
-      };
-
-      render() {
-        const { active, left, top, position } = this.state;
-        const { children, className, tooltip, tooltipColor, tooltipIcon, tooltipSize, ...other } = this.props;
-
-        const rest = omit(other, [
-          'onClick',
-          'onMouseEnter',
-          'onMouseLeave',
-          'tooltipHideOnClick',
-          'tooltipPosition',
-          'tooltipShowOnClick',
-          'documentObject',
-        ]);
-
-        const childProps = {
-          ...rest,
-          className,
-          onClick: this.handleClick,
-          onMouseEnter: this.handleMouseEnter,
-          onMouseLeave: this.handleMouseLeave,
+      } else if (position === POSITIONS.TOP) {
+        return {
+          top: top + yOffset,
+          left: left + width / 2 + xOffset,
+          position,
         };
-
-        return React.createElement(
-          ComposedComponent,
-          childProps,
-          children,
-          createPortal(
-            <Transition in={active} onExited={this.handleTransitionExited} timeout={{ enter: 0, exit: 1000 }}>
-              {state => {
-                const classNames = cx(theme['tooltip'], theme[tooltipColor], theme[tooltipSize], {
-                  [theme['is-entering']]: state === 'entering',
-                  [theme['is-entered']]: state === 'entered',
-                  [theme['is-exiting']]: state === 'exiting',
-                  [theme[position]]: theme[position],
-                });
-
-                return (
-                  <div className={classNames} data-teamleader-ui="tooltip" style={{ top, left }}>
-                    <Box className={theme['inner']} {...SIZES[tooltipSize]}>
-                      {tooltipIcon && <div className={theme['icon']}>{tooltipIcon}</div>}
-                      <div className={theme['text']}>{tooltip}</div>
-                    </Box>
-                  </div>
-                );
-              }}
-            </Transition>,
-            this.tooltipRoot,
-          ),
-        );
+      } else if (position === POSITIONS.LEFT) {
+        return {
+          top: top + height / 2 + yOffset,
+          left: left + xOffset,
+          position,
+        };
+      } else if (position === POSITIONS.RIGHT) {
+        return {
+          top: top + height / 2 + yOffset,
+          left: left + width + xOffset,
+          position,
+        };
       }
     }
 
-    return DocumentObjectProvider(props => {
-      return (
-        <DocumentObjectContext.Consumer>
-          {documentObject => <TooltippedComponent {...props} documentObject={documentObject} />}
-        </DocumentObjectContext.Consumer>
+    handleMouseEnter = event => {
+      this.activate(this.calculatePosition(event.currentTarget));
+
+      if (this.props.onMouseEnter) {
+        this.props.onMouseEnter(event);
+      }
+    };
+
+    handleMouseLeave = event => {
+      this.deactivate();
+
+      if (this.props.onMouseLeave) {
+        this.props.onMouseLeave(event);
+      }
+    };
+
+    handleClick = event => {
+      if (this.props.tooltipHideOnClick && this.state.active) {
+        this.deactivate();
+      }
+
+      if (this.props.tooltipShowOnClick && !this.state.active) {
+        this.activate(this.calculatePosition(event.currentTarget));
+      }
+
+      if (this.props.onClick) {
+        this.props.onClick(event);
+      }
+    };
+
+    handleTransitionExited = () => {
+      this.props.documentObject.body.removeChild(this.tooltipRoot);
+    };
+
+    render() {
+      const { active, left, top, position } = this.state;
+      const { children, className, tooltip, tooltipColor, tooltipIcon, tooltipSize, ...other } = this.props;
+
+      const rest = omit(other, [
+        'onClick',
+        'onMouseEnter',
+        'onMouseLeave',
+        'tooltipHideOnClick',
+        'tooltipPosition',
+        'tooltipShowOnClick',
+        'documentObject',
+      ]);
+
+      const childProps = {
+        ...rest,
+        className,
+        onClick: this.handleClick,
+        onMouseEnter: this.handleMouseEnter,
+        onMouseLeave: this.handleMouseLeave,
+      };
+
+      return React.createElement(
+        ComposedComponent,
+        childProps,
+        children,
+        createPortal(
+          <Transition in={active} onExited={this.handleTransitionExited} timeout={{ enter: 0, exit: 1000 }}>
+            {state => {
+              const classNames = cx(theme['tooltip'], theme[tooltipColor], theme[tooltipSize], {
+                [theme['is-entering']]: state === 'entering',
+                [theme['is-entered']]: state === 'entered',
+                [theme['is-exiting']]: state === 'exiting',
+                [theme[position]]: theme[position],
+              });
+
+              return (
+                <div className={classNames} data-teamleader-ui="tooltip" style={{ top, left }}>
+                  <Box className={theme['inner']} {...SIZES[tooltipSize]}>
+                    {tooltipIcon && <div className={theme['icon']}>{tooltipIcon}</div>}
+                    <div className={theme['text']}>{tooltip}</div>
+                  </Box>
+                </div>
+              );
+            }}
+          </Transition>,
+          this.tooltipRoot,
+        ),
       );
-    });
-  };
+    }
+  }
+
+  return DocumentObjectProvider(props => {
+    return (
+      <DocumentObjectContext.Consumer>
+        {documentObject => <TooltippedComponent {...props} documentObject={documentObject} />}
+      </DocumentObjectContext.Consumer>
+    );
+  });
 };
 
-export default tooltipFactory;
+export default Tooltip;

--- a/components/tooltip/Tooltip.js
+++ b/components/tooltip/Tooltip.js
@@ -6,6 +6,7 @@ import cx from 'classnames';
 import omit from 'lodash.omit';
 import { createPortal } from 'react-dom';
 import { getViewport } from '../utils/utils';
+import DocumentObjectProvider, { Context as DocumentObjectContext } from '../hoc/DocumentObjectProvider';
 import theme from './theme.css';
 
 const POSITIONS = {
@@ -43,6 +44,7 @@ const tooltipFactory = () => {
         tooltipPosition: PropTypes.oneOf(Object.keys(POSITIONS).map(key => POSITIONS[key])),
         tooltipShowOnClick: PropTypes.bool,
         tooltipSize: PropTypes.oneOf(Object.keys(SIZES)),
+        documentObject: PropTypes.object.isRequired,
       };
 
       static defaultProps = {
@@ -55,7 +57,7 @@ const tooltipFactory = () => {
         tooltipSize: 'medium',
       };
 
-      constructor() {
+      constructor(props) {
         super(...arguments);
 
         this.state = {
@@ -63,7 +65,7 @@ const tooltipFactory = () => {
           position: this.props.tooltipPosition,
         };
 
-        this.tooltipRoot = document.createElement('div');
+        this.tooltipRoot = props.documentObject.createElement('div');
         this.tooltipRoot.id = 'tooltip-root';
       }
 
@@ -88,7 +90,7 @@ const tooltipFactory = () => {
       }
 
       activate({ top, left, position }) {
-        document.body.appendChild(this.tooltipRoot);
+        this.props.documentObject.body.appendChild(this.tooltipRoot);
         this.setState({ active: true, top, left, position });
       }
 
@@ -160,7 +162,7 @@ const tooltipFactory = () => {
       };
 
       handleTransitionExited = () => {
-        document.body.removeChild(this.tooltipRoot);
+        this.props.documentObject.body.removeChild(this.tooltipRoot);
       };
 
       render() {
@@ -174,6 +176,7 @@ const tooltipFactory = () => {
           'tooltipHideOnClick',
           'tooltipPosition',
           'tooltipShowOnClick',
+          'documentObject',
         ]);
 
         const childProps = {
@@ -214,7 +217,13 @@ const tooltipFactory = () => {
       }
     }
 
-    return TooltippedComponent;
+    return DocumentObjectProvider(props => {
+      return (
+        <DocumentObjectContext.Consumer>
+          {documentObject => <TooltippedComponent {...props} documentObject={documentObject} />}
+        </DocumentObjectContext.Consumer>
+      );
+    });
   };
 };
 

--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -1,4 +1,1 @@
-import tooltipFactory from './Tooltip';
-
-export default tooltipFactory();
-export { tooltipFactory as Tooltip };
+export default from './Tooltip';


### PR DESCRIPTION
## Best to review per commit, because I refactored a useless factory

In `core` we render components in iframes via `React.createPortal`. Due to this, the components are actually running in a wrong JS context. Their context is the "main" frame, instead of the iframe.

Due to this, the `Tooltip` component for example (probably all components that also use `createPortal`), will render in the wrong place, because it's rendering in the main frame, instead of in the iframe.

To fix this I created a `DocumentObjectProvider` which does a "fake and invisible" render first, so we can get the correct `document` from the node. Afterwards we can render again and provide the document through context.

A component wrapped with this HOC can consume this "correct" document from the context and then use it.