### PR TITLE
Update disabled button styles

### DIFF
--- a/components/button/theme.css
+++ b/components/button/theme.css
@@ -24,7 +24,8 @@
   text-decoration: none;
   transition: background-color var(--animation-duration) var(--animation-curve-fast-out-slow-in),
     border-color var(--animation-duration) var(--animation-curve-fast-out-slow-in),
-    color var(--animation-duration) var(--animation-curve-fast-out-slow-in);
+    color var(--animation-duration) var(--animation-curve-fast-out-slow-in),
+    opacity var(--animation-duration) var(--animation-curve-fast-out-slow-in);
   user-select: none;
   white-space: nowrap;
   vertical-align: middle;
@@ -333,7 +334,6 @@
 .secondary {
   &[disabled] {
     background-color: var(--color-neutral);
-    border: 1px solid var(--color-neutral);
     color: var(--color-neutral-dark);
   }
 }
@@ -404,16 +404,14 @@
 
 .destructive {
   color: var(--color-neutral-lightest);
+  background-color: var(--color-ruby);
+  border: 1px solid var(--color-ruby-dark);
 
   &[disabled] {
-    background-color: var(--color-ruby-lightest);
-    border: 1px solid var(--color-ruby-lightest);
+    opacity: 0.24;
   }
 
   &:not([disabled]) {
-    background-color: var(--color-ruby);
-    border: 1px solid var(--color-ruby-dark);
-
     &:hover {
       background-color: var(--color-ruby-dark);
       border: 1px solid var(--color-ruby-darkest);
@@ -525,7 +523,7 @@
     border-radius: var(--button-border-radius) 0 0 var(--button-border-radius);
     margin-left: 0;
   }
- 
+
   > *:last-child:not(:only-child) {
     border-radius: 0 var(--button-border-radius) var(--button-border-radius) 0;
   }


### PR DESCRIPTION
### Description
This PR updates the styling of the buttons of following types: primary, secondary and destructive.

#### Screenshot before this PR
![screen shot 2018-07-17 at 17 17 34](https://user-images.githubusercontent.com/23736202/42829104-93e7c0de-89e9-11e8-9e23-27013f8a5140.png)
![screen shot 2018-07-17 at 17 17 42](https://user-images.githubusercontent.com/23736202/42829115-95f01084-89e9-11e8-800e-9674ddc507f3.png)
![screen shot 2018-07-17 at 17 17 51](https://user-images.githubusercontent.com/23736202/42829121-97b06428-89e9-11e8-83c6-3d50d0ac50de.png)

#### Screenshot after this PR
<img width="114" alt="screen shot 2018-07-17 at 17 48 50" src="https://user-images.githubusercontent.com/23736202/42829262-bce878f2-89e9-11e8-967e-fe1b60109043.png">
<img width="112" alt="screen shot 2018-07-17 at 17 49 00" src="https://user-images.githubusercontent.com/23736202/42829268-bedd574a-89e9-11e8-998e-cfa636978bf0.png">
<img width="100" alt="screen shot 2018-07-17 at 17 49 06" src="https://user-images.githubusercontent.com/23736202/42829278-c09ac2f2-89e9-11e8-9933-4ff337d5ce5b.png">

### Breaking changes
No breaking changes
