### PR TITLE
Adjust Dialog z-index to make sure it appears over the new navigation

### DIFF
--- a/components/dialog/theme.css
+++ b/components/dialog/theme.css
@@ -16,7 +16,7 @@
   position: fixed;
   top: 0;
   width: 100vw;
-  z-index: var(--z-index-higher);
+  z-index: 6000;
 }
 
 .dialog {


### PR DESCRIPTION
### Description
Fix for issue #230

Adjusted the z-index of the Dialog to what the current z-index of the dialogs in production are

### Breaking changes
none
