### PR TITLE
Active button in button group

### DIFF
--- a/components/box/index.js
+++ b/components/box/index.js
@@ -1,4 +1,5 @@
 import Box from './Box';
+import omitBoxProps from './omitBoxProps';
 
 export default Box;
-export { Box };
+export { Box, omitBoxProps };

--- a/components/box/omitBoxProps.js
+++ b/components/box/omitBoxProps.js
@@ -1,0 +1,37 @@
+import omit from 'lodash.omit';
+
+const omitBoxProps = props =>
+  omit(props, [
+    'alignContent',
+    'alignItems',
+    'alignSelf',
+    'boxSizing',
+    'children',
+    'className',
+    'display',
+    'element',
+    'flex',
+    'flexBasis',
+    'flexDirection',
+    'flexGrow',
+    'flexShrink',
+    'flexWrap',
+    'justifyContent',
+    'margin',
+    'marginHorizontal',
+    'marginVertical',
+    'marginBottom',
+    'marginLeft',
+    'marginRight',
+    'marginTop',
+    'order',
+    'padding',
+    'paddingHorizontal',
+    'paddingVertical',
+    'paddingBottom',
+    'paddingLeft',
+    'paddingRight',
+    'paddingTop',
+  ]);
+
+export default omitBoxProps;

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -14,6 +14,8 @@ class Button extends PureComponent {
     level: PropTypes.oneOf(['outline', 'primary', 'secondary', 'destructive']),
     /** If true, component will be disabled. */
     disabled: PropTypes.bool,
+    /** If true, component will be shown in an active state */
+    active: PropTypes.bool,
     /** If true, component will take the full width available. */
     fullWidth: PropTypes.bool,
     /** If set, button will be rendered as an anchor element. */
@@ -75,6 +77,7 @@ class Button extends PureComponent {
       className,
       level,
       disabled,
+      active,
       fullWidth,
       href,
       icon,
@@ -97,6 +100,7 @@ class Button extends PureComponent {
         [theme['inverse']]: inverse && level === 'outline',
         [theme['is-full-width']]: fullWidth,
         [theme['processing']]: processing,
+        [theme['active']]: active,
         [theme[size]]: theme[size],
       },
       className,

--- a/components/button/ButtonGroup.js
+++ b/components/button/ButtonGroup.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import omit from 'lodash.omit';
-import Box from '../box';
+import Box, { omitBoxProps } from '../box';
 import Button from './Button';
 import cx from 'classnames';
 import isComponentOfType from '../utils/is-component-of-type';
@@ -63,7 +63,7 @@ class ButtonGroup extends PureComponent {
           return React.createElement(child.type, {
             ...childProps,
             ...optionalChildProps,
-            ...groupProps,
+            ...omitBoxProps(groupProps),
           });
         })}
       </Box>

--- a/components/button/theme.css
+++ b/components/button/theme.css
@@ -67,7 +67,11 @@
       text-decoration: none;
     }
 
-    &:active {
+    &.active {
+      pointer-events: none;
+    }
+
+    &:active, &.active {
       box-shadow: none !important;
 
       &:before {
@@ -353,6 +357,13 @@
 
     &:active {
       background-color: var(--color-neutral);
+    }
+
+    &.active {
+      background-color: var(--color-teal);
+      border: 1px solid var(--color-teal-dark);
+      color: var(--color-neutral-lightest);
+      box-shadow: 0 0 0 1px var(--color-neutral-darkest);
     }
   }
 

--- a/stories/buttonGroup.js
+++ b/stories/buttonGroup.js
@@ -21,7 +21,7 @@ storiesOf('Button groups', module)
   .addDecorator(checkA11y)
   .addDecorator(withKnobs)
   .add('normal', () => (
-    <ButtonGroup segmented={boolean('Semented', false)}>
+    <ButtonGroup segmented={boolean('Segmented', false)}>
       <Button label="Button 1"/>
       <Button label="Button 2"/>
       <Button icon={<IconAddMediumOutline />} />
@@ -29,7 +29,7 @@ storiesOf('Button groups', module)
   ))
   .add('with active', () => (
     <State store={store}>
-      <ButtonGroup segmented={boolean('Semented', true)} value="option2" onChange={handleChangeValue} level="secondary">
+      <ButtonGroup segmented={boolean('Segmented', true)} value="option2" onChange={handleChangeValue} level="secondary">
         <Button label="Option 1" value="option1" />
         <Button label="Option 2" value="option2" />
         <Button label="Option 3" value="option3" />

--- a/stories/buttonGroup.js
+++ b/stories/buttonGroup.js
@@ -4,8 +4,17 @@ import { storiesOf } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
 import { withInfo } from '@storybook/addon-info';
 import { withKnobs, boolean } from '@storybook/addon-knobs/react';
+import { Store, State } from '@sambego/storybook-state';
 import { IconAddMediumOutline } from '@teamleader/ui-icons';
 import { Button, ButtonGroup } from '../components';
+
+const store = new Store({
+  value: 'option2',
+});
+
+const handleChangeValue = (value, event) => {
+  store.set({ value });
+};
 
 storiesOf('Button groups', module)
   .addDecorator((story, context) => withInfo({TableComponent: PropTable})(story)(context))
@@ -17,4 +26,13 @@ storiesOf('Button groups', module)
       <Button label="Button 2"/>
       <Button icon={<IconAddMediumOutline />} />
     </ButtonGroup>
+  ))
+  .add('with active', () => (
+    <State store={store}>
+      <ButtonGroup segmented={boolean('Semented', true)} value="option2" onChange={handleChangeValue} level="secondary">
+        <Button label="Option 1" value="option1" />
+        <Button label="Option 2" value="option2" />
+        <Button label="Option 3" value="option3" />
+      </ButtonGroup>
+    </State>
   ));


### PR DESCRIPTION
### Changed
- `Button` now has an `active` prop, which will show the button in an "inverted active state" (only fully supported for secondary buttons for now).
- `ButtonGroup` now supports having 1 active child button. This works by adding a `value` prop to both `ButtonGroup` and the `Button` children.
- `ButtonGroup` now passes props to the child buttons. This way you can define the size, level, ... on the `ButtonGroup` instead of adding it to all child buttons.
- created a function to omit all box props from a list of props.

![screen shot 2018-04-27 at 13 46 24](https://user-images.githubusercontent.com/330765/39361143-6ae7b1d8-4a21-11e8-9658-0c05e495ef53.png)
