### PR TITLE
Fix input triggering onChange for its old value when receiving props

### DIFF
--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -1,4 +1,4 @@
-import React, { Component, createElement } from 'react';
+import React, { PureComponent, createElement } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import omit from 'lodash.omit';
@@ -15,7 +15,7 @@ import Counter from '../counter';
 import { TextSmall } from '../typography';
 import theme from './theme.css';
 
-export default class Input extends Component {
+export default class Input extends PureComponent {
   static propTypes = {
     autoFocus: PropTypes.bool,
     /** Boolean indicating whether the input text should render in bold. */
@@ -78,87 +78,27 @@ export default class Input extends Component {
     step: 1,
   };
 
-  constructor(props) {
-    super(props);
-
-    this.handleChange = ::this.handleChange;
-    this.handleIncreaseValue = ::this.handleIncreaseValue;
-    this.handleDecreaseValue = ::this.handleDecreaseValue;
-
-    this.state = {
-      value: this.parseValue(this.getPropsValue()),
-    };
-  }
-
-  componentWillUpdate(nextProps) {
-    const value = this.getPropsValue(nextProps);
-    if (this.getPropsValue() !== value) {
-      this.updateValue(value, false);
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const newValue = Input.parseValue(Input.getPropsValue(nextProps), nextProps);
+    if (newValue !== prevState.value) {
+      return {
+        value: newValue,
+      };
     }
+
+    return null;
   }
 
-  getPropsValue(props = this.props) {
-    const { value, input } = props;
+  static getPropsValue({ input, value }) {
     const finalValue = input !== undefined ? input.value : value;
     return finalValue || '';
   }
 
-  parseValue(value) {
-    const { type } = this.props;
-    return type === 'number' ? this.toNumber(value) : value;
+  static parseValue(value, { type, min, max, precision }) {
+    return type === 'number' ? Input.toNumber(value, min, max, precision) : value;
   }
 
-  updateValue(rawValue, triggerOnChange = true) {
-    const { input } = this.props;
-    const value = this.parseValue(rawValue);
-
-    this.setState({
-      value,
-    });
-
-    if (triggerOnChange && input && input.onChange) {
-      input.onChange(value);
-    }
-  }
-
-  handleChange(event) {
-    this.updateValue(event.target.value);
-  }
-
-  handleIncreaseValue() {
-    this.updateStep(1);
-  }
-
-  handleDecreaseValue() {
-    this.updateStep(-1);
-  }
-
-  hasError() {
-    const { meta } = this.props;
-    return Boolean(meta && meta.error && meta.touched);
-  }
-
-  formatNumber(number) {
-    const { precision } = this.props;
-
-    let formattedNumber = this.toNumber(number);
-
-    if (precision !== null) {
-      formattedNumber = number.toFixed(precision);
-    }
-
-    return String(formattedNumber);
-  }
-
-  updateStep(n) {
-    const { step } = this.props;
-    const { value = 0 } = this.state;
-    this.updateValue(value + step * n);
-  }
-
-  toNumber(number) {
-    const { max, min, precision } = this.props;
-
+  static toNumber(number, min, max, precision) {
     let float = parseFloat(number);
 
     if (isNaN(float) || !isFinite(float)) {
@@ -171,6 +111,58 @@ export default class Input extends Component {
     float = Math.round(float * baseExponent) / baseExponent;
 
     return float;
+  }
+
+  state = {
+    value: '',
+  };
+
+  handleChange = event => {
+    this.updateValue(event.target.value);
+  };
+
+  handleIncreaseValue = () => {
+    this.updateStep(1);
+  };
+
+  handleDecreaseValue = () => {
+    this.updateStep(-1);
+  };
+
+  updateValue(rawValue, triggerOnChange = true) {
+    const { input } = this.props;
+    const value = Input.parseValue(rawValue, this.props);
+
+    this.setState({
+      value,
+    });
+
+    if (triggerOnChange && input && input.onChange) {
+      input.onChange(value);
+    }
+  }
+
+  hasError() {
+    const { meta } = this.props;
+    return Boolean(meta && meta.error && meta.touched);
+  }
+
+  formatNumber(number) {
+    const { min, max, precision } = this.props;
+
+    let formattedNumber = Input.toNumber(number, min, max, precision);
+
+    if (precision !== null) {
+      formattedNumber = number.toFixed(precision);
+    }
+
+    return String(formattedNumber);
+  }
+
+  updateStep(n) {
+    const { step } = this.props;
+    const { value = 0 } = this.state;
+    this.updateValue(value + step * n);
   }
 
   renderInput() {

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -86,32 +86,43 @@ export default class Input extends Component {
     this.handleDecreaseValue = ::this.handleDecreaseValue;
 
     this.state = {
-      value: this.parsePropsValue(),
+      value: this.parseValue(this.getPropsValue()),
     };
   }
 
-  parsePropsValue() {
-    const { type, value, input } = this.props;
-    const finalValue = input !== undefined ? input.value : value;
-    if (type === 'number') {
-      return this.toNumber(finalValue);
+  componentWillUpdate(nextProps) {
+    const value = this.getPropsValue(nextProps);
+    if (this.getPropsValue() !== value) {
+      this.updateValue(value, false);
     }
+  }
 
+  getPropsValue(props = this.props) {
+    const { value, input } = props;
+    const finalValue = input !== undefined ? input.value : value;
     return finalValue || '';
   }
 
-  componentWillUpdate(props, state) {
-    if (props.input && props.input.onChange && state.value !== undefined) {
-      props.input.onChange(state.value);
+  parseValue(value) {
+    const { type } = this.props;
+    return type === 'number' ? this.toNumber(value) : value;
+  }
+
+  updateValue(rawValue, triggerOnChange = true) {
+    const { input } = this.props;
+    const value = this.parseValue(rawValue);
+
+    this.setState({
+      value,
+    });
+
+    if (triggerOnChange && input && input.onChange) {
+      input.onChange(value);
     }
   }
 
   handleChange(event) {
-    const value = event.target.value;
-
-    this.setState(() => ({
-      value: this.props.type === 'number' ? Number(value) : value,
-    }));
+    this.updateValue(event.target.value);
   }
 
   handleIncreaseValue() {
@@ -141,12 +152,8 @@ export default class Input extends Component {
 
   updateStep(n) {
     const { step } = this.props;
-
-    this.setState(prevState => {
-      const number = this.toNumber((prevState.value || 0) + step * n);
-
-      return { value: number };
-    });
+    const { value = 0 } = this.state;
+    this.updateValue(value + step * n);
   }
 
   toNumber(number) {


### PR DESCRIPTION
### Description
The Input component triggered the onChange with its previous value when receiving props. Thus not taking a new value passes from outside. This PR fixes that by not relying solely on `componentWillUpdate` to update its state.
