### PR TITLE
Send full event object down to the provided onchange handler 

### DIFF
--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -59,20 +59,20 @@ export default class Input extends PureComponent {
   };
 
   handleChange = event => {
-    this.updateValue(event.target.value);
+    this.updateValue(event);
   };
 
-  handleIncreaseValue = () => {
-    this.updateStep(1);
+  handleIncreaseValue = event => {
+    this.updateStep(event, 1);
   };
 
-  handleDecreaseValue = () => {
-    this.updateStep(-1);
+  handleDecreaseValue = event => {
+    this.updateStep(event, -1);
   };
 
-  updateValue(rawValue, triggerOnChange = true) {
+  updateValue(event, rawValue, triggerOnChange = true) {
     const { input, onChange } = this.props;
-    const value = Input.parseValue(rawValue, this.props);
+    const value = Input.parseValue(rawValue || event.target.value, this.props);
 
     this.setState({
       value,
@@ -80,9 +80,9 @@ export default class Input extends PureComponent {
 
     if (triggerOnChange) {
       if (input && input.onChange) {
-        input.onChange(value);
+        input.onChange(event, value);
       } else if (onChange) {
-        onChange(value);
+        onChange(event, value);
       }
     }
   }
@@ -104,10 +104,10 @@ export default class Input extends PureComponent {
     return String(formattedNumber);
   }
 
-  updateStep(n) {
+  updateStep(event, n) {
     const { step } = this.props;
     const { value = 0 } = this.state;
-    this.updateValue(value + step * n);
+    this.updateValue(event, (value + step * n));
   }
 
   renderInput() {


### PR DESCRIPTION
### Description
Fix for issue #229 

The first parameter in the onChange handler you provide via the props no longer holds only the value, but the entire event object. I still pas down the value as a second argument, as with the increment buttons this value might not always be +1 or -1 as it depends on the defined steps.


### Breaking changes
The first parameter in the onChange handler is not just the value but the entire event object.