### PR TITLE
[#314] Fix button styling for Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- `Button`: `margin` is set to 0, to fix Safari styling issue ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#326](https://github.com/teamleadercrm/ui/pull/326))
+
 ## [0.11.1] - 2018-07-27
 
 ### Changed

--- a/components/button/theme.css
+++ b/components/button/theme.css
@@ -18,6 +18,7 @@
   display: inline-flex;
   justify-content: center;
   letter-spacing: 0;
+  margin: 0;
   outline: none;
   position: relative;
   text-align: center;


### PR DESCRIPTION
### Description

This PR fixes the styling for buttons in Safari, by setting its `margin` to 0.
Solves issue #314 

#### Screenshot before this PR

![screen shot 2018-08-01 at 10 28 36](https://user-images.githubusercontent.com/23736202/43510364-b034964e-9575-11e8-8970-8278a4951b0f.png)

#### Screenshot after this PR

![screen shot 2018-08-01 at 10 27 08](https://user-images.githubusercontent.com/23736202/43510319-93ef7a4e-9575-11e8-8560-3dce70e272af.png)

### Breaking changes

None.