### PR TITLE
Enhancement/pause toast timeout on hover

### DIFF
--- a/components/toast/Toast.js
+++ b/components/toast/Toast.js
@@ -68,13 +68,26 @@ class Toast extends PureComponent {
     );
   };
 
+  handleMouseEnter = () => {
+    if (this.props.timeout) {
+      clearTimeout(this.currentTimeout);
+      this.currentTimeout = null;
+    }
+  };
+
+  handleMouseLeave = () => {
+    if (this.props.timeout) {
+      this.scheduleTimeout(this.props);
+    }
+  };
+
   render() {
     const { children, className, label, processing } = this.props;
 
     const classNames = cx(theme['toast'], className);
 
     return (
-      <div data-teamleader-ui="toast">
+      <div data-teamleader-ui="toast" onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
         <div className={classNames}>
           {processing && <LoadingSpinner className={theme['spinner']} color="white" />}
           <TextBody className={theme['label']} color="white">

--- a/components/toast/Toast.js
+++ b/components/toast/Toast.js
@@ -14,12 +14,6 @@ class Toast extends PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.timeout) {
-      this.scheduleTimeout(nextProps);
-    }
-  }
-
   componentWillUnmount() {
     clearTimeout(this.currentTimeout);
   }


### PR DESCRIPTION
### Description
Hovering over a toast will now cancel it's timeout if one has been set, until the mouse leaves the toast after which the timeout will start over. 

### Breaking changes
none
