### PR TITLE
Indicate that a user has selected some datagrid items

### DIFF
--- a/components/checkbox/Checkbox.js
+++ b/components/checkbox/Checkbox.js
@@ -98,11 +98,7 @@ class Checkbox extends PureComponent {
           {...inputProps}
         />
         <span className={theme['shape']}>
-          {partiallySelected ? (
-            <IconMinusSmallOutline className={theme['icon']} />
-          ) : (
-            <IconCheckmark className={theme['icon']} />
-          )}
+          {checked ? <IconCheckmark className={theme['icon']} /> : <IconMinusSmallOutline className={theme['icon']} />}
         </span>
         {(label || children) && (
           <span className={theme['label']}>

--- a/components/checkbox/Checkbox.js
+++ b/components/checkbox/Checkbox.js
@@ -67,7 +67,7 @@ class Checkbox extends PureComponent {
   }
 
   render() {
-    const { checked, disabled, className, size, label, children, partiallySelected, ...others } = this.props;
+    const { checked, disabled, className, size, label, children, indeterminate, ...others } = this.props;
     const rest = omit(others, ['onChange']);
     const { boxProps, inputProps } = this.splitProps(rest);
     const TextElement = size === 'small' ? TextSmall : size === 'medium' ? TextBody : TextDisplay;
@@ -77,7 +77,7 @@ class Checkbox extends PureComponent {
       theme['checkbox'],
       theme[`is-${size}`],
       {
-        [theme['is-checked']]: checked || partiallySelected,
+        [theme['is-checked']]: checked || indeterminate,
         [theme['is-disabled']]: disabled,
       },
       className,
@@ -130,8 +130,8 @@ Checkbox.propTypes = {
   label: PropTypes.string,
   /** Callback function that is fired when checkbox is toggled. */
   onChange: PropTypes.func,
-  /** Indicate whether or not some subsequent child checkboxes, such as in a datagrid, are checked */
-  partiallySelected: PropTypes.bool,
+  /** Indicate whether the checkbox is neither checked or unchecked. */
+  indeterminate: PropTypes.bool,
   /** Size of the checkbox. */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
 };
@@ -139,7 +139,7 @@ Checkbox.propTypes = {
 Checkbox.defaultProps = {
   checked: false,
   disabled: false,
-  partiallySelected: false,
+  indeterminate: false,
   size: 'medium',
 };
 

--- a/components/checkbox/Checkbox.js
+++ b/components/checkbox/Checkbox.js
@@ -5,10 +5,10 @@ import cx from 'classnames';
 import omit from 'lodash.omit';
 import Box from '../box';
 import { TextBody, TextDisplay, TextSmall } from '../typography';
-import { IconCheckmarkSmallOutline, IconCheckmarkMediumOutline } from '@teamleader/ui-icons';
+import { IconCheckmarkSmallOutline, IconCheckmarkMediumOutline, IconMinusSmallOutline } from '@teamleader/ui-icons';
 
 class Checkbox extends PureComponent {
-  handleToggle = (event) => {
+  handleToggle = event => {
     const { disabled, checked, onChange } = this.props;
 
     if (event.pageX !== 0 && event.pageY !== 0) {
@@ -67,7 +67,7 @@ class Checkbox extends PureComponent {
   }
 
   render() {
-    const { checked, disabled, className, size, label, children, ...others } = this.props;
+    const { checked, disabled, className, size, label, children, partiallySelected, ...others } = this.props;
     const rest = omit(others, ['onChange']);
     const { boxProps, inputProps } = this.splitProps(rest);
     const TextElement = size === 'small' ? TextSmall : size === 'medium' ? TextBody : TextDisplay;
@@ -77,7 +77,7 @@ class Checkbox extends PureComponent {
       theme['checkbox'],
       theme[`is-${size}`],
       {
-        [theme['is-checked']]: checked,
+        [theme['is-checked']]: checked || partiallySelected,
         [theme['is-disabled']]: disabled,
       },
       className,
@@ -98,7 +98,11 @@ class Checkbox extends PureComponent {
           {...inputProps}
         />
         <span className={theme['shape']}>
-          <IconCheckmark className={theme['checkmark']} />
+          {partiallySelected ? (
+            <IconMinusSmallOutline className={theme['icon']} />
+          ) : (
+            <IconCheckmark className={theme['icon']} />
+          )}
         </span>
         {(label || children) && (
           <span className={theme['label']}>
@@ -130,6 +134,8 @@ Checkbox.propTypes = {
   label: PropTypes.string,
   /** Callback function that is fired when checkbox is toggled. */
   onChange: PropTypes.func,
+  /** Indicate whether or not some subsequent child checkboxes, such as in a datagrid, are checked */
+  partiallySelected: PropTypes.bool,
   /** Size of the checkbox. */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
 };
@@ -137,6 +143,7 @@ Checkbox.propTypes = {
 Checkbox.defaultProps = {
   checked: false,
   disabled: false,
+  partiallySelected: false,
   size: 'medium',
 };
 

--- a/components/checkbox/theme.css
+++ b/components/checkbox/theme.css
@@ -42,7 +42,7 @@
     transition-timing-function: var(--animation-curve-default);
   }
 
-  .checkmark {
+  .icon {
     transform: scale(0);
     opacity: 0;
     transition: all var(--animation-duration) var(--animation-curve-default);
@@ -66,7 +66,7 @@
       border-color: var(--color-mint-darkest);
     }
 
-    .checkmark {
+    .icon {
       transform: scale(1);
       opacity: 1;
     }

--- a/components/datagrid/DataGrid.js
+++ b/components/datagrid/DataGrid.js
@@ -63,6 +63,7 @@ class DataGrid extends PureComponent {
 
     this.setState({
       selectedRows: selectedBodyRowIndexes,
+      partiallySelected: false,
     });
 
     this.handleSelectionChange(selectedBodyRowIndexes);

--- a/components/datagrid/DataGrid.js
+++ b/components/datagrid/DataGrid.js
@@ -18,6 +18,7 @@ import { events } from '../utils';
 class DataGrid extends PureComponent {
   state = {
     selectedRows: [],
+    partiallySelected: false,
   };
 
   rowNodes = new Map();
@@ -78,6 +79,7 @@ class DataGrid extends PureComponent {
       return {
         ...prevState,
         selectedRows,
+        partiallySelected: selectedRows.length > 0 && this.props.children[1].length !== selectedRows.length,
       };
     });
   };
@@ -109,7 +111,7 @@ class DataGrid extends PureComponent {
 
   render() {
     const { children, className, selectable, stickyFromLeft, stickyFromRight, ...others } = this.props;
-    const { selectedRows } = this.state;
+    const { selectedRows, partiallySelected } = this.state;
 
     const classNames = cx(theme['data-grid'], className);
     const rest = omit(others, ['comparableId', 'onSelectionChange']);
@@ -130,6 +132,7 @@ class DataGrid extends PureComponent {
                   selected: selectedRows.length === children[1].length,
                   selectable,
                   sliceTo: stickyFromLeft > 0 ? stickyFromLeft : 0,
+                  partiallySelected: partiallySelected,
                 });
               } else if (isComponentOfType(BodyRow, child)) {
                 return React.cloneElement(child, {

--- a/components/datagrid/HeaderRow.js
+++ b/components/datagrid/HeaderRow.js
@@ -8,7 +8,17 @@ import theme from './theme.css';
 
 class HeaderRow extends PureComponent {
   render() {
-    const { className, children, sliceFrom, sliceTo, onSelectionChange, selected, selectable, ...others } = this.props;
+    const {
+      className,
+      children,
+      sliceFrom,
+      sliceTo,
+      onSelectionChange,
+      partiallySelected,
+      selected,
+      selectable,
+      ...others
+    } = this.props;
 
     const childrenArray = Array.isArray(children) ? children : [children];
     const childrenSliced = childrenArray.slice(sliceFrom, sliceTo);
@@ -18,7 +28,12 @@ class HeaderRow extends PureComponent {
       <Row backgroundColor="neutral" className={classNames} data-teamleader-ui="datagrid-header-row" {...others}>
         {selectable && (
           <HeaderCell flex="min-width">
-            <Checkbox checked={selected} onChange={onSelectionChange} size="large" />
+            <Checkbox
+              checked={selected}
+              onChange={onSelectionChange}
+              size="large"
+              partiallySelected={partiallySelected}
+            />
           </HeaderCell>
         )}
         {childrenSliced}
@@ -31,6 +46,7 @@ HeaderRow.propTypes = {
   className: PropTypes.string,
   children: PropTypes.any,
   onSelectionChange: PropTypes.func,
+  partiallySelected: PropTypes.bool,
   selectable: PropTypes.bool,
   selected: PropTypes.bool,
   sliceFrom: PropTypes.number,

--- a/components/datagrid/HeaderRow.js
+++ b/components/datagrid/HeaderRow.js
@@ -28,12 +28,7 @@ class HeaderRow extends PureComponent {
       <Row backgroundColor="neutral" className={classNames} data-teamleader-ui="datagrid-header-row" {...others}>
         {selectable && (
           <HeaderCell flex="min-width">
-            <Checkbox
-              checked={selected}
-              onChange={onSelectionChange}
-              size="large"
-              partiallySelected={partiallySelected}
-            />
+            <Checkbox checked={selected} onChange={onSelectionChange} size="large" indeterminate={partiallySelected} />
           </HeaderCell>
         )}
         {childrenSliced}

--- a/stories/checkbox.js
+++ b/stories/checkbox.js
@@ -39,4 +39,11 @@ storiesOf('Checkboxes', module)
         inside
       </TextBody>
     </Checkbox>
+  ))
+  .add('With indeterminate state', () => (
+    <Checkbox
+      partiallySelected={boolean('Indeterminate', false)}
+      label={text('Label', 'I am the label')}
+      size={select('Size', sizes, 'medium')}
+    />
   ));


### PR DESCRIPTION
### Description
If a Datagrid's items are selectable, it will now also show when some items have been selected by showing a "-" icon in the checkbox as indicator to the user.

#### Screenshot before this PR
![screen shot 2018-07-06 at 11 34 14](https://user-images.githubusercontent.com/21224391/42371710-8ca4b034-8110-11e8-99e2-7251e12bbd72.png)

#### Screenshot after this PR
![screen shot 2018-07-06 at 11 35 41](https://user-images.githubusercontent.com/21224391/42371781-bd6e4e64-8110-11e8-85a8-ac4a8d43caba.png)

### Breaking changes
none
