### PR TITLE
Remove deprecated lifecycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 
+- `DataGrid`: the `componentWillReceiveProps` lifecycle is replaced, as it will be decrecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
+- `Overlay`: the `componentWillUpdate` lifecycle is replaced, as it will be decrecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
+
 ## [0.11.2] - 2018-08-01
 
 ### Added

--- a/components/datagrid/DataGrid.js
+++ b/components/datagrid/DataGrid.js
@@ -37,18 +37,16 @@ class DataGrid extends PureComponent {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.comparableId !== this.props.comparableId) {
+  componentDidUpdate(prevProps) {
+    this.setCalculatedRowWidth();
+
+    if (prevProps.comparableId !== this.props.comparableId) {
       this.handleSelectionChange([]);
 
       this.setState({
         selectedRows: [],
       });
     }
-  }
-
-  componentDidUpdate() {
-    this.setCalculatedRowWidth();
   }
 
   handleHeaderRowSelectionChange = value => {

--- a/components/overlay/Overlay.js
+++ b/components/overlay/Overlay.js
@@ -15,10 +15,14 @@ class Overlay extends PureComponent {
     }
   }
 
-  componentWillUpdate(nextProps) {
+  componentDidUpdate(prevProps) {
+    if (this.props.active && !prevProps.active && this.props.onEscKeyDown) {
+      document.body.addEventListener('keydown', this.handleEscKey);
+    }
+
     if (this.props.lockScroll) {
-      const becomingActive = nextProps.active && !this.props.active;
-      const becomingUnactive = !nextProps.active && this.props.active;
+      const becomingActive = this.props.active && !prevProps.active;
+      const becomingUnactive = !this.props.active && prevProps.active;
 
       if (becomingActive) {
         document.body.style.overflow = 'hidden';
@@ -27,12 +31,6 @@ class Overlay extends PureComponent {
       if (becomingUnactive && !document.querySelectorAll('[data-teamleader-ui="overlay"]')[1]) {
         document.body.style.overflow = '';
       }
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    if (this.props.active && !prevProps.active && this.props.onEscKeyDown) {
-      document.body.addEventListener('keydown', this.handleEscKey);
     }
   }
 


### PR DESCRIPTION
### Description

This PR removes and replaces all the deprecated lifecycles `componentWillRecieveProps` and `componentWillUpdate` (there are no `componentWillMount' lifecycles used over the repo).

This PR resolves issue #299, together with PR #330

Nothing has visually changed

#### Screenshot before this PR

Not applicable.

#### Screenshot after this PR

Not applicable.

### Breaking changes

None.