### PR TITLE
Label: make it possible to add box props to the label Box container

### DIFF
--- a/components/label/Label.js
+++ b/components/label/Label.js
@@ -13,7 +13,7 @@ export default class Label extends PureComponent {
     children: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.array]),
     connectedLeft: PropTypes.element,
     connectedRight: PropTypes.element,
-    for: PropTypes.string,
+		htmlFor: PropTypes.string,
     inverse: PropTypes.bool,
     helpText: PropTypes.string,
     required: PropTypes.bool,
@@ -28,12 +28,24 @@ export default class Label extends PureComponent {
   };
 
   render() {
-    const { children, connectedLeft, connectedRight, className, inverse, helpText, required, size, ...others } = this.props;
+    const {
+      children,
+      connectedLeft,
+      connectedRight,
+      className,
+      inverse,
+      helpText,
+      required,
+      size,
+      ...others
+    } = this.props;
+
     const childProps = {
       inverse,
       marginTop: 1,
       size,
     };
+
     const classNames = cx(
       theme['label'],
       {
@@ -41,10 +53,11 @@ export default class Label extends PureComponent {
       },
       className,
     );
+
     const Element = size === 'large' ? TextDisplay : TextBody;
 
     return (
-      <Box element="label" htmlFor={this.props.for} marginBottom={3} className={classNames} {...others}>
+      <Box element="label" marginBottom={3} className={classNames} {...others}>
         {React.Children.map(children, child => {
           if (isComponentOfType(Input, child)) {
             return React.cloneElement(child, childProps);

--- a/components/label/Label.js
+++ b/components/label/Label.js
@@ -13,7 +13,6 @@ export default class Label extends PureComponent {
     children: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.array]),
     connectedLeft: PropTypes.element,
     connectedRight: PropTypes.element,
-		htmlFor: PropTypes.string,
     inverse: PropTypes.bool,
     helpText: PropTypes.string,
     required: PropTypes.bool,

--- a/components/label/Label.js
+++ b/components/label/Label.js
@@ -28,7 +28,7 @@ export default class Label extends PureComponent {
   };
 
   render() {
-    const { children, connectedLeft, connectedRight, className, inverse, helpText, required, size } = this.props;
+    const { children, connectedLeft, connectedRight, className, inverse, helpText, required, size, ...others } = this.props;
     const childProps = {
       inverse,
       marginTop: 1,
@@ -44,7 +44,7 @@ export default class Label extends PureComponent {
     const Element = size === 'large' ? TextDisplay : TextBody;
 
     return (
-      <Box element="label" htmlFor={this.props.for} marginBottom={3} className={classNames}>
+      <Box element="label" htmlFor={this.props.for} marginBottom={3} className={classNames} {...others}>
         {React.Children.map(children, child => {
           if (isComponentOfType(Input, child)) {
             return React.cloneElement(child, childProps);


### PR DESCRIPTION
### Description
In this PR we make it possible to add box props to the label Box container. Also the prop `for` has been replaced by `htmlFor`.

### Breaking changes
⚠️ Label component doesn't support the `for` prop anymore. You can pass the `htmlFor` prop instead and will be applied to Label by `...others` from now on.
