### PR TITLE
🐛 Make sure IconMenu can receive Box props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Changed the element of `IconMenu` to our `Box` component ([@InstaK](https://github.com/InstaK) in [#324](https://github.com/teamleadercrm/ui/pull/324))
+- `IconMenu` now returns a `Box` component instead of a `div` ([@InstaK](https://github.com/InstaK) in [#324](https://github.com/teamleadercrm/ui/pull/324))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Changed the element of `IconMenu` to our `Box` component ([@InstaK](<(https://github.com/Kemosabert)>) in [#324](https://github.com/teamleadercrm/ui/pull/324))
+- Changed the element of `IconMenu` to our `Box` component ([@InstaK](https://github.com/InstaK) in [#324](https://github.com/teamleadercrm/ui/pull/324))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Changed the element of `IconMenu` to our `Box` component ([@InstaK](<(https://github.com/Kemosabert)>) in [#324](https://github.com/teamleadercrm/ui/pull/324))
+
 ### Deprecated
 
 ### Removed

--- a/components/menu/IconMenu.js
+++ b/components/menu/IconMenu.js
@@ -5,6 +5,7 @@ import { IconMoreMediumOutline } from '@teamleader/ui-icons';
 import IconButton from '../button/IconButton.js';
 import Menu from './Menu.js';
 import theme from './theme.css';
+import Box from '../box';
 
 class IconMenu extends PureComponent {
   state = {
@@ -42,7 +43,7 @@ class IconMenu extends PureComponent {
     const buttonIcon = icon || <IconMoreMediumOutline />;
 
     return (
-      <div data-teamleader-ui="icon-menu" {...other} className={cx(theme['icon-menu'], className)}>
+      <Box data-teamleader-ui="icon-menu" {...other} className={cx(theme['icon-menu'], className)}>
         <IconButton className={theme['icon']} icon={buttonIcon} onClick={this.handleButtonClick} />
         <Menu
           active={this.state.active}
@@ -55,7 +56,7 @@ class IconMenu extends PureComponent {
         >
           {children}
         </Menu>
-      </div>
+      </Box>
     );
   }
 }


### PR DESCRIPTION
### Description

It was not possible to add margin on the IconMenu element, I assume this is because it's not a Box element. I'm not sure if this was added this way on purpose, if so, I'll read it in the comments I suppose 🤷‍♂️ otherwise, now I fixed it.

### Breaking changes

- None

### Changelog

Also: should I already add the changes in this changelog when creating the PR? @duivvv @lowiebenoot 