### PR TITLE
Update: move propTypes & defaultProps outside class

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,6 +13,11 @@
         "react-hot-loader/babel",
         "transform-react-jsx-source"
       ]
+    },
+    "production": {
+      "plugins": [
+        "transform-react-remove-prop-types"
+      ]
     }
   }
 }

--- a/components/badge/Badge.js
+++ b/components/badge/Badge.js
@@ -6,37 +6,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class Badge extends PureComponent {
-  static propTypes = {
-    /** The content to display inside the badge. */
-    children: PropTypes.any,
-    /** A class name for the wrapper to give custom styles. */
-    className: PropTypes.string,
-    /** If true, component will be disabled. */
-    disabled: PropTypes.bool,
-    /** Sets a custom element to use as the badge component wrapper. */
-    element: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
-    /** The icon displayed inside the badge. */
-    icon: PropTypes.element,
-    /** The position of the icon inside the badge. */
-    iconPlacement: PropTypes.oneOf(['left', 'right']),
-    /** If true, component will adapt styles from it's parent component. */
-    inherit: PropTypes.bool,
-    /** If true, component will be rendered in inverse mode. */
-    inverse: PropTypes.bool,
-    /** Callback function that is fired when mouse leaves the component. */
-    onMouseLeave: PropTypes.func,
-    /** Callback function that is fired when the mouse button is released. */
-    onMouseUp: PropTypes.func,
-  };
-
-  static defaultProps = {
-    disabled: false,
-    element: 'button',
-    iconPlacement: 'left',
-    inherit: true,
-    inverse: false,
-  };
-
   handleMouseUp = event => {
     this.badgeNode.getNode().blur();
     if (this.props.onMouseUp) {
@@ -89,5 +58,36 @@ class Badge extends PureComponent {
     );
   }
 }
+
+Badge.propTypes = {
+  /** The content to display inside the badge. */
+  children: PropTypes.any,
+  /** A class name for the wrapper to give custom styles. */
+  className: PropTypes.string,
+  /** If true, component will be disabled. */
+  disabled: PropTypes.bool,
+  /** Sets a custom element to use as the badge component wrapper. */
+  element: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+  /** The icon displayed inside the badge. */
+  icon: PropTypes.element,
+  /** The position of the icon inside the badge. */
+  iconPlacement: PropTypes.oneOf(['left', 'right']),
+  /** If true, component will adapt styles from it's parent component. */
+  inherit: PropTypes.bool,
+  /** If true, component will be rendered in inverse mode. */
+  inverse: PropTypes.bool,
+  /** Callback function that is fired when mouse leaves the component. */
+  onMouseLeave: PropTypes.func,
+  /** Callback function that is fired when the mouse button is released. */
+  onMouseUp: PropTypes.func,
+};
+
+Badge.defaultProps = {
+  disabled: false,
+  element: 'button',
+  iconPlacement: 'left',
+  inherit: true,
+  inverse: false,
+};
 
 export default Badge;

--- a/components/banner/Banner.js
+++ b/components/banner/Banner.js
@@ -7,25 +7,6 @@ import theme from './theme.css';
 import { IconCloseMediumOutline } from '@teamleader/ui-icons';
 
 class Banner extends PureComponent {
-  static propTypes = {
-    /** The content to display inside the banner. */
-    children: PropTypes.node,
-    /** A class name for the wrapper to give custom styles. */
-    className: PropTypes.string,
-    /** The color of the banner. */
-    color: PropTypes.oneOf(['white', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua']),
-    /** The icon displayed on the left inside the banner. */
-    icon: PropTypes.element,
-    /** Callback function that is fired when the close button of the banner is clicked. */
-    onClose: PropTypes.func,
-    /** If true, component will take the full width of it's container. */
-    fullWidth: PropTypes.bool,
-  };
-
-  static defaultProps = {
-    color: 'white',
-  };
-
   constructor() {
     super(...arguments);
     this.handleClick = ::this.handleClick;
@@ -62,5 +43,24 @@ class Banner extends PureComponent {
     );
   }
 }
+
+Banner.propTypes = {
+  /** The content to display inside the banner. */
+  children: PropTypes.node,
+  /** A class name for the wrapper to give custom styles. */
+  className: PropTypes.string,
+  /** The color of the banner. */
+  color: PropTypes.oneOf(['white', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua']),
+  /** The icon displayed on the left inside the banner. */
+  icon: PropTypes.element,
+  /** Callback function that is fired when the close button of the banner is clicked. */
+  onClose: PropTypes.func,
+  /** If true, component will take the full width of it's container. */
+  fullWidth: PropTypes.bool,
+};
+
+Banner.defaultProps = {
+  color: 'white',
+};
 
 export default Banner;

--- a/components/bullet/Bullet.js
+++ b/components/bullet/Bullet.js
@@ -5,20 +5,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class Bullet extends PureComponent {
-  static propTypes = {
-    /** A class name for the wrapper to give custom styles. */
-    className: PropTypes.string,
-    /** The color of the bullet. */
-    color: PropTypes.oneOf(['neutral', 'mint', 'aqua', 'violet', 'teal', 'gold', 'ruby']),
-    /** The size of the bullet. */
-    size: PropTypes.oneOf(['small', 'medium']),
-  };
-
-  static defaultProps = {
-    color: 'neutral',
-    size: 'medium',
-  };
-
   render() {
     const { className, color, size, ...others } = this.props;
     const classNames = cx(theme['bullet'], theme[color], theme[size], className);
@@ -26,5 +12,19 @@ class Bullet extends PureComponent {
     return <Box data-teamleader-ui="bullet" className={classNames} element="span" {...others} />;
   }
 }
+
+Bullet.propTypes = {
+  /** A class name for the wrapper to give custom styles. */
+  className: PropTypes.string,
+  /** The color of the bullet. */
+  color: PropTypes.oneOf(['neutral', 'mint', 'aqua', 'violet', 'teal', 'gold', 'ruby']),
+  /** The size of the bullet. */
+  size: PropTypes.oneOf(['small', 'medium']),
+};
+
+Bullet.defaultProps = {
+  color: 'neutral',
+  size: 'medium',
+};
 
 export default Bullet;

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -5,52 +5,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class Button extends PureComponent {
-  static propTypes = {
-    /** The content to display inside the button. */
-    children: PropTypes.any,
-    /** A class name for the button to give custom styles. */
-    className: PropTypes.string,
-    /** Determines which kind of button to be rendered. */
-    level: PropTypes.oneOf(['outline', 'primary', 'secondary', 'destructive']),
-    /** If true, component will be disabled. */
-    disabled: PropTypes.bool,
-    /** If true, component will be shown in an active state */
-    active: PropTypes.bool,
-    /** If true, component will take the full width available. */
-    fullWidth: PropTypes.bool,
-    /** If set, button will be rendered as an anchor element. */
-    href: PropTypes.string,
-    /** The icon displayed inside the button. */
-    icon: PropTypes.element,
-    /** The position of the icon inside the button. */
-    iconPlacement: PropTypes.oneOf(['left', 'right']),
-    /** If true, component will be rendered in inverse mode. */
-    inverse: PropTypes.bool,
-    /** The textual label displayed inside the button. */
-    label: PropTypes.string,
-    /** Callback function that is fired when mouse leaves the component. */
-    onMouseLeave: PropTypes.func,
-    /** Callback function that is fired when the mouse button is released. */
-    onMouseUp: PropTypes.func,
-    /** If true, component will show a loading spinner instead of label or children. */
-    processing: PropTypes.bool,
-    /** Size of the button. */
-    size: PropTypes.oneOf(['small', 'medium', 'large']),
-    /** Type of the button element. */
-    type: PropTypes.string,
-  };
-
-  static defaultProps = {
-    className: '',
-    fullWidth: false,
-    level: 'secondary',
-    iconPlacement: 'left',
-    inverse: false,
-    processing: false,
-    size: 'medium',
-    type: 'button',
-  };
-
   getSpinnerColor() {
     const { inverse, level } = this.props;
 
@@ -141,5 +95,51 @@ class Button extends PureComponent {
     );
   }
 }
+
+Button.propTypes = {
+  /** The content to display inside the button. */
+  children: PropTypes.any,
+  /** A class name for the button to give custom styles. */
+  className: PropTypes.string,
+  /** Determines which kind of button to be rendered. */
+  level: PropTypes.oneOf(['outline', 'primary', 'secondary', 'destructive']),
+  /** If true, component will be disabled. */
+  disabled: PropTypes.bool,
+  /** If true, component will be shown in an active state */
+  active: PropTypes.bool,
+  /** If true, component will take the full width available. */
+  fullWidth: PropTypes.bool,
+  /** If set, button will be rendered as an anchor element. */
+  href: PropTypes.string,
+  /** The icon displayed inside the button. */
+  icon: PropTypes.element,
+  /** The position of the icon inside the button. */
+  iconPlacement: PropTypes.oneOf(['left', 'right']),
+  /** If true, component will be rendered in inverse mode. */
+  inverse: PropTypes.bool,
+  /** The textual label displayed inside the button. */
+  label: PropTypes.string,
+  /** Callback function that is fired when mouse leaves the component. */
+  onMouseLeave: PropTypes.func,
+  /** Callback function that is fired when the mouse button is released. */
+  onMouseUp: PropTypes.func,
+  /** If true, component will show a loading spinner instead of label or children. */
+  processing: PropTypes.bool,
+  /** Size of the button. */
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  /** Type of the button element. */
+  type: PropTypes.string,
+};
+
+Button.defaultProps = {
+  className: '',
+  fullWidth: false,
+  level: 'secondary',
+  iconPlacement: 'left',
+  inverse: false,
+  processing: false,
+  size: 'medium',
+  type: 'button',
+};
 
 export default Button;

--- a/components/button/ButtonGroup.js
+++ b/components/button/ButtonGroup.js
@@ -8,23 +8,6 @@ import isComponentOfType from '../utils/is-component-of-type';
 import theme from './theme.css';
 
 class ButtonGroup extends PureComponent {
-  static propTypes = {
-    /** The content to display inside the button group. */
-    children: PropTypes.node,
-    /** A class name for the wrapper to give custom styles. */
-    className: PropTypes.string,
-    /** If true, child components will be displayed segmented. */
-    segmented: PropTypes.bool,
-    /** The value of the currently active button. */
-    value: PropTypes.string,
-    /** Callback function that is fired when the active button changes. */
-    onChange: PropTypes.func,
-  };
-
-  static defaultProps = {
-    segmented: false,
-  };
-
   handleChange = (value, event) => {
     if (this.props.onChange) {
       this.props.onChange(value, event);
@@ -70,5 +53,22 @@ class ButtonGroup extends PureComponent {
     );
   }
 }
+
+ButtonGroup.propTypes = {
+  /** The content to display inside the button group. */
+  children: PropTypes.node,
+  /** A class name for the wrapper to give custom styles. */
+  className: PropTypes.string,
+  /** If true, child components will be displayed segmented. */
+  segmented: PropTypes.bool,
+  /** The value of the currently active button. */
+  value: PropTypes.string,
+  /** Callback function that is fired when the active button changes. */
+  onChange: PropTypes.func,
+};
+
+ButtonGroup.defaultProps = {
+  segmented: false,
+};
 
 export default ButtonGroup;

--- a/components/button/IconButton.js
+++ b/components/button/IconButton.js
@@ -4,26 +4,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class IconButton extends Component {
-  static propTypes = {
-    children: PropTypes.node,
-    className: PropTypes.string,
-    disabled: PropTypes.bool,
-    href: PropTypes.string,
-    icon: PropTypes.element,
-    onMouseLeave: PropTypes.func,
-    onMouseUp: PropTypes.func,
-    size: PropTypes.oneOf(['small', 'medium']),
-    color: PropTypes.oneOf(['neutral', 'white', 'mint', 'violet', 'ruby', 'gold', 'aqua']),
-    type: PropTypes.string,
-  };
-
-  static defaultProps = {
-    className: '',
-    size: 'medium',
-    color: 'neutral',
-    type: 'button',
-  };
-
   handleMouseUp = event => {
     this.buttonNode.blur();
     if (this.props.onMouseUp) {
@@ -70,5 +50,25 @@ class IconButton extends Component {
     return React.createElement(element, props, icon, children);
   }
 }
+
+IconButton.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  href: PropTypes.string,
+  icon: PropTypes.element,
+  onMouseLeave: PropTypes.func,
+  onMouseUp: PropTypes.func,
+  size: PropTypes.oneOf(['small', 'medium']),
+  color: PropTypes.oneOf(['neutral', 'white', 'mint', 'violet', 'ruby', 'gold', 'aqua']),
+  type: PropTypes.string,
+};
+
+IconButton.defaultProps = {
+  className: '',
+  size: 'medium',
+  color: 'neutral',
+  type: 'button',
+};
 
 export default IconButton;

--- a/components/button/LinkButton.js
+++ b/components/button/LinkButton.js
@@ -4,27 +4,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class LinkButton extends PureComponent {
-  static propTypes = {
-    children: PropTypes.any,
-    className: PropTypes.string,
-    disabled: PropTypes.bool,
-    element: PropTypes.element,
-    icon: PropTypes.element,
-    iconPlacement: PropTypes.oneOf(['left', 'right']),
-    inverse: PropTypes.bool,
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    onMouseLeave: PropTypes.func,
-    onMouseUp: PropTypes.func,
-    size: PropTypes.oneOf(['small', 'medium', 'large']),
-  };
-
-  static defaultProps = {
-    className: '',
-    iconPlacement: 'left',
-    inverse: false,
-    size: 'medium',
-  };
-
   handleMouseUp = event => {
     this.buttonNode.blur();
     if (this.props.onMouseUp) {
@@ -80,5 +59,26 @@ class LinkButton extends PureComponent {
     );
   }
 }
+
+LinkButton.propTypes = {
+  children: PropTypes.any,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  element: PropTypes.element,
+  icon: PropTypes.element,
+  iconPlacement: PropTypes.oneOf(['left', 'right']),
+  inverse: PropTypes.bool,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onMouseLeave: PropTypes.func,
+  onMouseUp: PropTypes.func,
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+};
+
+LinkButton.defaultProps = {
+  className: '',
+  iconPlacement: 'left',
+  inverse: false,
+  size: 'medium',
+};
 
 export default LinkButton;

--- a/components/checkbox/Checkbox.js
+++ b/components/checkbox/Checkbox.js
@@ -8,31 +8,6 @@ import { TextBody, TextDisplay, TextSmall } from '../typography';
 import { IconCheckmarkSmallOutline, IconCheckmarkMediumOutline } from '@teamleader/ui-icons';
 
 class Checkbox extends PureComponent {
-  static propTypes = {
-    /** If true, the checkbox will be checked. */
-    checked: PropTypes.bool,
-    /** The content to display next to the checkbox. */
-    children: PropTypes.node,
-    /** If true, component will be disabled. */
-    disabled: PropTypes.bool,
-    /** Name for form input. */
-    name: PropTypes.string,
-    /** A class name for the wrapper to give custom styles. */
-    className: PropTypes.string,
-    /** The textual label displayed next to the checkbox. */
-    label: PropTypes.string,
-    /** Callback function that is fired when checkbox is toggled. */
-    onChange: PropTypes.func,
-    /** Size of the checkbox. */
-    size: PropTypes.oneOf(['small', 'medium', 'large']),
-  };
-
-  static defaultProps = {
-    checked: false,
-    disabled: false,
-    size: 'medium',
-  };
-
   constructor() {
     super(...arguments);
     this.handleToggle = ::this.handleToggle;
@@ -144,5 +119,30 @@ class Checkbox extends PureComponent {
     );
   }
 }
+
+Checkbox.propTypes = {
+  /** If true, the checkbox will be checked. */
+  checked: PropTypes.bool,
+  /** The content to display next to the checkbox. */
+  children: PropTypes.node,
+  /** If true, component will be disabled. */
+  disabled: PropTypes.bool,
+  /** Name for form input. */
+  name: PropTypes.string,
+  /** A class name for the wrapper to give custom styles. */
+  className: PropTypes.string,
+  /** The textual label displayed next to the checkbox. */
+  label: PropTypes.string,
+  /** Callback function that is fired when checkbox is toggled. */
+  onChange: PropTypes.func,
+  /** Size of the checkbox. */
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+};
+
+Checkbox.defaultProps = {
+  checked: false,
+  disabled: false,
+  size: 'medium',
+};
 
 export default Checkbox;

--- a/components/compactMessage/CompactMessage.js
+++ b/components/compactMessage/CompactMessage.js
@@ -5,13 +5,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class CompactMessage extends PureComponent {
-  static propTypes = {
-    className: PropTypes.string,
-    children: PropTypes.any.isRequired,
-    image: PropTypes.element,
-    button: PropTypes.element,
-  };
-
   render() {
     const { className, children, image, button, ...others } = this.props;
 
@@ -28,5 +21,12 @@ class CompactMessage extends PureComponent {
     );
   }
 }
+
+CompactMessage.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.any.isRequired,
+  image: PropTypes.element,
+  button: PropTypes.element,
+};
 
 export default CompactMessage;

--- a/components/counter/Counter.js
+++ b/components/counter/Counter.js
@@ -5,20 +5,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class Counter extends PureComponent {
-  static propTypes = {
-    children: PropTypes.any,
-    className: PropTypes.string,
-    color: PropTypes.oneOf(['neutral', 'mint', 'aqua', 'violet', 'teal', 'gold', 'ruby']),
-    count: PropTypes.number.isRequired,
-    maxCount: PropTypes.number,
-    size: PropTypes.oneOf(['small', 'medium']),
-  };
-
-  static defaultProps = {
-    color: 'neutral',
-    size: 'medium',
-  };
-
   render() {
     const { children, className, color, count, maxCount, size, ...others } = this.props;
 
@@ -31,5 +17,19 @@ class Counter extends PureComponent {
     );
   }
 }
+
+Counter.propTypes = {
+  children: PropTypes.any,
+  className: PropTypes.string,
+  color: PropTypes.oneOf(['neutral', 'mint', 'aqua', 'violet', 'teal', 'gold', 'ruby']),
+  count: PropTypes.number.isRequired,
+  maxCount: PropTypes.number,
+  size: PropTypes.oneOf(['small', 'medium']),
+};
+
+Counter.defaultProps = {
+  color: 'neutral',
+  size: 'medium',
+};
 
 export default Counter;

--- a/components/datagrid/BodyRow.js
+++ b/components/datagrid/BodyRow.js
@@ -7,16 +7,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class BodyRow extends PureComponent {
-  static propTypes = {
-    className: PropTypes.string,
-    children: PropTypes.any,
-    onSelectionChange: PropTypes.func,
-    selectable: PropTypes.bool,
-    selected: PropTypes.bool,
-    sliceFrom: PropTypes.number,
-    sliceTo: PropTypes.number,
-  };
-
   render() {
     const { className, children, sliceFrom, sliceTo, onSelectionChange, selected, selectable, ...others } = this.props;
 
@@ -36,5 +26,15 @@ class BodyRow extends PureComponent {
     );
   }
 }
+
+BodyRow.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.any,
+  onSelectionChange: PropTypes.func,
+  selectable: PropTypes.bool,
+  selected: PropTypes.bool,
+  sliceFrom: PropTypes.number,
+  sliceTo: PropTypes.number,
+};
 
 export default BodyRow;

--- a/components/datagrid/Cell.js
+++ b/components/datagrid/Cell.js
@@ -5,27 +5,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class Cell extends PureComponent {
-  static propTypes = {
-    align: PropTypes.oneOf(['left', 'center', 'right']),
-    backgroundColor: PropTypes.oneOf(['white', 'neutral']),
-    border: PropTypes.oneOf(['around', 'left', 'right']),
-    bordered: PropTypes.bool,
-    children: PropTypes.any,
-    className: PropTypes.string,
-    flex: PropTypes.oneOf(['min-width', '1', '2', '3', '4']),
-    preventOverflow: PropTypes.bool,
-    soft: PropTypes.bool,
-    strong: PropTypes.bool,
-  };
-
-  static defaultProps = {
-    align: 'left',
-    flex: '1',
-    preventOverflow: true,
-    soft: false,
-    strong: false,
-  };
-
   render() {
     const {
       align,
@@ -60,5 +39,26 @@ class Cell extends PureComponent {
     );
   }
 }
+
+Cell.propTypes = {
+  align: PropTypes.oneOf(['left', 'center', 'right']),
+  backgroundColor: PropTypes.oneOf(['white', 'neutral']),
+  border: PropTypes.oneOf(['around', 'left', 'right']),
+  bordered: PropTypes.bool,
+  children: PropTypes.any,
+  className: PropTypes.string,
+  flex: PropTypes.oneOf(['min-width', '1', '2', '3', '4']),
+  preventOverflow: PropTypes.bool,
+  soft: PropTypes.bool,
+  strong: PropTypes.bool,
+};
+
+Cell.defaultProps = {
+  align: 'left',
+  flex: '1',
+  preventOverflow: true,
+  soft: false,
+  strong: false,
+};
 
 export default Cell;

--- a/components/datagrid/DataGrid.js
+++ b/components/datagrid/DataGrid.js
@@ -16,16 +16,6 @@ import theme from './theme.css';
 import { events } from '../utils';
 
 class DataGrid extends PureComponent {
-  static propTypes = {
-    children: PropTypes.node,
-    className: PropTypes.string,
-    comparableId: PropTypes.any,
-    selectable: PropTypes.bool,
-    stickyFromLeft: PropTypes.number,
-    stickyFromRight: PropTypes.number,
-    onSelectionChange: PropTypes.func,
-  };
-
   constructor() {
     super(...arguments);
 
@@ -182,6 +172,16 @@ class DataGrid extends PureComponent {
     );
   }
 }
+
+DataGrid.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  comparableId: PropTypes.any,
+  selectable: PropTypes.bool,
+  stickyFromLeft: PropTypes.number,
+  stickyFromRight: PropTypes.number,
+  onSelectionChange: PropTypes.func,
+};
 
 DataGrid.HeaderRow = HeaderRow;
 DataGrid.HeaderCell = HeaderCell;

--- a/components/datagrid/FooterRow.js
+++ b/components/datagrid/FooterRow.js
@@ -6,14 +6,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class FooterRow extends PureComponent {
-  static propTypes = {
-    className: PropTypes.string,
-    children: PropTypes.any,
-    preserveSelectableSpace: PropTypes.bool,
-    sliceFrom: PropTypes.number,
-    sliceTo: PropTypes.number,
-  };
-
   render() {
     const { className, children, sliceFrom, sliceTo, preserveSelectableSpace, ...others } = this.props;
 
@@ -29,5 +21,13 @@ class FooterRow extends PureComponent {
     );
   }
 }
+
+FooterRow.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.any,
+  preserveSelectableSpace: PropTypes.bool,
+  sliceFrom: PropTypes.number,
+  sliceTo: PropTypes.number,
+};
 
 export default FooterRow;

--- a/components/datagrid/HeaderCell.js
+++ b/components/datagrid/HeaderCell.js
@@ -6,17 +6,6 @@ import cx from 'classnames';
 import { IconChevronDownSmallOutline, IconChevronUpSmallOutline } from '@teamleader/ui-icons';
 
 class HeaderCell extends PureComponent {
-  static propTypes = {
-    children: PropTypes.any,
-    className: PropTypes.string,
-    onClick: PropTypes.func,
-    sorted: PropTypes.oneOf(['none', 'asc', 'desc']),
-  };
-
-  static defaultProps = {
-    sorted: 'none',
-  };
-
   render() {
     const { children, className, onClick, sorted, ...others } = this.props;
 
@@ -37,5 +26,16 @@ class HeaderCell extends PureComponent {
     );
   }
 }
+
+HeaderCell.propTypes = {
+  children: PropTypes.any,
+  className: PropTypes.string,
+  onClick: PropTypes.func,
+  sorted: PropTypes.oneOf(['none', 'asc', 'desc']),
+};
+
+HeaderCell.defaultProps = {
+  sorted: 'none',
+};
 
 export default HeaderCell;

--- a/components/datagrid/HeaderRow.js
+++ b/components/datagrid/HeaderRow.js
@@ -7,16 +7,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class HeaderRow extends PureComponent {
-  static propTypes = {
-    className: PropTypes.string,
-    children: PropTypes.any,
-    onSelectionChange: PropTypes.func,
-    selectable: PropTypes.bool,
-    selected: PropTypes.bool,
-    sliceFrom: PropTypes.number,
-    sliceTo: PropTypes.number,
-  };
-
   render() {
     const { className, children, sliceFrom, sliceTo, onSelectionChange, selected, selectable, ...others } = this.props;
 
@@ -36,5 +26,15 @@ class HeaderRow extends PureComponent {
     );
   }
 }
+
+HeaderRow.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.any,
+  onSelectionChange: PropTypes.func,
+  selectable: PropTypes.bool,
+  selected: PropTypes.bool,
+  sliceFrom: PropTypes.number,
+  sliceTo: PropTypes.number,
+};
 
 export default HeaderRow;

--- a/components/datagrid/Row.js
+++ b/components/datagrid/Row.js
@@ -5,16 +5,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class Row extends PureComponent {
-  static propTypes = {
-    backgroundColor: PropTypes.oneOf(['white', 'neutral']),
-    className: PropTypes.string,
-    children: PropTypes.any,
-  };
-
-  static defaultProps = {
-    backgroundColor: 'white',
-  };
-
   render() {
     const { backgroundColor, className, children, ...others } = this.props;
 
@@ -27,5 +17,15 @@ class Row extends PureComponent {
     );
   }
 }
+
+Row.propTypes = {
+  backgroundColor: PropTypes.oneOf(['white', 'neutral']),
+  className: PropTypes.string,
+  children: PropTypes.any,
+};
+
+Row.defaultProps = {
+  backgroundColor: 'white',
+};
 
 export default Row;

--- a/components/dialog/Dialog.js
+++ b/components/dialog/Dialog.js
@@ -7,35 +7,6 @@ import Transition from 'react-transition-group/Transition';
 import theme from './theme.css';
 
 class Dialog extends PureComponent {
-  static propTypes = {
-    /** If true, the dialog will show on screen. */
-    active: PropTypes.bool,
-    /** Specify which backdrop the dialog should show. */
-    backdrop: PropTypes.string,
-    /** The content to display inside the dialog. */
-    children: PropTypes.node,
-    /** A class name for the wrapper to give custom styles. */
-    className: PropTypes.string,
-    /** Callback function that is fired when the escape key is pressed. */
-    onEscKeyDown: PropTypes.func,
-    /** Callback function that is fired when the mouse clicks on the overlay. */
-    onOverlayClick: PropTypes.func,
-    /** Callback function that is fired when the mouse button is pressed on the overlay. */
-    onOverlayMouseDown: PropTypes.func,
-    /** Callback function that is fired when the mouse moves over the overlay. */
-    onOverlayMouseMove: PropTypes.func,
-    /** Callback function that is fired when the mouse button is released from the overlay. */
-    onOverlayMouseUp: PropTypes.func,
-    /** The size of the dialog. */
-    size: PropTypes.oneOf(['small', 'medium', 'large', 'fullscreen']),
-  };
-
-  static defaultProps = {
-    active: false,
-    backdrop: 'dark',
-    size: 'medium',
-  };
-
   constructor() {
     super(...arguments);
 
@@ -103,5 +74,34 @@ class Dialog extends PureComponent {
     return createPortal(dialog, this.dialogRoot);
   }
 }
+
+Dialog.propTypes = {
+  /** If true, the dialog will show on screen. */
+  active: PropTypes.bool,
+  /** Specify which backdrop the dialog should show. */
+  backdrop: PropTypes.string,
+  /** The content to display inside the dialog. */
+  children: PropTypes.node,
+  /** A class name for the wrapper to give custom styles. */
+  className: PropTypes.string,
+  /** Callback function that is fired when the escape key is pressed. */
+  onEscKeyDown: PropTypes.func,
+  /** Callback function that is fired when the mouse clicks on the overlay. */
+  onOverlayClick: PropTypes.func,
+  /** Callback function that is fired when the mouse button is pressed on the overlay. */
+  onOverlayMouseDown: PropTypes.func,
+  /** Callback function that is fired when the mouse moves over the overlay. */
+  onOverlayMouseMove: PropTypes.func,
+  /** Callback function that is fired when the mouse button is released from the overlay. */
+  onOverlayMouseUp: PropTypes.func,
+  /** The size of the dialog. */
+  size: PropTypes.oneOf(['small', 'medium', 'large', 'fullscreen']),
+};
+
+Dialog.defaultProps = {
+  active: false,
+  backdrop: 'dark',
+  size: 'medium',
+};
 
 export default Dialog;

--- a/components/icon/Icon.js
+++ b/components/icon/Icon.js
@@ -5,20 +5,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class Icon extends PureComponent {
-  static propTypes = {
-    children: PropTypes.any,
-    className: PropTypes.string,
-    color: PropTypes.oneOf(['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'teal']),
-    opacity: PropTypes.number,
-    tint: PropTypes.oneOf(['lightest', 'light', 'normal', 'dark', 'darkest']),
-  };
-
-  static defaultProps = {
-    color: 'teal',
-    tint: 'normal',
-    opacity: 0.84,
-  };
-
   render() {
     const { children, className, color, tint, opacity, ...others } = this.props;
 
@@ -41,5 +27,19 @@ class Icon extends PureComponent {
     );
   }
 }
+
+Icon.propTypes = {
+  children: PropTypes.any,
+  className: PropTypes.string,
+  color: PropTypes.oneOf(['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'teal']),
+  opacity: PropTypes.number,
+  tint: PropTypes.oneOf(['lightest', 'light', 'normal', 'dark', 'darkest']),
+};
+
+Icon.defaultProps = {
+  color: 'teal',
+  tint: 'normal',
+  opacity: 0.84,
+};
 
 export default Icon;

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -16,68 +16,6 @@ import { TextSmall } from '../typography';
 import theme from './theme.css';
 
 export default class Input extends PureComponent {
-  static propTypes = {
-    autoFocus: PropTypes.bool,
-    /** Boolean indicating whether the input text should render in bold. */
-    bold: PropTypes.bool,
-    /** Sets a class name to give custom styles. */
-    className: PropTypes.string,
-    connectedLeft: PropTypes.element,
-    connectedRight: PropTypes.element,
-    /** The number to render as a counter inside the input. */
-    counter: PropTypes.number,
-    /** Boolean indicating whether the input should render as disabled. */
-    disabled: PropTypes.bool,
-    /** The text string to use as help text below the input. */
-    helpText: PropTypes.string,
-    /** The icon displayed inside the input. */
-    icon: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
-    /** The position of the icon inside the input. */
-    iconPlacement: PropTypes.oneOf(['left', 'right']),
-    /** The text string to use as input identifier. */
-    id: PropTypes.string,
-    /** Boolean indicating whether the input should render as inverse. */
-    inverse: PropTypes.bool,
-    max: PropTypes.number,
-    min: PropTypes.number,
-    /** Object to provide meta information for redux forms. */
-    meta: InputMetaPropTypes,
-    /** Object to provide input information for redux forms. */
-    input: FieldInputPropTypes,
-    /** Callback function that is fired when component is blurred. */
-    onBlur: PropTypes.func,
-    /** Callback function that is fired when the component's value changes. */
-    onChange: PropTypes.func,
-    /** Callback function that is fired when component is focused. */
-    onFocus: PropTypes.func,
-    /** The text string to use as placeholder. */
-    placeholder: PropTypes.string,
-    precision: PropTypes.number,
-    /** Boolean indicating whether the input should render as read only. */
-    readOnly: PropTypes.bool,
-    /** Size of the input element. */
-    size: PropTypes.oneOf(['small', 'medium', 'large']),
-    /** Limit increment value for numeric inputs. */
-    step: PropTypes.number,
-    /** Type of the input element. It can be a valid HTML5 input type. */
-    type: PropTypes.string,
-    /** Current value of the input element. */
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  };
-
-  static defaultProps = {
-    iconPlacement: 'left',
-    inverse: false,
-    disabled: false,
-    placeholder: '',
-    precision: null,
-    min: Number.MIN_SAFE_INTEGER,
-    max: Number.MAX_SAFE_INTEGER,
-    readOnly: false,
-    size: 'medium',
-    step: 1,
-  };
-
   static getDerivedStateFromProps(nextProps, prevState) {
     const value = nextProps.input ? nextProps.input.value : nextProps.value;
     if (value !== undefined) {
@@ -327,3 +265,65 @@ export default class Input extends PureComponent {
     );
   }
 }
+
+Input.propTypes = {
+  autoFocus: PropTypes.bool,
+  /** Boolean indicating whether the input text should render in bold. */
+  bold: PropTypes.bool,
+  /** Sets a class name to give custom styles. */
+  className: PropTypes.string,
+  connectedLeft: PropTypes.element,
+  connectedRight: PropTypes.element,
+  /** The number to render as a counter inside the input. */
+  counter: PropTypes.number,
+  /** Boolean indicating whether the input should render as disabled. */
+  disabled: PropTypes.bool,
+  /** The text string to use as help text below the input. */
+  helpText: PropTypes.string,
+  /** The icon displayed inside the input. */
+  icon: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
+  /** The position of the icon inside the input. */
+  iconPlacement: PropTypes.oneOf(['left', 'right']),
+  /** The text string to use as input identifier. */
+  id: PropTypes.string,
+  /** Boolean indicating whether the input should render as inverse. */
+  inverse: PropTypes.bool,
+  max: PropTypes.number,
+  min: PropTypes.number,
+  /** Object to provide meta information for redux forms. */
+  meta: InputMetaPropTypes,
+  /** Object to provide input information for redux forms. */
+  input: FieldInputPropTypes,
+  /** Callback function that is fired when component is blurred. */
+  onBlur: PropTypes.func,
+  /** Callback function that is fired when the component's value changes. */
+  onChange: PropTypes.func,
+  /** Callback function that is fired when component is focused. */
+  onFocus: PropTypes.func,
+  /** The text string to use as placeholder. */
+  placeholder: PropTypes.string,
+  precision: PropTypes.number,
+  /** Boolean indicating whether the input should render as read only. */
+  readOnly: PropTypes.bool,
+  /** Size of the input element. */
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  /** Limit increment value for numeric inputs. */
+  step: PropTypes.number,
+  /** Type of the input element. It can be a valid HTML5 input type. */
+  type: PropTypes.string,
+  /** Current value of the input element. */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};
+
+Input.defaultProps = {
+  iconPlacement: 'left',
+  inverse: false,
+  disabled: false,
+  placeholder: '',
+  precision: null,
+  min: Number.MIN_SAFE_INTEGER,
+  max: Number.MAX_SAFE_INTEGER,
+  readOnly: false,
+  size: 'medium',
+  step: 1,
+};

--- a/components/island/Island.js
+++ b/components/island/Island.js
@@ -12,19 +12,6 @@ const SIZES = {
 };
 
 class Island extends PureComponent {
-  static propTypes = {
-    children: PropTypes.node,
-    className: PropTypes.string,
-    color: PropTypes.oneOf(['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'white']),
-    dark: PropTypes.bool,
-    size: PropTypes.oneOf(Object.keys(SIZES)),
-  };
-
-  static defaultProps = {
-    color: 'white',
-    size: 'medium',
-  };
-
   isDark(color) {
     if (color !== 'white' && color !== 'neutral') {
       return false;
@@ -51,5 +38,18 @@ class Island extends PureComponent {
     );
   }
 }
+
+Island.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  color: PropTypes.oneOf(['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'white']),
+  dark: PropTypes.bool,
+  size: PropTypes.oneOf(Object.keys(SIZES)),
+};
+
+Island.defaultProps = {
+  color: 'white',
+  size: 'medium',
+};
 
 export default Island;

--- a/components/label/Label.js
+++ b/components/label/Label.js
@@ -8,24 +8,6 @@ import isComponentOfType from '../utils/is-component-of-type';
 import cx from 'classnames';
 
 export default class Label extends PureComponent {
-  static propTypes = {
-    className: PropTypes.string,
-    children: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.array]),
-    connectedLeft: PropTypes.element,
-    connectedRight: PropTypes.element,
-    inverse: PropTypes.bool,
-    helpText: PropTypes.string,
-    required: PropTypes.bool,
-    size: PropTypes.oneOf(['small', 'medium', 'large']),
-  };
-
-  static defaultProps = {
-    inverse: false,
-    helpText: 'Optional',
-    required: false,
-    size: 'medium',
-  };
-
   render() {
     const {
       children,
@@ -89,3 +71,21 @@ export default class Label extends PureComponent {
     );
   }
 }
+
+Label.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.array]),
+  connectedLeft: PropTypes.element,
+  connectedRight: PropTypes.element,
+  inverse: PropTypes.bool,
+  helpText: PropTypes.string,
+  required: PropTypes.bool,
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+};
+
+Label.defaultProps = {
+  inverse: false,
+  helpText: 'Optional',
+  required: false,
+  size: 'medium',
+};

--- a/components/link/Link.js
+++ b/components/link/Link.js
@@ -4,18 +4,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class Link extends PureComponent {
-  static propTypes = {
-    children: PropTypes.node.isRequired,
-    className: PropTypes.string,
-    inherit: PropTypes.bool,
-    element: PropTypes.element,
-  };
-
-  static defaultProps = {
-    className: '',
-    inherit: true,
-  };
-
   render() {
     const { children, className, element, inherit, ...others } = this.props;
 
@@ -36,5 +24,17 @@ class Link extends PureComponent {
     );
   }
 }
+
+Link.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  inherit: PropTypes.bool,
+  element: PropTypes.element,
+};
+
+Link.defaultProps = {
+  className: '',
+  inherit: true,
+};
 
 export default Link;

--- a/components/loadingMolecule/LoadingMolecule.js
+++ b/components/loadingMolecule/LoadingMolecule.js
@@ -4,21 +4,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class LoadingMolecule extends PureComponent {
-  static defaultProps = {
-    className: '',
-    startColor: '#BABABA',
-    stopColor: '#DADADA',
-    type: 'normal',
-  };
-
-  static propTypes = {
-    className: PropTypes.string,
-    basePath: PropTypes.string.isRequired,
-    startColor: PropTypes.string.isRequired,
-    stopColor: PropTypes.string.isRequired,
-    type: PropTypes.string,
-  };
-
   constructor() {
     super(...arguments);
     this.randomGradientPostFix = Math.random()
@@ -80,5 +65,20 @@ class LoadingMolecule extends PureComponent {
     );
   }
 }
+
+LoadingMolecule.defaultProps = {
+  className: '',
+  startColor: '#BABABA',
+  stopColor: '#DADADA',
+  type: 'normal',
+};
+
+LoadingMolecule.propTypes = {
+  className: PropTypes.string,
+  basePath: PropTypes.string.isRequired,
+  startColor: PropTypes.string.isRequired,
+  stopColor: PropTypes.string.isRequired,
+  type: PropTypes.string,
+};
 
 export default LoadingMolecule;

--- a/components/loadingSpinner/LoadingSpinner.js
+++ b/components/loadingSpinner/LoadingSpinner.js
@@ -5,17 +5,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class LoadingSpinner extends PureComponent {
-  static propTypes = {
-    className: PropTypes.string,
-    color: PropTypes.oneOf(['white', 'teal']),
-    size: PropTypes.oneOf(['small', 'medium']),
-  };
-
-  static defaultProps = {
-    color: 'teal',
-    size: 'medium',
-  };
-
   render() {
     const { className, color, size, ...others } = this.props;
     const classNames = cx(theme['loading-spinner'], theme[`is-${color}`], theme[`is-${size}`], className);
@@ -23,5 +12,16 @@ class LoadingSpinner extends PureComponent {
     return <Box data-teamleader-ui="loading-spinner" className={classNames} {...others} />;
   }
 }
+
+LoadingSpinner.propTypes = {
+  className: PropTypes.string,
+  color: PropTypes.oneOf(['white', 'teal']),
+  size: PropTypes.oneOf(['small', 'medium']),
+};
+
+LoadingSpinner.defaultProps = {
+  color: 'teal',
+  size: 'medium',
+};
 
 export default LoadingSpinner;

--- a/components/menu/IconMenu.js
+++ b/components/menu/IconMenu.js
@@ -7,25 +7,6 @@ import Menu from './Menu.js';
 import theme from './theme.css';
 
 class IconMenu extends PureComponent {
-  static propTypes = {
-    children: PropTypes.node,
-    className: PropTypes.string,
-    icon: PropTypes.element,
-    onClick: PropTypes.func,
-    onHide: PropTypes.func,
-    onSelect: PropTypes.func,
-    onShow: PropTypes.func,
-    position: PropTypes.string,
-    selectable: PropTypes.bool,
-    selected: PropTypes.any,
-  };
-
-  static defaultProps = {
-    className: '',
-    position: 'auto',
-    selectable: false,
-  };
-
   state = {
     active: false,
   };
@@ -78,5 +59,24 @@ class IconMenu extends PureComponent {
     );
   }
 }
+
+IconMenu.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  icon: PropTypes.element,
+  onClick: PropTypes.func,
+  onHide: PropTypes.func,
+  onSelect: PropTypes.func,
+  onShow: PropTypes.func,
+  position: PropTypes.string,
+  selectable: PropTypes.bool,
+  selected: PropTypes.any,
+};
+
+IconMenu.defaultProps = {
+  className: '',
+  position: 'auto',
+  selectable: false,
+};
 
 export default IconMenu;

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -17,26 +17,6 @@ const POSITION = {
 };
 
 class Menu extends PureComponent {
-  static propTypes = {
-    active: PropTypes.bool,
-    children: PropTypes.node,
-    className: PropTypes.string,
-    onHide: PropTypes.func,
-    onSelect: PropTypes.func,
-    onShow: PropTypes.func,
-    outline: PropTypes.bool,
-    position: PropTypes.oneOf(Object.keys(POSITION).map(key => POSITION[key])),
-    selectable: PropTypes.bool,
-    selected: PropTypes.any,
-  };
-
-  static defaultProps = {
-    active: false,
-    outline: true,
-    position: POSITION.STATIC,
-    selectable: true,
-  };
-
   state = {
     active: this.props.active,
   };
@@ -237,5 +217,25 @@ class Menu extends PureComponent {
     );
   }
 }
+
+Menu.propTypes = {
+  active: PropTypes.bool,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  onHide: PropTypes.func,
+  onSelect: PropTypes.func,
+  onShow: PropTypes.func,
+  outline: PropTypes.bool,
+  position: PropTypes.oneOf(Object.keys(POSITION).map(key => POSITION[key])),
+  selectable: PropTypes.bool,
+  selected: PropTypes.any,
+};
+
+Menu.defaultProps = {
+  active: false,
+  outline: true,
+  position: POSITION.STATIC,
+  selectable: true,
+};
 
 export default Menu;

--- a/components/menu/MenuItem.js
+++ b/components/menu/MenuItem.js
@@ -4,23 +4,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class MenuItem extends PureComponent {
-  static propTypes = {
-    caption: PropTypes.string,
-    children: PropTypes.any,
-    className: PropTypes.string,
-    disabled: PropTypes.bool,
-    icon: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-    onClick: PropTypes.func,
-    selected: PropTypes.bool,
-    shortcut: PropTypes.string,
-  };
-
-  static defaultProps = {
-    className: '',
-    disabled: false,
-    selected: false,
-  };
-
   handleClick = event => {
     const { disabled, onClick } = this.props;
 
@@ -52,5 +35,22 @@ class MenuItem extends PureComponent {
     );
   }
 }
+
+MenuItem.propTypes = {
+  caption: PropTypes.string,
+  children: PropTypes.any,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  icon: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  onClick: PropTypes.func,
+  selected: PropTypes.bool,
+  shortcut: PropTypes.string,
+};
+
+MenuItem.defaultProps = {
+  className: '',
+  disabled: false,
+  selected: false,
+};
 
 export default MenuItem;

--- a/components/message/Message.js
+++ b/components/message/Message.js
@@ -6,19 +6,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class Message extends PureComponent {
-  static propTypes = {
-    className: PropTypes.string,
-    children: PropTypes.any.isRequired,
-    image: PropTypes.element,
-    imagePositioning: PropTypes.oneOf(['center', 'left', 'right']),
-    button: PropTypes.element,
-    link: PropTypes.element,
-  };
-
-  static defaultProps = {
-    imagePositioning: 'left',
-  };
-
   render() {
     const { className, children, image, imagePositioning, button, link, ...others } = this.props;
 
@@ -41,5 +28,18 @@ class Message extends PureComponent {
     );
   }
 }
+
+Message.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.any.isRequired,
+  image: PropTypes.element,
+  imagePositioning: PropTypes.oneOf(['center', 'left', 'right']),
+  button: PropTypes.element,
+  link: PropTypes.element,
+};
+
+Message.defaultProps = {
+  imagePositioning: 'left',
+};
 
 export default Message;

--- a/components/overlay/Overlay.js
+++ b/components/overlay/Overlay.js
@@ -5,21 +5,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class Overlay extends PureComponent {
-  static propTypes = {
-    active: PropTypes.bool,
-    backdrop: PropTypes.string,
-    children: PropTypes.node,
-    className: PropTypes.string,
-    lockScroll: PropTypes.bool,
-    onClick: PropTypes.func,
-    onEscKeyDown: PropTypes.func,
-  };
-
-  static defaultProps = {
-    backdrop: 'dark',
-    lockScroll: true,
-  };
-
   constructor() {
     super(...arguments);
 
@@ -117,5 +102,20 @@ class Overlay extends PureComponent {
     );
   }
 }
+
+Overlay.propTypes = {
+  active: PropTypes.bool,
+  backdrop: PropTypes.string,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  lockScroll: PropTypes.bool,
+  onClick: PropTypes.func,
+  onEscKeyDown: PropTypes.func,
+};
+
+Overlay.defaultProps = {
+  backdrop: 'dark',
+  lockScroll: true,
+};
 
 export default Overlay;

--- a/components/pagination/Pagination.js
+++ b/components/pagination/Pagination.js
@@ -7,23 +7,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class Pagination extends PureComponent {
-  static propTypes = {
-    inverse: PropTypes.bool,
-    nextPageText: PropTypes.string,
-    numPages: PropTypes.number.isRequired,
-    maxNumPagesVisible: PropTypes.number,
-    currentPage: PropTypes.number.isRequired,
-    prevPageText: PropTypes.string,
-    className: PropTypes.string,
-    children: PropTypes.func.isRequired,
-  };
-
-  static defaultProps = {
-    currentPage: 1,
-    inverse: false,
-    maxNumPagesVisible: 7,
-  };
-
   render() {
     const {
       className,
@@ -118,5 +101,22 @@ class Pagination extends PureComponent {
     );
   }
 }
+
+Pagination.propTypes = {
+  inverse: PropTypes.bool,
+  nextPageText: PropTypes.string,
+  numPages: PropTypes.number.isRequired,
+  maxNumPagesVisible: PropTypes.number,
+  currentPage: PropTypes.number.isRequired,
+  prevPageText: PropTypes.string,
+  className: PropTypes.string,
+  children: PropTypes.func.isRequired,
+};
+
+Pagination.defaultProps = {
+  currentPage: 1,
+  inverse: false,
+  maxNumPagesVisible: 7,
+};
 
 export default Pagination;

--- a/components/qTip/QTip.js
+++ b/components/qTip/QTip.js
@@ -8,14 +8,6 @@ import { IconArrowRightSmallOutline } from '@teamleader/ui-icons';
 import Box from '../box';
 
 class QTip extends PureComponent {
-  static propTypes = {
-    children: PropTypes.node.isRequired,
-    closed: PropTypes.bool,
-    highlighted: PropTypes.bool,
-    icon: PropTypes.element.isRequired,
-    onChange: PropTypes.func.isRequired,
-  };
-
   render() {
     const { children, closed, highlighted, icon, onChange, ...others } = this.props;
 
@@ -45,5 +37,13 @@ class QTip extends PureComponent {
     );
   }
 }
+
+QTip.propTypes = {
+  children: PropTypes.node.isRequired,
+  closed: PropTypes.bool,
+  highlighted: PropTypes.bool,
+  icon: PropTypes.element.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
 
 export default QTip;

--- a/components/radio/RadioButton.js
+++ b/components/radio/RadioButton.js
@@ -7,25 +7,6 @@ import Box from '../box';
 import { TextBody, TextDisplay, TextSmall } from '../typography';
 
 class RadioButton extends PureComponent {
-  static propTypes = {
-    checked: PropTypes.bool,
-    children: PropTypes.node,
-    disabled: PropTypes.bool,
-    name: PropTypes.string,
-    className: PropTypes.string,
-    label: PropTypes.string,
-    onChange: PropTypes.func,
-    onMouseEnter: PropTypes.func,
-    onMouseLeave: PropTypes.func,
-    size: PropTypes.oneOf(['small', 'medium', 'large']),
-  };
-
-  static defaultProps = {
-    checked: false,
-    disabled: false,
-    size: 'medium',
-  };
-
   constructor() {
     super(...arguments);
     this.handleToggle = ::this.handleToggle;
@@ -141,5 +122,24 @@ class RadioButton extends PureComponent {
     );
   }
 }
+
+RadioButton.propTypes = {
+  checked: PropTypes.bool,
+  children: PropTypes.node,
+  disabled: PropTypes.bool,
+  name: PropTypes.string,
+  className: PropTypes.string,
+  label: PropTypes.string,
+  onChange: PropTypes.func,
+  onMouseEnter: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+};
+
+RadioButton.defaultProps = {
+  checked: false,
+  disabled: false,
+  size: 'medium',
+};
 
 export default RadioButton;

--- a/components/radio/RadioGroup.js
+++ b/components/radio/RadioGroup.js
@@ -6,19 +6,6 @@ import isComponentOfType from '../utils/is-component-of-type';
 import omit from 'lodash.omit';
 
 class RadioGroup extends PureComponent {
-  static propTypes = {
-    children: PropTypes.node,
-    className: PropTypes.string,
-    disabled: PropTypes.bool,
-    onChange: PropTypes.func,
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-  };
-
-  static defaultProps = {
-    className: '',
-    disabled: false,
-  };
-
   constructor() {
     super(...arguments);
 
@@ -52,5 +39,18 @@ class RadioGroup extends PureComponent {
     );
   }
 }
+
+RadioGroup.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  onChange: PropTypes.func,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+};
+
+RadioGroup.defaultProps = {
+  className: '',
+  disabled: false,
+};
 
 export default RadioGroup;

--- a/components/section/Section.js
+++ b/components/section/Section.js
@@ -12,19 +12,6 @@ const SIZES = {
 };
 
 class Section extends PureComponent {
-  static propTypes = {
-    children: PropTypes.node,
-    className: PropTypes.string,
-    color: PropTypes.oneOf(['white', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua']),
-    dark: PropTypes.bool,
-    size: PropTypes.oneOf(Object.keys(SIZES)),
-  };
-
-  static defaultProps = {
-    color: 'white',
-    size: 'medium',
-  };
-
   isDark(color) {
     if (color !== 'white' && color !== 'neutral') {
       return false;
@@ -51,5 +38,18 @@ class Section extends PureComponent {
     );
   }
 }
+
+Section.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  color: PropTypes.oneOf(['white', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua']),
+  dark: PropTypes.bool,
+  size: PropTypes.oneOf(Object.keys(SIZES)),
+};
+
+Section.defaultProps = {
+  color: 'white',
+  size: 'medium',
+};
 
 export default Section;

--- a/components/statusBullet/StatusBullet.js
+++ b/components/statusBullet/StatusBullet.js
@@ -5,18 +5,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class StatusBullet extends PureComponent {
-  static propTypes = {
-    children: PropTypes.any,
-    className: PropTypes.string,
-    color: PropTypes.oneOf(['mint', 'violet', 'ruby', 'gold', 'aqua', 'neutral']),
-    size: PropTypes.oneOf(['small', 'medium']),
-  };
-
-  static defaultProps = {
-    color: 'neutral',
-    size: 'medium',
-  };
-
   render() {
     const { children, className, color, size, ...others } = this.props;
 
@@ -29,5 +17,17 @@ class StatusBullet extends PureComponent {
     );
   }
 }
+
+StatusBullet.propTypes = {
+  children: PropTypes.any,
+  className: PropTypes.string,
+  color: PropTypes.oneOf(['mint', 'violet', 'ruby', 'gold', 'aqua', 'neutral']),
+  size: PropTypes.oneOf(['small', 'medium']),
+};
+
+StatusBullet.defaultProps = {
+  color: 'neutral',
+  size: 'medium',
+};
 
 export default StatusBullet;

--- a/components/statusLabel/StatusLabel.js
+++ b/components/statusLabel/StatusLabel.js
@@ -15,18 +15,6 @@ const SIZES = {
 };
 
 class StatusLabel extends PureComponent {
-  static propTypes = {
-    children: PropTypes.any.isRequired,
-    className: PropTypes.string,
-    color: PropTypes.oneOf(['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua']),
-    size: PropTypes.oneOf(Object.keys(SIZES)),
-  };
-
-  static defaultProps = {
-    color: 'neutral',
-    size: 'medium',
-  };
-
   render() {
     const { children, className, color, size, ...others } = this.props;
 
@@ -39,5 +27,17 @@ class StatusLabel extends PureComponent {
     );
   }
 }
+
+StatusLabel.propTypes = {
+  children: PropTypes.any.isRequired,
+  className: PropTypes.string,
+  color: PropTypes.oneOf(['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua']),
+  size: PropTypes.oneOf(Object.keys(SIZES)),
+};
+
+StatusLabel.defaultProps = {
+  color: 'neutral',
+  size: 'medium',
+};
 
 export default StatusLabel;

--- a/components/tab/IconTab.js
+++ b/components/tab/IconTab.js
@@ -6,21 +6,6 @@ import theme from './theme.css';
 import omit from 'lodash.omit';
 
 class IconTab extends PureComponent {
-  static propTypes = {
-    active: PropTypes.bool,
-    children: PropTypes.node.isRequired,
-    className: PropTypes.string,
-    counter: PropTypes.node,
-    element: PropTypes.node,
-    icon: PropTypes.node.isRequired,
-    onClick: PropTypes.func,
-  };
-
-  static defaultProps = {
-    element: 'a',
-    active: false,
-  };
-
   constructor() {
     super(...arguments);
     this.handleClick = ::this.handleClick;
@@ -65,5 +50,20 @@ class IconTab extends PureComponent {
     );
   }
 }
+
+IconTab.propTypes = {
+  active: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  counter: PropTypes.node,
+  element: PropTypes.node,
+  icon: PropTypes.node.isRequired,
+  onClick: PropTypes.func,
+};
+
+IconTab.defaultProps = {
+  element: 'a',
+  active: false,
+};
 
 export default IconTab;

--- a/components/tab/TabGroup.js
+++ b/components/tab/TabGroup.js
@@ -5,17 +5,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class TabGroup extends PureComponent {
-  static propTypes = {
-    children: PropTypes.node.isRequired,
-    className: PropTypes.string,
-    inverted: PropTypes.bool,
-    size: PropTypes.oneOf(['small', 'medium']),
-  };
-
-  static defaultProps = {
-    inverted: false,
-  };
-
   render() {
     const { children, className, inverted, size, ...others } = this.props;
 
@@ -34,5 +23,16 @@ class TabGroup extends PureComponent {
     );
   }
 }
+
+TabGroup.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  inverted: PropTypes.bool,
+  size: PropTypes.oneOf(['small', 'medium']),
+};
+
+TabGroup.defaultProps = {
+  inverted: false,
+};
 
 export default TabGroup;

--- a/components/tab/TitleTab.js
+++ b/components/tab/TitleTab.js
@@ -8,22 +8,6 @@ import omit from 'lodash.omit';
 import { Heading4 } from '../typography';
 
 class TitleTab extends PureComponent {
-  static propTypes = {
-    active: PropTypes.bool,
-    children: PropTypes.node.isRequired,
-    className: PropTypes.string,
-    counter: PropTypes.node,
-    element: PropTypes.node,
-    onClick: PropTypes.func,
-    size: PropTypes.oneOf(['small', 'medium']),
-  };
-
-  static defaultProps = {
-    element: 'a',
-    active: false,
-    size: 'medium',
-  };
-
   constructor() {
     super(...arguments);
     this.handleClick = ::this.handleClick;
@@ -79,5 +63,21 @@ class TitleTab extends PureComponent {
     );
   }
 }
+
+TitleTab.propTypes = {
+  active: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  counter: PropTypes.node,
+  element: PropTypes.node,
+  onClick: PropTypes.func,
+  size: PropTypes.oneOf(['small', 'medium']),
+};
+
+TitleTab.defaultProps = {
+  element: 'a',
+  active: false,
+  size: 'medium',
+};
 
 export default TitleTab;

--- a/components/tag/Tag.js
+++ b/components/tag/Tag.js
@@ -7,20 +7,6 @@ import theme from './theme.css';
 import { IconCloseMediumOutline, IconCloseSmallOutline } from '@teamleader/ui-icons';
 
 class Tag extends PureComponent {
-  static propTypes = {
-    children: PropTypes.any.isRequired,
-    className: PropTypes.string,
-    inverse: PropTypes.bool,
-    onLabelClick: PropTypes.func,
-    onRemoveClick: PropTypes.func,
-    size: PropTypes.oneOf(['small', 'medium', 'large']),
-  };
-
-  static defaultProps = {
-    inverse: false,
-    size: 'medium',
-  };
-
   render() {
     const { children, className, inverse, onLabelClick, onRemoveClick, size, ...others } = this.props;
 
@@ -60,5 +46,19 @@ class Tag extends PureComponent {
     );
   }
 }
+
+Tag.propTypes = {
+  children: PropTypes.any.isRequired,
+  className: PropTypes.string,
+  inverse: PropTypes.bool,
+  onLabelClick: PropTypes.func,
+  onRemoveClick: PropTypes.func,
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+};
+
+Tag.defaultProps = {
+  inverse: false,
+  size: 'medium',
+};
 
 export default Tag;

--- a/components/toast/Toast.js
+++ b/components/toast/Toast.js
@@ -10,18 +10,6 @@ import { IconCloseMediumOutline } from '@teamleader/ui-icons';
 import theme from './theme.css';
 
 class Toast extends PureComponent {
-  static propTypes = {
-    action: PropTypes.string,
-    active: PropTypes.bool,
-    children: PropTypes.node,
-    className: PropTypes.string,
-    label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-    onClose: PropTypes.func,
-    onTimeout: PropTypes.func, // eslint-disable-line
-    processing: PropTypes.bool,
-    timeout: PropTypes.number,
-  };
-
   constructor() {
     super(...arguments);
 
@@ -112,5 +100,17 @@ class Toast extends PureComponent {
     return createPortal(toast, this.toastRoot);
   }
 }
+
+Toast.propTypes = {
+  action: PropTypes.string,
+  active: PropTypes.bool,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  onClose: PropTypes.func,
+  onTimeout: PropTypes.func, // eslint-disable-line
+  processing: PropTypes.bool,
+  timeout: PropTypes.number,
+};
 
 export default Toast;

--- a/components/toggle/Toggle.js
+++ b/components/toggle/Toggle.js
@@ -7,23 +7,6 @@ import Box from '../box';
 import { TextBody, TextDisplay, TextSmall } from '../typography';
 
 class Toggle extends PureComponent {
-  static propTypes = {
-    checked: PropTypes.bool,
-    children: PropTypes.node,
-    disabled: PropTypes.bool,
-    name: PropTypes.string,
-    className: PropTypes.string,
-    label: PropTypes.string,
-    onChange: PropTypes.func,
-    size: PropTypes.oneOf(['small', 'medium', 'large']),
-  };
-
-  static defaultProps = {
-    checked: false,
-    disabled: false,
-    size: 'medium',
-  };
-
   constructor() {
     super(...arguments);
     this.handleToggle = ::this.handleToggle;
@@ -135,5 +118,22 @@ class Toggle extends PureComponent {
     );
   }
 }
+
+Toggle.propTypes = {
+  checked: PropTypes.bool,
+  children: PropTypes.node,
+  disabled: PropTypes.bool,
+  name: PropTypes.string,
+  className: PropTypes.string,
+  label: PropTypes.string,
+  onChange: PropTypes.func,
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+};
+
+Toggle.defaultProps = {
+  checked: false,
+  disabled: false,
+  size: 'medium',
+};
 
 export default Toggle;

--- a/components/tooltip/Tooltip.js
+++ b/components/tooltip/Tooltip.js
@@ -30,32 +30,6 @@ const SIZES = {
 
 const Tooltip = ComposedComponent => {
   class TooltippedComponent extends Component {
-    static propTypes = {
-      children: PropTypes.node,
-      className: PropTypes.string,
-      onClick: PropTypes.func,
-      onMouseEnter: PropTypes.func,
-      onMouseLeave: PropTypes.func,
-      tooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-      tooltipColor: PropTypes.oneOf(['white', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'inverse']),
-      tooltipHideOnClick: PropTypes.bool,
-      tooltipIcon: PropTypes.element,
-      tooltipPosition: PropTypes.oneOf(Object.keys(POSITIONS).map(key => POSITIONS[key])),
-      tooltipShowOnClick: PropTypes.bool,
-      tooltipSize: PropTypes.oneOf(Object.keys(SIZES)),
-      documentObject: PropTypes.object.isRequired,
-    };
-
-    static defaultProps = {
-      className: '',
-      tooltipColor: 'white',
-      tooltipHideOnClick: true,
-      tooltipIcon: null,
-      tooltipPosition: POSITIONS.TOP,
-      tooltipShowOnClick: false,
-      tooltipSize: 'medium',
-    };
-
     constructor(props) {
       super(...arguments);
 
@@ -215,6 +189,32 @@ const Tooltip = ComposedComponent => {
       );
     }
   }
+
+  TooltippedComponent.propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string,
+    onClick: PropTypes.func,
+    onMouseEnter: PropTypes.func,
+    onMouseLeave: PropTypes.func,
+    tooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    tooltipColor: PropTypes.oneOf(['white', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'inverse']),
+    tooltipHideOnClick: PropTypes.bool,
+    tooltipIcon: PropTypes.element,
+    tooltipPosition: PropTypes.oneOf(Object.keys(POSITIONS).map(key => POSITIONS[key])),
+    tooltipShowOnClick: PropTypes.bool,
+    tooltipSize: PropTypes.oneOf(Object.keys(SIZES)),
+    documentObject: PropTypes.object.isRequired,
+  };
+
+  TooltippedComponent.defaultProps = {
+    className: '',
+    tooltipColor: 'white',
+    tooltipHideOnClick: true,
+    tooltipIcon: null,
+    tooltipPosition: POSITIONS.TOP,
+    tooltipShowOnClick: false,
+    tooltipSize: 'medium',
+  };
 
   return DocumentObjectProvider(props => {
     return (

--- a/components/typography/Monospaced.js
+++ b/components/typography/Monospaced.js
@@ -4,16 +4,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class Monospaced extends PureComponent {
-  static propTypes = {
-    children: PropTypes.node,
-    className: PropTypes.string,
-    element: PropTypes.node,
-  };
-
-  static defaultProps = {
-    element: 'span',
-  };
-
   render() {
     const { children, className, element } = this.props;
 
@@ -28,5 +18,15 @@ class Monospaced extends PureComponent {
     );
   }
 }
+
+Monospaced.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  element: PropTypes.node,
+};
+
+Monospaced.defaultProps = {
+  element: 'span',
+};
 
 export default Monospaced;

--- a/components/typography/Text.js
+++ b/components/typography/Text.js
@@ -7,19 +7,6 @@ import theme from './theme.css';
 
 const factory = (baseType, type, defaultElement) => {
   class Text extends PureComponent {
-    static propTypes = {
-      children: PropTypes.node,
-      className: PropTypes.string,
-      color: PropTypes.oneOf(['white', 'neutral', 'mint', 'teal', 'violet', 'ruby', 'gold', 'aqua']),
-      element: PropTypes.node,
-      soft: PropTypes.bool,
-    };
-
-    static defaultProps = {
-      element: null,
-      soft: false,
-    };
-
     isSoft(color) {
       if (color !== 'white' && color !== 'teal') {
         return false;
@@ -54,6 +41,19 @@ const factory = (baseType, type, defaultElement) => {
       );
     }
   }
+
+  Text.propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string,
+    color: PropTypes.oneOf(['white', 'neutral', 'mint', 'teal', 'violet', 'ruby', 'gold', 'aqua']),
+    element: PropTypes.node,
+    soft: PropTypes.bool,
+  };
+
+  Text.defaultProps = {
+    element: null,
+    soft: false,
+  };
 
   return Text;
 };

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "babel-core": "^6.17.0",
     "babel-eslint": "^8.0.2",
     "babel-loader": "^7.1.2",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.13",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-latest": "^6.24.1",


### PR DESCRIPTION
### Description
* Move static propTypes & defaultProps outside of the component class.
* Install babel-plugin-transform-react-remove-prop-types to remove PropTypes from production builds (package size decreased with **20kb**)

### Breaking changes
None.
