### PR TITLE
:bug: check if onChange is explicitly set for non-redux-forms

### DIFF
--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -130,15 +130,19 @@ export default class Input extends PureComponent {
   };
 
   updateValue(rawValue, triggerOnChange = true) {
-    const { input } = this.props;
+    const { input, onChange } = this.props;
     const value = Input.parseValue(rawValue, this.props);
 
     this.setState({
       value,
     });
 
-    if (triggerOnChange && input && input.onChange) {
-      input.onChange(value);
+    if (triggerOnChange) {
+      if (input && input.onChange) {
+        input.onChange(value);
+      } else if (onChange) {
+        onChange(value);
+      }
     }
   }
 


### PR DESCRIPTION
### Description
I tried bumping the version to 0.8.0 on core but then the Input fields got broken, this is because an onChange wasn't possible to be passed down to this component. @timdegroote fixed this bug.