### PR TITLE
Don't vertically center or resize the icon for when error is multiline

### DIFF
--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -183,12 +183,14 @@ export default class Input extends PureComponent {
 
   renderValidationMessage() {
     return (
-      <Box marginTop={2} display="flex" alignItems="center">
-        <IconWarningBadgedSmallFilled className={theme['validation-icon']} />
-        <TextSmall className={theme['validation-text']} element="span" marginLeft={1}>
+      <TextSmall className={theme['validation-text']} marginTop={2} display="flex">
+        <Box element="span" className={theme['validation-icon']}>
+          <IconWarningBadgedSmallFilled />
+        </Box>
+        <Box element="span" marginLeft={1}>
           {this.props.meta.error}
-        </TextSmall>
-      </Box>
+        </Box>
+      </TextSmall>
     );
   }
 

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -382,7 +382,10 @@
       box-shadow: 0 0 0 1px var(--input-error-border);
     }
 
-    .validation-icon,
+    .validation-icon {
+      margin-top: -1px;
+    }
+
     .validation-text {
       color: var(--color-ruby-dark);
     }
@@ -409,7 +412,6 @@
       box-shadow: 0 0 0 1px var(--input-error-border-inverse);
     }
 
-    .validation-icon,
     .validation-text {
       color: var(--color-ruby-light);
     }


### PR DESCRIPTION
This fixes issues with the error icon when the error spans multiple lines:
![screen shot 2018-07-25 at 12 43 06](https://user-images.githubusercontent.com/1674142/43202879-f04322fe-901c-11e8-95f1-3e71268e9a9f.png)
