### PR TITLE
Render Toasts in a container and update animation

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -28,7 +28,7 @@ import StatusBullet from './statusBullet';
 import StatusLabel from './statusLabel';
 import { IconTab, TitleTab, TabGroup } from './tab';
 import Tag from './tag';
-import { Toast } from './toast';
+import { Toast, ToastContainer } from './toast';
 import Toggle from './toggle';
 import Label from './label';
 import Tooltip from './tooltip';
@@ -90,6 +90,7 @@ export {
   Tag,
   TitleTab,
   Toast,
+  ToastContainer,
   Toggle,
   Tooltip,
   QTip,

--- a/components/toast/Toast.js
+++ b/components/toast/Toast.js
@@ -5,16 +5,11 @@ import cx from 'classnames';
 import { IconButton, LinkButton } from '../button';
 import { TextBody } from '../typography';
 import LoadingSpinner from '../loadingSpinner';
-import { createPortal } from 'react-dom';
 import { IconCloseMediumOutline } from '@teamleader/ui-icons';
 import theme from './theme.css';
 
 class Toast extends PureComponent {
-  toastRoot = document.createElement('div');
-
   componentDidMount() {
-    document.body.appendChild(this.toastRoot);
-
     if (this.props.active && this.props.timeout) {
       this.scheduleTimeout(this.props);
     }
@@ -28,7 +23,6 @@ class Toast extends PureComponent {
 
   componentWillUnmount() {
     clearTimeout(this.currentTimeout);
-    document.body.removeChild(this.toastRoot);
   }
 
   scheduleTimeout = props => {
@@ -74,7 +68,7 @@ class Toast extends PureComponent {
   render() {
     const { active, children, className, label, processing } = this.props;
 
-    const toast = (
+    return (
       <Transition in={active} timeout={{ enter: 0, exit: 1000 }}>
         {state => {
           if (state === 'exited') {
@@ -104,8 +98,6 @@ class Toast extends PureComponent {
         }}
       </Transition>
     );
-
-    return createPortal(toast, this.toastRoot);
   }
 }
 

--- a/components/toast/Toast.js
+++ b/components/toast/Toast.js
@@ -74,7 +74,7 @@ class Toast extends PureComponent {
     const classNames = cx(theme['toast'], className);
 
     return (
-      <div className={theme['toast-wrapper']}>
+      <div>
         <div data-teamleader-ui="toast" className={classNames}>
           {processing && <LoadingSpinner className={theme['spinner']} color="white" />}
           <TextBody className={theme['label']} color="white">

--- a/components/toast/Toast.js
+++ b/components/toast/Toast.js
@@ -74,8 +74,8 @@ class Toast extends PureComponent {
     const classNames = cx(theme['toast'], className);
 
     return (
-      <div>
-        <div data-teamleader-ui="toast" className={classNames}>
+      <div data-teamleader-ui="toast">
+        <div className={classNames}>
           {processing && <LoadingSpinner className={theme['spinner']} color="white" />}
           <TextBody className={theme['label']} color="white">
             {label}

--- a/components/toast/Toast.js
+++ b/components/toast/Toast.js
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Transition from 'react-transition-group/Transition';
 import cx from 'classnames';
 import { IconButton, LinkButton } from '../button';
 import { TextBody } from '../typography';
@@ -10,13 +9,13 @@ import theme from './theme.css';
 
 class Toast extends PureComponent {
   componentDidMount() {
-    if (this.props.active && this.props.timeout) {
+    if (this.props.timeout) {
       this.scheduleTimeout(this.props);
     }
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.active && nextProps.timeout) {
+    if (nextProps.timeout) {
       this.scheduleTimeout(nextProps);
     }
   }
@@ -66,37 +65,21 @@ class Toast extends PureComponent {
   };
 
   render() {
-    const { active, children, className, label, processing } = this.props;
+    const { children, className, label, processing } = this.props;
+
+    const classNames = cx(theme['toast'], className);
 
     return (
-      <Transition in={active} timeout={{ enter: 0, exit: 1000 }}>
-        {state => {
-          if (state === 'exited') {
-            return null;
-          }
-
-          const classNames = cx(
-            theme['toast'],
-            {
-              [theme['is-entering']]: state === 'entering',
-              [theme['is-entered']]: state === 'entered',
-              [theme['is-exiting']]: state === 'exiting',
-            },
-            className,
-          );
-
-          return (
-            <div data-teamleader-ui="toast" className={classNames}>
-              {processing && <LoadingSpinner className={theme['spinner']} color="white" />}
-              <TextBody className={theme['label']} color="white">
-                {label}
-                {children}
-              </TextBody>
-              {this.renderCustomAction() || this.renderCustomLink() || this.renderCloseButton()}
-            </div>
-          );
-        }}
-      </Transition>
+      <div className={theme['toast-wrapper']}>
+        <div data-teamleader-ui="toast" className={classNames}>
+          {processing && <LoadingSpinner className={theme['spinner']} color="white" />}
+          <TextBody className={theme['label']} color="white">
+            {label}
+            {children}
+          </TextBody>
+          {this.renderCustomAction() || this.renderCustomLink() || this.renderCloseButton()}
+        </div>
+      </div>
     );
   }
 }
@@ -106,8 +89,6 @@ Toast.propTypes = {
   action: PropTypes.func,
   /** The label for the custom action you want to show */
   actionLabel: PropTypes.string,
-  /** Show or hide the Toast  */
-  active: PropTypes.bool,
   /** The content to display inside the Toast */
   children: PropTypes.node,
   /** A class name for the Toast to give custom styles. */

--- a/components/toast/ToastContainer.js
+++ b/components/toast/ToastContainer.js
@@ -2,13 +2,39 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import theme from './theme.css';
 import cx from 'classnames';
+import { TransitionGroup, CSSTransition } from 'react-transition-group';
 
 class ToastContainer extends PureComponent {
   render() {
     const { children, className } = this.props;
     const classNames = cx(theme['container'], className);
 
-    return <ul className={classNames}>{children}</ul>;
+    return (
+      <ul className={classNames}>
+        <TransitionGroup component="li">
+          {React.Children.map(children, (child, id) => {
+            return (
+              <CSSTransition
+                timeout={1000}
+                key={id}
+                classNames={{
+                  appear: cx(theme['appear']),
+                  appearActive: cx(theme['appear-active']),
+                  enter: cx(theme['enter']),
+                  enterActive: cx(theme['enter-active']),
+                  enterDone: cx(theme['enter-done']),
+                  exit: cx(theme['exit']),
+                  exitActive: cx(theme['exit-active']),
+                  exitDone: cx(theme['exit-done']),
+                }}
+              >
+                {child}
+              </CSSTransition>
+            );
+          })}
+        </TransitionGroup>
+      </ul>
+    );
   }
 }
 

--- a/components/toast/ToastContainer.js
+++ b/components/toast/ToastContainer.js
@@ -1,0 +1,22 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import theme from './theme.css';
+import cx from 'classnames';
+
+class ToastContainer extends PureComponent {
+  render() {
+    const { children, className } = this.props;
+    const classNames = cx(theme['container'], className);
+
+    return <ul className={classNames}>{children}</ul>;
+  }
+}
+
+ToastContainer.propTypes = {
+  /** The content to display inside the ToastContainer */
+  children: PropTypes.any,
+  /** A custom class name for custom styling */
+  className: PropTypes.string,
+};
+
+export default ToastContainer;

--- a/components/toast/ToastContainer.js
+++ b/components/toast/ToastContainer.js
@@ -10,7 +10,7 @@ class ToastContainer extends PureComponent {
     const classNames = cx(theme['container'], className);
 
     return (
-      <ul className={classNames}>
+      <ul className={classNames} data-teamleader-ui="toast-container">
         <TransitionGroup component="li">
           {React.Children.map(children, (child, id) => {
             return (

--- a/components/toast/index.js
+++ b/components/toast/index.js
@@ -1,4 +1,5 @@
 import Toast from './Toast';
+import ToastContainer from './ToastContainer';
 
 export default Toast;
-export { Toast };
+export { Toast, ToastContainer };

--- a/components/toast/theme.css
+++ b/components/toast/theme.css
@@ -21,6 +21,9 @@
   right: var(--toast-offset);
   z-index: var(--z-index-high);
 }
+.toast-wrapper {
+  /*overflow: hidden;*/
+}
 .toast {
   composes: box-shadow-400;
   composes: reset-box-sizing;
@@ -31,7 +34,7 @@
   min-width: var(--toast-min-width);
   max-width: var(--toast-max-width);
   min-height: var(--toast-min-height);
-  margin-bottom: var(--toast-offset);
+  margin-bottom: var(--toast-spacing);
   padding: var(--toast-spacing);
   transition: all var(--animation-duration) var(--animation-curve-default) var(--animation-duration);
   display: flex;
@@ -40,6 +43,10 @@
 
   .toast-link {
     color: var(--color-teal-light);
+  }
+
+  &:before {
+    position: relative;
   }
 }
 
@@ -58,13 +65,34 @@
   margin-right: var(--toast-spacing);
 }
 
-.is-exiting,
-.is-entering {
+.enter {
   opacity: 0;
   transform: translateY(100%);
+  max-height: 0;
 }
-
-.is-entered {
+.enter-active {
   opacity: 1;
   transform: translateY(0%);
+  max-height: 180px;
+  transition: opacity 0.3s ease-out, transform 0.3s ease-out, max-height 0.3s ease-out;
+}
+.enter-done {
+  opacity: 1;
+}
+.exit {
+  opacity: 1;
+  max-height: 180px;
+  transform: translateX(0);
+}
+.exit-active {
+  opacity: 0;
+  overflow: hidden;
+  transform: translateX(100%);
+  max-height: 0px;
+  margin-top: 0px;
+  transition: opacity 0.5s ease, transform 0.5s ease, max-height 0.5s ease 0.19s;
+}
+
+.exit-done {
+  transition: all 2s ease;
 }

--- a/components/toast/theme.css
+++ b/components/toast/theme.css
@@ -12,23 +12,28 @@
   --toast-spacing: calc(1.8 * var(--unit));
   --toast-offset: calc(3 * var(--unit));
 }
-
+.container {
+  bottom: 0;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  position: fixed;
+  right: var(--toast-offset);
+  z-index: var(--z-index-high);
+}
 .toast {
   composes: box-shadow-400;
   composes: reset-box-sizing;
   align-items: center;
   border-radius: var(--toast-border-radius);
   background-color: var(--toast-background-color);
-  bottom: var(--toast-offset);
   display: flex;
   min-width: var(--toast-min-width);
   max-width: var(--toast-max-width);
   min-height: var(--toast-min-height);
+  margin-bottom: var(--toast-offset);
   padding: var(--toast-spacing);
-  position: fixed;
-  right: var(--toast-offset);
   transition: all var(--animation-duration) var(--animation-curve-default) var(--animation-duration);
-  z-index: var(--z-index-high);
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/components/toast/theme.css
+++ b/components/toast/theme.css
@@ -11,6 +11,7 @@
   --toast-min-height: calc(6 * var(--unit));
   --toast-spacing: calc(1.8 * var(--unit));
   --toast-offset: calc(3 * var(--unit));
+  --toast-animation-curve: var(--animation-curve-fast-out-linear-in);
 }
 .container {
   bottom: 0;
@@ -74,7 +75,8 @@
   opacity: 1;
   transform: translateY(0%);
   max-height: 180px;
-  transition: opacity 0.3s ease-out, transform 0.3s ease-out, max-height 0.3s ease-out;
+  transition: opacity 0.3s var(--toast-animation-curve), transform 0.3s var(--toast-animation-curve),
+    max-height 0.3s var(--toast-animation-curve);
 }
 .enter-done {
   opacity: 1;
@@ -90,7 +92,8 @@
   transform: translateX(100%);
   max-height: 0px;
   margin-top: 0px;
-  transition: opacity 0.5s ease, transform 0.5s ease, max-height 0.5s ease 0.19s;
+  transition: opacity 0.5s var(--toast-animation-curve), transform 0.5s var(--toast-animation-curve),
+    max-height 0.5s var(--toast-animation-curve) 0.32s;
 }
 
 .exit-done {

--- a/components/toast/theme.css
+++ b/components/toast/theme.css
@@ -93,8 +93,8 @@
   transform: translateX(100%);
   max-height: 0px;
   margin-top: 0px;
-  transition: opacity 0.3s var(--toast-animation-curve), transform 0.3s var(--toast-animation-curve),
-    max-height 0.3s var(--toast-animation-curve) 0.2s;
+  transition: opacity 0.5s var(--toast-animation-curve), transform 0.5s var(--toast-animation-curve),
+    max-height 0.5s var(--toast-animation-curve) 0.3s;
 }
 
 .exit-done {

--- a/components/toast/theme.css
+++ b/components/toast/theme.css
@@ -22,9 +22,7 @@
   right: var(--toast-offset);
   z-index: var(--z-index-high);
 }
-.toast-wrapper {
-  /*overflow: hidden;*/
-}
+
 .toast {
   composes: box-shadow-400;
   composes: reset-box-sizing;
@@ -40,7 +38,6 @@
   transition: all var(--animation-duration) var(--animation-curve-default) var(--animation-duration);
   display: flex;
   align-items: center;
-  justify-content: space-between;
 
   .toast-link {
     color: var(--color-teal-light);
@@ -49,6 +46,10 @@
   &:before {
     position: relative;
   }
+}
+
+.label {
+  flex-grow: 1;
 }
 
 .action-button {

--- a/components/toast/theme.css
+++ b/components/toast/theme.css
@@ -78,7 +78,7 @@
 }
 .enter-active {
   opacity: 1;
-  transform: translateY(0%);
+  transform: translate3d(0, 0, 0);
   max-height: 180px;
   transition: opacity 0.3s var(--toast-animation-curve), transform 0.3s var(--toast-animation-curve),
     max-height 0.3s var(--toast-animation-curve);
@@ -94,7 +94,7 @@
 .exit-active {
   opacity: 0;
   overflow: hidden;
-  transform: translateX(100%);
+  transform: translate3d(100%, 0, 0);
   max-height: 0px;
   margin-top: 0px;
   transition: opacity 0.5s var(--toast-animation-curve), transform 0.5s var(--toast-animation-curve),

--- a/components/toast/theme.css
+++ b/components/toast/theme.css
@@ -92,8 +92,8 @@
   transform: translateX(100%);
   max-height: 0px;
   margin-top: 0px;
-  transition: opacity 0.5s var(--toast-animation-curve), transform 0.5s var(--toast-animation-curve),
-    max-height 0.5s var(--toast-animation-curve) 0.32s;
+  transition: opacity 0.3s var(--toast-animation-curve), transform 0.3s var(--toast-animation-curve),
+    max-height 0.3s var(--toast-animation-curve) 0.2s;
 }
 
 .exit-done {

--- a/stories/toast.js
+++ b/stories/toast.js
@@ -4,25 +4,73 @@ import { storiesOf } from '@storybook/react';
 import { Store, State } from '@sambego/storybook-state';
 import { checkA11y } from 'storybook-addon-a11y';
 import { withInfo } from '@storybook/addon-info';
+import { withKnobs, number } from '@storybook/addon-knobs/react';
 import { Button, Toast, Link, ToastContainer } from '../components';
 
 const store = new Store({
-  active: false,
+  children: [],
 });
 
-const handleButtonClick = () => {
-  store.set({ active: true });
-};
-
-const handleToastCloseButtonClick = () => {
-  store.set({ active: false });
-};
-
-const handleToastTimeout = () => {
-  store.set({ active: false });
-};
-
 const handleCustomAction = () => true;
+
+const handleRemoveToast = () => {
+  const currentChildren = store.get('children');
+  store.set({ children: currentChildren.filter((val, idx) => idx !== 0) });
+};
+
+const handleAddToastWithAction = () => {
+  const currentChildren = store.get('children');
+  const toast = (
+    <Toast
+      label="Toast label"
+      onClose={handleRemoveToast}
+      timeout={3000}
+      onTimeout={handleRemoveToast}
+      actionLabel="confirm"
+      action={handleCustomAction}
+    />
+  );
+  store.set({ children: [...currentChildren, toast] });
+};
+
+const handleAddToastWithLink = () => {
+  const currentChildren = store.get('children');
+  const toast = (
+    <Toast
+      label="Toast label"
+      onClose={handleRemoveToast}
+      timeout={3000}
+      onTimeout={handleRemoveToast}
+      link={<Link href="https://www.teamleader.be">link</Link>}
+    />
+  );
+  store.set({ children: [...currentChildren, toast] });
+};
+
+const handleAddToastWithMultilineLabel = () => {
+  const currentChildren = store.get('children');
+  const toast = (
+    <Toast
+      label="Connection timed out. Showing limited amount of messages."
+      onClose={handleRemoveToast}
+      timeout={3000}
+      onTimeout={handleRemoveToast}
+      actionLabel="Try again"
+      action={handleCustomAction}
+    />
+  );
+  store.set({ children: [...currentChildren, toast] });
+};
+
+const handleAddToastWithSpinner = () => {
+  const currentChildren = store.get('children');
+  const toast = <Toast label="Working..." timeout={3000} onTimeout={handleRemoveToast} processing />;
+  store.set({ children: [...currentChildren, toast] });
+};
+
+const getArrayOfNumbers = length => {
+  return Array.apply(null, { length: length }).map(Number.call, Number);
+};
 
 storiesOf('Toast', module)
   .addDecorator((story, context) =>
@@ -32,88 +80,49 @@ storiesOf('Toast', module)
     })(story)(context),
   )
   .addDecorator(checkA11y)
-  .add('with close button', () => (
-    <div>
-      <Button label="Make a toast" onClick={handleButtonClick} />
-      <ToastContainer>
-        <State store={store}>
-          <Toast
-            active={false}
-            label="Toast label"
-            timeout={300000}
-            onClose={handleToastCloseButtonClick}
-            onTimeout={handleToastTimeout}
-          />
-        </State>
-      </ToastContainer>
-    </div>
-  ))
+  .addDecorator(withKnobs)
+  .add('with close button', () => {
+    const numberOfToasts = number('Toasts', 0);
+
+    return (
+      <div>
+        <ToastContainer>
+          {getArrayOfNumbers(numberOfToasts).map((val, idx) => {
+            return <Toast key={idx} label="Toast label" onClose={handleRemoveToast} />;
+          })}
+        </ToastContainer>
+      </div>
+    );
+  })
   .add('with custom action', () => (
     <div>
-      <Button label="Make a toast" onClick={handleButtonClick} />
-      <ToastContainer>
-        <State store={store}>
-          <Toast
-            actionLabel="Confirm"
-            action={handleCustomAction}
-            active={false}
-            label="Toast label"
-            timeout={3000}
-            onClose={handleToastCloseButtonClick}
-            onTimeout={handleToastTimeout}
-          />
-        </State>
-      </ToastContainer>
+      <Button label="Make a toast" onClick={handleAddToastWithAction} />
+      <State store={store}>
+        <ToastContainer children={[]} />
+      </State>
     </div>
   ))
   .add('with custom link', () => (
     <div>
-      <Button label="Make a toast" onClick={handleButtonClick} />
-      <ToastContainer />
+      <Button label="Make a toast" onClick={handleAddToastWithLink} />
       <State store={store}>
-        <Toast
-          link={<Link href="https://www.teamleader.be">link</Link>}
-          active={false}
-          label="Toast label"
-          timeout={3000}
-          onClose={handleToastCloseButtonClick}
-          onTimeout={handleToastTimeout}
-        />
+        <ToastContainer children={[]} />
       </State>
     </div>
   ))
   .add('with multiline label', () => (
     <div>
-      <Button label="Make a toast" onClick={handleButtonClick} />
-      <ToastContainer>
-        <State store={store}>
-          <Toast
-            action={handleCustomAction}
-            actionLabel="Try again"
-            active={false}
-            label="Connection timed out. Showing limited amount of messages."
-            timeout={3000}
-            onClose={handleToastCloseButtonClick}
-            onTimeout={handleToastTimeout}
-          />
-        </State>
-      </ToastContainer>
+      <Button label="Make a toast" onClick={handleAddToastWithMultilineLabel} />
+      <State store={store}>
+        <ToastContainer children={[]} />
+      </State>
     </div>
   ))
   .add('with loading spinner', () => (
     <div>
-      <Button label="Make a toast" onClick={handleButtonClick} />
-      <ToastContainer>
-        <State store={store}>
-          <Toast
-            active={false}
-            label="Working..."
-            timeout={3000}
-            onClose={handleToastCloseButtonClick}
-            onTimeout={handleToastTimeout}
-            processing
-          />
-        </State>
-      </ToastContainer>
+      <Button label="Make a toast" onClick={handleAddToastWithSpinner} />
+      <State store={store}>
+        <ToastContainer children={[]} />
+      </State>
     </div>
   ));

--- a/stories/toast.js
+++ b/stories/toast.js
@@ -18,6 +18,12 @@ const handleRemoveToast = () => {
   store.set({ children: currentChildren.filter((val, idx) => idx !== 0) });
 };
 
+const handleAddToastWithClose = () => {
+  const currentChildren = store.get('children');
+  const toast = <Toast label="Toast label" onClose={handleRemoveToast} timeout={3000} onTimeout={handleRemoveToast} />;
+  store.set({ children: [...currentChildren, toast] });
+};
+
 const handleAddToastWithAction = () => {
   const currentChildren = store.get('children');
   const toast = (
@@ -68,10 +74,6 @@ const handleAddToastWithSpinner = () => {
   store.set({ children: [...currentChildren, toast] });
 };
 
-const getArrayOfNumbers = length => {
-  return Array.apply(null, { length: length }).map(Number.call, Number);
-};
-
 storiesOf('Toast', module)
   .addDecorator((story, context) =>
     withInfo({
@@ -81,19 +83,14 @@ storiesOf('Toast', module)
   )
   .addDecorator(checkA11y)
   .addDecorator(withKnobs)
-  .add('with close button', () => {
-    const numberOfToasts = number('Toasts', 0);
-
-    return (
-      <div>
-        <ToastContainer>
-          {getArrayOfNumbers(numberOfToasts).map((val, idx) => {
-            return <Toast key={idx} label="Toast label" onClose={handleRemoveToast} />;
-          })}
-        </ToastContainer>
-      </div>
-    );
-  })
+  .add('with close button', () => (
+    <div>
+      <Button label="Make a toast" onClick={handleAddToastWithClose} />
+      <State store={store}>
+        <ToastContainer children={[]} />
+      </State>
+    </div>
+  ))
   .add('with custom action', () => (
     <div>
       <Button label="Make a toast" onClick={handleAddToastWithAction} />

--- a/stories/toast.js
+++ b/stories/toast.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/react';
 import { Store, State } from '@sambego/storybook-state';
 import { checkA11y } from 'storybook-addon-a11y';
 import { withInfo } from '@storybook/addon-info';
-import { Button, Toast, Link } from '../components';
+import { Button, Toast, Link, ToastContainer } from '../components';
 
 const store = new Store({
   active: false,
@@ -35,36 +35,41 @@ storiesOf('Toast', module)
   .add('with close button', () => (
     <div>
       <Button label="Make a toast" onClick={handleButtonClick} />
-      <State store={store}>
-        <Toast
-          active={false}
-          label="Toast label"
-          timeout={3000}
-          onClose={handleToastCloseButtonClick}
-          onTimeout={handleToastTimeout}
-        />
-      </State>
+      <ToastContainer>
+        <State store={store}>
+          <Toast
+            active={false}
+            label="Toast label"
+            timeout={3000}
+            onClose={handleToastCloseButtonClick}
+            onTimeout={handleToastTimeout}
+          />
+        </State>
+      </ToastContainer>
     </div>
   ))
   .add('with custom action', () => (
     <div>
       <Button label="Make a toast" onClick={handleButtonClick} />
-      <State store={store}>
-        <Toast
-          actionLabel="Confirm"
-          action={handleCustomAction}
-          active={false}
-          label="Toast label"
-          timeout={3000}
-          onClose={handleToastCloseButtonClick}
-          onTimeout={handleToastTimeout}
-        />
-      </State>
+      <ToastContainer>
+        <State store={store}>
+          <Toast
+            actionLabel="Confirm"
+            action={handleCustomAction}
+            active={false}
+            label="Toast label"
+            timeout={3000}
+            onClose={handleToastCloseButtonClick}
+            onTimeout={handleToastTimeout}
+          />
+        </State>
+      </ToastContainer>
     </div>
   ))
   .add('with custom link', () => (
     <div>
       <Button label="Make a toast" onClick={handleButtonClick} />
+      <ToastContainer />
       <State store={store}>
         <Toast
           link={<Link href="https://www.teamleader.be">link</Link>}
@@ -80,31 +85,35 @@ storiesOf('Toast', module)
   .add('with multiline label', () => (
     <div>
       <Button label="Make a toast" onClick={handleButtonClick} />
-      <State store={store}>
-        <Toast
-          action={handleCustomAction}
-          actionLabel="Try again"
-          active={false}
-          label="Connection timed out. Showing limited amount of messages."
-          timeout={3000}
-          onClose={handleToastCloseButtonClick}
-          onTimeout={handleToastTimeout}
-        />
-      </State>
+      <ToastContainer>
+        <State store={store}>
+          <Toast
+            action={handleCustomAction}
+            actionLabel="Try again"
+            active={false}
+            label="Connection timed out. Showing limited amount of messages."
+            timeout={3000}
+            onClose={handleToastCloseButtonClick}
+            onTimeout={handleToastTimeout}
+          />
+        </State>
+      </ToastContainer>
     </div>
   ))
   .add('with loading spinner', () => (
     <div>
       <Button label="Make a toast" onClick={handleButtonClick} />
-      <State store={store}>
-        <Toast
-          active={false}
-          label="Working..."
-          timeout={3000}
-          onClose={handleToastCloseButtonClick}
-          onTimeout={handleToastTimeout}
-          processing
-        />
-      </State>
+      <ToastContainer>
+        <State store={store}>
+          <Toast
+            active={false}
+            label="Working..."
+            timeout={3000}
+            onClose={handleToastCloseButtonClick}
+            onTimeout={handleToastTimeout}
+            processing
+          />
+        </State>
+      </ToastContainer>
     </div>
   ));

--- a/stories/toast.js
+++ b/stories/toast.js
@@ -40,7 +40,7 @@ storiesOf('Toast', module)
           <Toast
             active={false}
             label="Toast label"
-            timeout={3000}
+            timeout={300000}
             onClose={handleToastCloseButtonClick}
             onTimeout={handleToastTimeout}
           />


### PR DESCRIPTION
### Description
Toasts no longer need the active prop to be rendered and can now be stacked as they are rendered in a containing element.

### Breaking changes
Toasts should be rendered inside the ToastContainer element which will provide flawless animations.

**NOTE:**
To display this in the stories we have two ways with both their ad- and disadvantages. I provided now two ways from which we can pick. If anyone has a solution to include all the ad- and no disadvantages, shoot! 
1. We can have the toast appearing and disappearing by controlling a numbered input field at the bottom. This has the advantage that it shows the full code with all the props in the preview. (With Close button example)

2. We can have the toasts interactive as in that they will appear on the click of a button and close when clicked or timed out. But this means we can not see the props on the Toasts themselves and see the State component in the code preview. (other examples)

I would love to hear what you guys think is the best way.