### PR TITLE
Re-calculate Popover position on screen resize

### DIFF
--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -26,8 +26,6 @@ const factory = (axis, calculatePositions, Overlay) => {
     componentDidMount() {
       document.body.appendChild(this.popoverRoot);
 
-      this.setPlacementThrottled = throttle(this.setPlacement, 250);
-
       events.addEventsToWindow({
         resize: this.setPlacementThrottled,
         scroll: this.setPlacementThrottled,
@@ -39,6 +37,7 @@ const factory = (axis, calculatePositions, Overlay) => {
         resize: this.setPlacementThrottled,
         scroll: this.setPlacementThrottled,
       });
+
       document.body.removeChild(this.popoverRoot);
     }
 
@@ -57,6 +56,8 @@ const factory = (axis, calculatePositions, Overlay) => {
         });
       }
     };
+
+    setPlacementThrottled = throttle(this.setPlacement, 250);
 
     render() {
       const { left, top, arrowLeft, arrowTop } = this.state.positioning;

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -23,10 +23,10 @@ const factory = (axis, calculatePositions, Overlay) => {
       },
     };
 
-    setPlacementThrottled = () => throttle(this.setPlacement, 16);
-
     componentDidMount() {
       document.body.appendChild(this.popoverRoot);
+
+      this.setPlacementThrottled = throttle(this.setPlacement, 250);
 
       events.addEventsToWindow({
         resize: this.setPlacementThrottled,
@@ -39,7 +39,6 @@ const factory = (axis, calculatePositions, Overlay) => {
         resize: this.setPlacementThrottled,
         scroll: this.setPlacementThrottled,
       });
-
       document.body.removeChild(this.popoverRoot);
     }
 
@@ -113,7 +112,7 @@ const factory = (axis, calculatePositions, Overlay) => {
                   <div className={theme['arrow']} style={{ left: `${arrowLeft}px`, top: `${arrowTop}px` }} />
                   <div className={theme['inner']}>
                     {children}
-                    <ReactResizeDetector handleHeight onResize={this.setPlacementThrottled} />
+                    <ReactResizeDetector handleHeight handleWidth onResize={this.setPlacementThrottled} />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
### Description
Fix for issue #304. The issue here was that the throttle function did not work as expected due to how event pooling works in React, hence the callback function was rarely called. Fixed this 

### Breaking changes
none
