### PR TITLE
Update start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,17 @@ To start the spec site locally, follow these simple steps:
 $ git clone https://github.com/teamleadercrm/ui
 $ cd ui/
 $ npm i
-$ npm start -- --port 3000
+$ npm start
 ```
 
 Open up a browser and the local spec will be available at [http://localhost:3000/](http://localhost:3000/).
+
+To start the project on another port, set the `PORT` variable when running the `start` command.
+As in this example for port `3001`:
+
+```bash
+$ PORT=3001 npm start
+```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "prettier": "prettier --write '**/*.{js,json,md,css}'",
     "prepare": "npm run build",
     "start": "better-npm-run start",
-    "storybook": "better-npm-run storybook",
+    "start": "PORT=${PORT:-3000}; better-npm-run start --port $PORT",
     "build-storybook": " better-npm-run compile"
   }
 }


### PR DESCRIPTION
### Description

This PR removes the need to pass the port when running `npm start`.
It defaults now directly to port `3000`, which can be overridden.
Starting up the project locally is now easier and more in line with the other teamleadercrm repo's.

#### Screenshot before this PR

Not applicable.

#### Screenshot after this PR

Not applicable.

### Breaking changes

None.