### PR TITLE
Label: extra check for Select component so 'optional' wouldn't render twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - `Button`: `margin` is set to 0, to fix Safari styling issue ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#326](https://github.com/teamleadercrm/ui/pull/326))
+- `Label`: added extra check for our new Select component so the word 'optional' wouldn't render twice ([@driesd](https://github.com/driesd) in [#328](https://github.com/teamleadercrm/ui/pull/328))
 
 ## [0.11.1] - 2018-07-27
 

--- a/components/label/Label.js
+++ b/components/label/Label.js
@@ -1,6 +1,7 @@
 import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Input from '../input';
+import Select from '../select';
 import Box from '../box';
 import { TextBody, TextDisplay, TextSmall } from '../typography';
 import theme from './theme.css';
@@ -40,7 +41,7 @@ export default class Label extends PureComponent {
     return (
       <Box element="label" marginBottom={3} className={classNames} {...others}>
         {React.Children.map(children, child => {
-          if (isComponentOfType(Input, child)) {
+          if (isComponentOfType(Input, child) || isComponentOfType(Select, child)) {
             return React.cloneElement(child, childProps);
           }
 


### PR DESCRIPTION
### Description

`Label`: Add extra check for our new Select component so the word 'optional' wouldn't render twice

#### Screenshot before this PR

![schermafdruk 2018-08-01 17 22 45](https://user-images.githubusercontent.com/5336831/43531226-a81fc7b4-95af-11e8-8b21-995bb2e7b62a.png)

#### Screenshot after this PR

![schermafdruk 2018-08-01 17 26 36](https://user-images.githubusercontent.com/5336831/43531452-173b7fc6-95b0-11e8-9ae4-c7fa312ddb4f.png)

### Breaking changes

None.
