### PR TITLE
Refactor menu component

### DIFF
--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -191,19 +191,21 @@ class Menu extends PureComponent {
   }
 
   render() {
-    const outlineStyle = { width: this.state.width, height: this.state.height };
-    const className = cx(
+    const { width, height, active, position } = this.state;
+    const { className, outline } = this.props;
+
+    const clasNames = cx(
       theme['menu'],
-      theme[this.state.position],
+      theme[position],
       {
-        [theme['active']]: this.state.active,
+        [theme['active']]: active,
       },
-      this.props.className,
+      className,
     );
 
     return (
-      <div data-teamleader-ui="menu" className={className} style={this.getRootStyle()}>
-        {this.props.outline ? <div className={theme['outline']} style={outlineStyle} /> : null}
+      <div data-teamleader-ui="menu" className={clasNames} style={this.getRootStyle()}>
+        {outline ? <div className={theme['outline']} style={{ width, height }} /> : null}
         <ul
           ref={node => {
             this.menuNode = node;

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -68,10 +68,7 @@ class Menu extends PureComponent {
 
   componentWillUpdate(nextProps, nextState) {
     if (!this.state.active && nextState.active) {
-      events.addEventsToDocument({
-        click: this.handleDocumentClick,
-        touchstart: this.handleDocumentClick,
-      });
+      this.addEvents();
     }
   }
 
@@ -80,10 +77,7 @@ class Menu extends PureComponent {
       if (this.props.onHide) {
         this.props.onHide();
       }
-      events.removeEventsFromDocument({
-        click: this.handleDocumentClick,
-        touchstart: this.handleDocumentClick,
-      });
+      this.removeEvents();
     } else if (!prevState.active && this.state.active && this.props.onShow) {
       this.props.onShow();
     }
@@ -91,13 +85,24 @@ class Menu extends PureComponent {
 
   componentWillUnmount() {
     if (this.state.active) {
-      events.removeEventsFromDocument({
-        click: this.handleDocumentClick,
-        touchstart: this.handleDocumentClick,
-      });
+      this.removeEvents();
     }
     clearTimeout(this.positionTimeoutHandle);
     clearTimeout(this.activateTimeoutHandle);
+  }
+
+  addEvents() {
+    events.addEventsToDocument({
+      click: this.handleDocumentClick,
+      touchstart: this.handleDocumentClick,
+    });
+  }
+
+  removeEvents() {
+    events.removeEventsFromDocument({
+      click: this.handleDocumentClick,
+      touchstart: this.handleDocumentClick,
+    });
   }
 
   handleDocumentClick = event => {

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -68,23 +68,6 @@ class Menu extends PureComponent {
     }
   }
 
-  componentWillUpdate(nextProps, nextState) {
-    if (!this.state.active && nextState.active) {
-      this.addEvents();
-    }
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    if (prevState.active && !this.state.active) {
-      if (this.props.onHide) {
-        this.props.onHide();
-      }
-      this.removeEvents();
-    } else if (!prevState.active && this.state.active && this.props.onShow) {
-      this.props.onShow();
-    }
-  }
-
   componentWillUnmount() {
     if (this.state.active) {
       this.removeEvents();
@@ -187,11 +170,27 @@ class Menu extends PureComponent {
   }
 
   show() {
+    const { onShow } = this.props;
+
+    if (onShow) {
+      onShow();
+    }
+
     this.setState({ active: true });
+
+    this.addEvents();
   }
 
   hide() {
+    const { onHide } = this.props;
+
+    if (onHide) {
+      onHide();
+    }
+
     this.setState({ active: false });
+
+    this.removeEvents();
   }
 
   render() {

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -156,23 +156,22 @@ class Menu extends PureComponent {
     }
   }
 
-  renderItems() {
+  getItems() {
+    const { children, selectable, selected } = this.props;
+
     // Because React Hot Loader creates proxied versions of your components,
     // comparing reference types of elements won't work
     // https://github.com/gaearon/react-hot-loader/blob/master/docs/Known%20Limitations.md#checking-element-types
     const MenuItemType = <MenuItem />.type;
 
-    return React.Children.map(this.props.children, item => {
+    return React.Children.map(children, item => {
       if (!item) {
         return item;
       }
 
       if (item.type === MenuItemType) {
         return React.cloneElement(item, {
-          selected:
-            typeof item.props.value !== 'undefined' &&
-            this.props.selectable &&
-            item.props.value === this.props.selected,
+          selected: typeof item.props.value !== 'undefined' && selectable && item.props.value === selected,
           onClick: this.handleSelect.bind(this, item),
         });
       } else {
@@ -213,7 +212,7 @@ class Menu extends PureComponent {
           className={theme['menu-inner']}
           style={this.getMenuStyle()}
         >
-          {this.renderItems()}
+          {this.getItems()}
         </ul>
       </div>
     );

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -61,6 +61,30 @@ class Menu extends PureComponent {
     }
   }
 
+  show() {
+    const { onShow } = this.props;
+
+    if (onShow) {
+      onShow();
+    }
+
+    this.setState({ active: true });
+
+    this.addEvents();
+  }
+
+  hide() {
+    const { onHide } = this.props;
+
+    if (onHide) {
+      onHide();
+    }
+
+    this.setState({ active: false });
+
+    this.removeEvents();
+  }
+
   componentWillUnmount() {
     if (this.state.active) {
       this.removeEvents();
@@ -122,6 +146,14 @@ class Menu extends PureComponent {
     return `${toTop ? 'top' : 'bottom'}${toLeft ? 'Left' : 'Right'}`;
   }
 
+  getRootStyle() {
+    const { width, height, position } = this.state;
+
+    if (position !== POSITION.STATIC) {
+      return { width, height };
+    }
+  }
+
   getMenuStyle() {
     const { width, height, position } = this.state;
     if (position !== POSITION.STATIC) {
@@ -136,14 +168,6 @@ class Menu extends PureComponent {
       } else if (position === POSITION.TOP_LEFT) {
         return { clip: 'rect(0 0 0 0)' };
       }
-    }
-  }
-
-  getRootStyle() {
-    const { width, height, position } = this.state;
-
-    if (position !== POSITION.STATIC) {
-      return { width, height };
     }
   }
 
@@ -169,30 +193,6 @@ class Menu extends PureComponent {
         return React.cloneElement(item);
       }
     });
-  }
-
-  show() {
-    const { onShow } = this.props;
-
-    if (onShow) {
-      onShow();
-    }
-
-    this.setState({ active: true });
-
-    this.addEvents();
-  }
-
-  hide() {
-    const { onHide } = this.props;
-
-    if (onHide) {
-      onHide();
-    }
-
-    this.setState({ active: false });
-
-    this.removeEvents();
   }
 
   render() {

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -65,7 +65,6 @@ class Menu extends PureComponent {
     if (this.state.active) {
       this.removeEvents();
     }
-    clearTimeout(this.activateTimeoutHandle);
   }
 
   addEvents() {

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -121,9 +121,6 @@ class Menu extends PureComponent {
 
     if (onClick) {
       event.persist();
-    }
-
-    if (onClick) {
       onClick(event);
     }
 
@@ -161,7 +158,7 @@ class Menu extends PureComponent {
       return this.getActiveMenuStyle();
     }
 
-    return this.getMenyStyleByPosition();
+    return this.getMenuStyleByPosition();
   }
 
   getActiveMenuStyle() {
@@ -169,7 +166,7 @@ class Menu extends PureComponent {
     return { clip: `rect(0 ${width}px ${height}px 0)` };
   }
 
-  getMenyStyleByPosition() {
+  getMenuStyleByPosition() {
     const { width, height, position } = this.state;
 
     switch (position) {

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -96,18 +96,22 @@ class Menu extends PureComponent {
   };
 
   handleSelect = (item, event) => {
+    const { onSelect } = this.props;
     const { value, onClick } = item.props;
+
+    if (onSelect) {
+      onSelect(value);
+    }
+
     if (onClick) {
       event.persist();
     }
-    this.setState({ active: false }, () => {
-      if (onClick) {
-        onClick(event);
-      }
-      if (this.props.onSelect) {
-        this.props.onSelect(value);
-      }
-    });
+
+    if (onClick) {
+      onClick(event);
+    }
+
+    this.hide();
   };
 
   calculatePosition() {

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -25,7 +25,7 @@ class Menu extends PureComponent {
 
     const { position } = this.props;
     if (position === POSITION.AUTO) {
-      this.setState({ position: this.calculatePosition });
+      this.setState({ position: this.calculatePosition() });
     }
   }
 

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -57,7 +57,7 @@ class Menu extends PureComponent {
     }
 
     if (prevState.position !== this.state.position && this.state.position === POSITION.AUTO) {
-      this.setState({ position: this.calculatePosition });
+      this.setState({ position: this.calculatePosition() });
     }
   }
 

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -84,7 +84,7 @@ class Menu extends PureComponent {
 
   handleDocumentClick = event => {
     if (this.state.active && !events.targetIsDescendant(event, ReactDOM.findDOMNode(this))) {
-      this.setState({ active: false });
+      this.hide();
     }
   };
 

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -211,7 +211,7 @@ class Menu extends PureComponent {
     const { width, height, active, position } = this.state;
     const { className, outline } = this.props;
 
-    const clasNames = cx(
+    const classNames = cx(
       theme['menu'],
       theme[position],
       {
@@ -221,7 +221,7 @@ class Menu extends PureComponent {
     );
 
     return (
-      <div data-teamleader-ui="menu" className={clasNames} style={this.getRootStyle()}>
+      <div data-teamleader-ui="menu" className={classNames} style={this.getRootStyle()}>
         {outline ? <div className={theme['outline']} style={{ width, height }} /> : null}
         <ul
           ref={node => {

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -17,9 +17,7 @@ const POSITION = {
 };
 
 class Menu extends PureComponent {
-  state = {
-    active: this.props.active,
-  };
+  state = {};
 
   componentDidMount() {
     const { width, height } = this.menuNode.getBoundingClientRect();
@@ -31,40 +29,35 @@ class Menu extends PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.position !== nextProps.position) {
-      const position = nextProps.position === POSITION.AUTO ? this.calculatePosition() : nextProps.position;
-      this.setState({ position });
+  static getDerivedStateFromProps(props, state) {
+    const newStateSlice = {};
+
+    if (props.active !== state.active) {
+      newStateSlice.active = props.active;
     }
 
-    /**
-     * If the menu is going to be activated via props and its not active, verify
-     * the position is appropriated and then show it recalculating position if its
-     * wrong. It should be shown in two consecutive setState.
-     */
-    if (!this.props.active && nextProps.active && !this.state.active) {
-      if (nextProps.position === POSITION.AUTO) {
-        const position = this.calculatePosition();
-        if (this.state.position !== position) {
-          this.setState({ position, active: false }, () => {
-            this.activateTimeoutHandle = setTimeout(() => {
-              this.show();
-            }, 20);
-          });
-        } else {
-          this.show();
-        }
-      } else {
-        this.show();
-      }
+    if (props.position !== state.position) {
+      newStateSlice.position = props.position;
     }
 
-    /**
-     * If the menu is being deactivated via props and the current state is
-     * active, it should be hid.
-     */
-    if (this.props.active && !nextProps.active && this.state.active) {
+    if (newStateSlice.active || newStateSlice.position) {
+      return newStateSlice;
+    }
+
+    return null;
+  }
+
+  componentDidUpdate(prevState) {
+    if (prevState.active && !this.state.active) {
       this.hide();
+    }
+
+    if (!prevState.active && this.state.active) {
+      this.show();
+    }
+
+    if (prevState.position !== this.state.position && this.state.position === POSITION.AUTO) {
+      this.setState({ position: this.calculatePosition });
     }
   }
 

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -187,8 +187,7 @@ class Menu extends PureComponent {
   }
 
   show() {
-    const { width, height } = this.menuNode.getBoundingClientRect();
-    this.setState({ active: true, width, height });
+    this.setState({ active: true });
   }
 
   hide() {

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -155,19 +155,34 @@ class Menu extends PureComponent {
   }
 
   getMenuStyle() {
+    const { active } = this.state;
+
+    if (active) {
+      return this.getActiveMenuStyle();
+    }
+
+    return this.getMenyStyleByPosition();
+  }
+
+  getActiveMenuStyle() {
+    const { width, height } = this.state;
+    return { clip: `rect(0 ${width}px ${height}px 0)` };
+  }
+
+  getMenyStyleByPosition() {
     const { width, height, position } = this.state;
-    if (position !== POSITION.STATIC) {
-      if (this.state.active) {
-        return { clip: `rect(0 ${width}px ${height}px 0)` };
-      } else if (position === POSITION.TOP_RIGHT) {
+
+    switch (position) {
+      case POSITION.TOP_RIGHT:
         return { clip: `rect(0 ${width}px 0 ${width}px)` };
-      } else if (position === POSITION.BOTTOM_RIGHT) {
+      case POSITION.BOTTOM_RIGHT:
         return { clip: `rect(${height}px ${width}px ${height}px ${width}px)` };
-      } else if (position === POSITION.BOTTOM_LEFT) {
+      case POSITION.BOTTOM_LEFT:
         return { clip: `rect(${height}px 0 ${height}px 0)` };
-      } else if (position === POSITION.TOP_LEFT) {
+      case POSITION.TOP_LEFT:
         return { clip: 'rect(0 0 0 0)' };
-      }
+      default:
+        return {};
     }
   }
 

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -22,11 +22,13 @@ class Menu extends PureComponent {
   };
 
   componentDidMount() {
-    this.positionTimeoutHandle = setTimeout(() => {
-      const { width, height } = this.menuNode.getBoundingClientRect();
-      const position = this.props.position === POSITION.AUTO ? this.calculatePosition() : this.props.position;
-      this.setState({ position, width, height });
-    });
+    const { width, height } = this.menuNode.getBoundingClientRect();
+    this.setState({ width, height });
+
+    const { position } = this.props;
+    if (position === POSITION.AUTO) {
+      this.setState({ position: this.calculatePosition });
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -87,7 +89,6 @@ class Menu extends PureComponent {
     if (this.state.active) {
       this.removeEvents();
     }
-    clearTimeout(this.positionTimeoutHandle);
     clearTimeout(this.activateTimeoutHandle);
   }
 

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -140,8 +140,10 @@ class Menu extends PureComponent {
   }
 
   getRootStyle() {
-    if (this.state.position !== POSITION.STATIC) {
-      return { width: this.state.width, height: this.state.height };
+    const { width, height, position } = this.state;
+
+    if (position !== POSITION.STATIC) {
+      return { width, height };
     }
   }
 

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -112,13 +112,17 @@ class Menu extends PureComponent {
 
   calculatePosition() {
     const parentNode = ReactDOM.findDOMNode(this).parentNode;
+
     if (!parentNode) {
       return;
     }
+
     const { top, left, height, width } = parentNode.getBoundingClientRect();
-    const { height: wh, width: ww } = getViewport();
-    const toTop = top < wh / 2 - height / 2;
-    const toLeft = left < ww / 2 - width / 2;
+    const { height: vh, width: vw } = getViewport();
+
+    const toTop = top < vh / 2 - height / 2;
+    const toLeft = left < vw / 2 - width / 2;
+
     return `${toTop ? 'top' : 'bottom'}${toLeft ? 'Left' : 'Right'}`;
   }
 


### PR DESCRIPTION
### Description

This PR refactors the menu component.
Mainly, it removes the deprecated `compenentWillUpdate` and `componentWillRecieveProps`.
As this component had been copied from another library, I also took the opportunity to write most code more clearly and structured.

This PR resolves issue #299, together with PR #331 

Nothing has visually changed.

#### Screenshot before this PR

![screen shot 2018-08-02 at 12 30 33](https://user-images.githubusercontent.com/23736202/43578722-ed1fe470-964f-11e8-9b12-a2e41487c077.png)

#### Screenshot after this PR

![screen shot 2018-08-02 at 12 29 20](https://user-images.githubusercontent.com/23736202/43578664-c14dfcba-964f-11e8-81f2-1efa61ab9553.png)

### Breaking changes
None.