### PR TITLE
♻️ Center-align cells when DataGrid is selectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - `IconMenu` now returns a `Box` component instead of a `div` ([@InstaK](https://github.com/InstaK) in [#324](https://github.com/teamleadercrm/ui/pull/324))
-- `HeaderCell` and `BodyCell` of `DataGrid` now return a center-aligned `Cell` ([@InstaK](https://github.com/InstaK) in [#325](https://github.com/teamleadercrm/ui/pull/325))
+- The `Checkbox` in `DataGrid` is now centered ([@InstaK](https://github.com/InstaK) in [#325](https://github.com/teamleadercrm/ui/pull/325))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - `IconMenu` now returns a `Box` component instead of a `div` ([@InstaK](https://github.com/InstaK) in [#324](https://github.com/teamleadercrm/ui/pull/324))
+- `HeaderCell` and `BodyCell` of `DataGrid` now return a center-aligned `Cell` ([@InstaK](https://github.com/InstaK) in [#325](https://github.com/teamleadercrm/ui/pull/325))
 
 ### Deprecated
 

--- a/components/datagrid/BodyRow.js
+++ b/components/datagrid/BodyRow.js
@@ -27,7 +27,7 @@ class BodyRow extends PureComponent {
     return (
       <Row className={classNames} data-teamleader-ui="datagrid-body-row" {...others}>
         {selectable && (
-          <Cell flex="min-width">
+          <Cell align="center" flex="min-width">
             <Checkbox checked={selected} onChange={onSelectionChange} size={checkboxSize} />
           </Cell>
         )}

--- a/components/datagrid/HeaderRow.js
+++ b/components/datagrid/HeaderRow.js
@@ -28,7 +28,7 @@ class HeaderRow extends PureComponent {
     return (
       <Row backgroundColor="neutral" className={classNames} data-teamleader-ui="datagrid-header-row" {...others}>
         {selectable && (
-          <HeaderCell flex="min-width">
+          <HeaderCell align="center" flex="min-width">
             <Checkbox
               checked={selected}
               onChange={onSelectionChange}


### PR DESCRIPTION
### Description

The Checkboxes of a selectable DataGrid used to take up the whole container they were in. Because they now allow different sizes, when the checkboxSize is small, it's not aligned. Now it is.

#### Screenshot before this PR

![screenshot 2018-07-30 17 07 12](https://user-images.githubusercontent.com/9056632/43405820-06e157ae-941b-11e8-9cda-00229929b7d0.jpg)


#### Screenshot after this PR

![screenshot 2018-07-30 17 07 37](https://user-images.githubusercontent.com/9056632/43405832-125694b4-941b-11e8-87b5-73296509c9cd.jpg)


### Breaking changes

- none
