### PR TITLE
Also check for any value passed by redux-form in getDerivedStateFromProps

### DIFF
--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -79,7 +79,8 @@ export default class Input extends PureComponent {
   };
 
   static getDerivedStateFromProps(nextProps, prevState) {
-    if (nextProps.value !== undefined) {
+    const value = nextProps.input ? nextProps.input.value : nextProps.value;
+    if (value !== undefined) {
       const newValue = Input.parseValue(Input.getPropsValue(nextProps), nextProps);
       if (newValue !== prevState.value) {
         return {


### PR DESCRIPTION
Currently when redux-form has an initial value set for the input component the value isn't taken properly. This adds a check in gDSFP so that the input value passed from redux-form isn't ignored.