### PR TITLE
Check if nextProps.value is not undefined before updating state

### DIFF
--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -80,12 +80,12 @@ export default class Input extends PureComponent {
 
   static getDerivedStateFromProps(nextProps, prevState) {
     if (nextProps.value !== undefined) {
-			const newValue = Input.parseValue(Input.getPropsValue(nextProps), nextProps);
-			if (newValue !== prevState.value) {
-				return {
-					value: newValue,
-				};
-			}
+      const newValue = Input.parseValue(Input.getPropsValue(nextProps), nextProps);
+      if (newValue !== prevState.value) {
+        return {
+          value: newValue,
+        };
+      }
     }
 
     return null;

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -79,11 +79,13 @@ export default class Input extends PureComponent {
   };
 
   static getDerivedStateFromProps(nextProps, prevState) {
-    const newValue = Input.parseValue(Input.getPropsValue(nextProps), nextProps);
-    if (newValue !== prevState.value) {
-      return {
-        value: newValue,
-      };
+    if (nextProps.value !== undefined) {
+			const newValue = Input.parseValue(Input.getPropsValue(nextProps), nextProps);
+			if (newValue !== prevState.value) {
+				return {
+					value: newValue,
+				};
+			}
     }
 
     return null;


### PR DESCRIPTION
### Description
Fixes a change value bug when typing into input field. If the value prop is passed by the parent component it should take that value otherwise it should take the value from internal state.

### Breaking changes
None.
