### PR TITLE
🐛 Popover SVG anchor element

### DIFF
--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -7,8 +7,8 @@ function getAnchorPosition(anchorEl) {
   const anchorPosition = {
     top: anchorRect.top,
     left: anchorRect.left,
-    width: anchorEl.offsetWidth,
-    height: anchorEl.offsetHeight,
+    width: Math.round(anchorRect.width),
+    height: Math.round(anchorRect.height),
   };
 
   anchorPosition.right = anchorRect.right || anchorPosition.left + anchorPosition.width;

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -20,8 +20,9 @@ function getAnchorPosition(anchorEl) {
 }
 
 function getTargetPosition(targetEl) {
-  const width = targetEl.offsetWidth;
-  const height = targetEl.offsetHeight;
+  const targetRect = targetEl.getBoundingClientRect();
+  const width = Math.round(targetRect.width);
+  const height = Math.round(targetRect.height);
 
   return {
     top: 0,

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -57,7 +57,7 @@ const directionWest = (anchorPosition, targetPosition) => ({
   arrowLeft: targetPosition.width - ARROW_OFFSET,
 });
 
-const directionEast = (anchorPosition, targetPosition) => ({
+const directionEast = anchorPosition => ({
   left: anchorPosition.right + POPUP_OFFSET,
   arrowLeft: -ARROW_OFFSET,
 });
@@ -112,7 +112,7 @@ const directionNorth = (anchorPosition, targetPosition) => ({
   arrowTop: targetPosition.height - ARROW_OFFSET,
 });
 
-const directionSouth = (anchorPosition, targetPosition) => ({
+const directionSouth = anchorPosition => ({
   top: anchorPosition.top + anchorPosition.height + POPUP_OFFSET,
   arrowTop: -ARROW_OFFSET,
 });

--- a/stories/popover.js
+++ b/stories/popover.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/react';
 import { Store, State } from '@sambego/storybook-state';
 import { checkA11y } from 'storybook-addon-a11y';
 import { withInfo } from '@storybook/addon-info';
-import { Banner, Box, Button, ButtonGroup, Heading3, Link, PopoverHorizontal, PopoverVertical, Section, TextBody, TextSmall } from '../components';
+import { Banner, Box, Button, ButtonGroup, Heading3, Link, PopoverHorizontal, PopoverVertical, TextBody, TextSmall } from '../components';
 
 const store = new Store({
   active: false,

--- a/stories/popover.js
+++ b/stories/popover.js
@@ -1,16 +1,27 @@
 import React from 'react';
-import PropTable from "./components/propTable";
+import PropTable from './components/propTable';
 import { storiesOf } from '@storybook/react';
 import { Store, State } from '@sambego/storybook-state';
 import { checkA11y } from 'storybook-addon-a11y';
 import { withInfo } from '@storybook/addon-info';
-import { Banner, Box, Button, ButtonGroup, Heading3, Link, PopoverHorizontal, PopoverVertical, TextBody, TextSmall } from '../components';
+import {
+  Banner,
+  Box,
+  Button,
+  ButtonGroup,
+  Heading3,
+  Link,
+  PopoverHorizontal,
+  PopoverVertical,
+  TextBody,
+  TextSmall,
+} from '../components';
 
 const store = new Store({
   active: false,
 });
 
-const handleButtonClick = (event) => {
+const handleButtonClick = event => {
   store.set({ anchorEl: event.currentTarget, active: true });
 };
 
@@ -25,7 +36,7 @@ const contentBoxWithSingleTextLine = (
 );
 
 storiesOf('Popover', module)
-  .addDecorator((story, context) => withInfo({TableComponent: PropTable})(story)(context))
+  .addDecorator((story, context) => withInfo({ TableComponent: PropTable })(story)(context))
   .addDecorator(checkA11y)
   .add('horizontal', () => (
     <Box>


### PR DESCRIPTION
### Description
I was using a popover in core on an SVG element. The popover was rendered, but the top was always 0 for every element. I went inside UI and noticed that the offsetHeight is being used to calculate the position. However, this doesn't work on an SVG. Using getBoundingClientRect (which we were already doing) and rounding up the width and height of those values returns the same width and height for an svg as for another HTML element.

I also added this to the `getTargetPosition` function because there we were also using offsetWidth and offsetHeight, just in case the targetElement would be an SVG.

Because I wanted to be sure we would have the same values [(and because there are differences between offsetWidth, clientWidth, regular width (css property) and getBoundingClientRect.width)](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements) I tested some things and made screenshots of 'em.

GBCR = getBoundingClientRect

The first number is the GBCR.width, the second is the offsetWidth.
As you can see, for a button, both work and are the same (except for rounding), but for SVG only the GBCR.width works.
![screen shot 2018-05-07 at 09 42 05 1](https://user-images.githubusercontent.com/9056632/39692814-49e52e3e-51e2-11e8-807d-2337e03a6fcf.jpg)

Of course, just using `Math.round()` fixes the rounding problem and this makes sure GBCR.width equals offsetWidth.
![screen shot 2018-05-07 at 09 58 05](https://user-images.githubusercontent.com/9056632/39692945-af7c29e6-51e2-11e8-9dc5-5beda539ea6b.jpg)

To make sure borders, paddings and *not* margins were taken into account, I also tested this:
![screen shot 2018-05-07 at 09 59 24](https://user-images.githubusercontent.com/9056632/39693013-e575211a-51e2-11e8-8c6d-bb8c7a1549f8.jpg)

The margin was 33px, so the numbers shouldn't end on a 4 or a 7 anymore if the margin was also added for one of both.
