### PR TITLE
Add changes to Menu to the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
 
 ### Fixed
 
-- `DataGrid`: the `componentWillReceiveProps` lifecycle is replaced, as it will be deprecated in React 17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
-- `Overlay`: the `componentWillUpdate` lifecycle is replaced, as it will be deprecated in React 17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
-- `Menu`: the `componentWillUpdate` and `componentWillReceiveProps` lifecycles are replaced, as they will be deprecated in React 17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#330](https://github.com/teamleadercrm/ui/pull/330))
+- `DataGrid`: the `componentWillReceiveProps` lifecycle is replaced by the `componentDidUpdate` lifecycle, as it will be deprecated in React 17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
+- `Overlay`: the `componentWillUpdate` lifecycle is replaced by the `componentDidUpdate` lifecycle, as it will be deprecated in React 17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
+- `Menu`: the `componentWillUpdate` lifecycle is replaced by the `componentDidUpdate` lifecycle and the `componentWillReceiveProps` lifecycle is replaced by the `getDerivedStateFromProps` and `componentDidUpdate` lifecycles, as they will be deprecated in React 17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#330](https://github.com/teamleadercrm/ui/pull/330))
 
 ## [0.11.2] - 2018-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - `DataGrid`: the `componentWillReceiveProps` lifecycle is replaced, as it will be deprecated in React 17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
 - `Overlay`: the `componentWillUpdate` lifecycle is replaced, as it will be deprecated in React 17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
-- `Menu`: the `componentWillUpdate` and `componentWillRecieveProps` lifecycles are replaced, as they will be deprecated in React 17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#330](https://github.com/teamleadercrm/ui/pull/330))
+- `Menu`: the `componentWillUpdate` and `componentWillReceiveProps` lifecycles are replaced, as they will be deprecated in React 17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#330](https://github.com/teamleadercrm/ui/pull/330))
 
 ## [0.11.2] - 2018-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
 
 ### Fixed
 
-- `DataGrid`: the `componentWillReceiveProps` lifecycle is replaced, as it will be decrecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
-- `Overlay`: the `componentWillUpdate` lifecycle is replaced, as it will be decrecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
-- `Menu`: the `componentWillUpdate` and `componentWillRecieveProps` lifecycles are replaced, as they will be decrecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#330](https://github.com/teamleadercrm/ui/pull/330))
+- `DataGrid`: the `componentWillReceiveProps` lifecycle is replaced, as it will be deprecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
+- `Overlay`: the `componentWillUpdate` lifecycle is replaced, as it will be deprecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
+- `Menu`: the `componentWillUpdate` and `componentWillRecieveProps` lifecycles are replaced, as they will be deprecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#330](https://github.com/teamleadercrm/ui/pull/330))
 
 ## [0.11.2] - 2018-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - `DataGrid`: the `componentWillReceiveProps` lifecycle is replaced, as it will be decrecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
 - `Overlay`: the `componentWillUpdate` lifecycle is replaced, as it will be decrecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
+- `Menu`: the `componentWillUpdate` and `componentWillRecieveProps` lifecycles are replaced, as they will be decrecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#330](https://github.com/teamleadercrm/ui/pull/330))
 
 ## [0.11.2] - 2018-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
 
 ### Fixed
 
-- `DataGrid`: the `componentWillReceiveProps` lifecycle is replaced, as it will be deprecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
-- `Overlay`: the `componentWillUpdate` lifecycle is replaced, as it will be deprecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
-- `Menu`: the `componentWillUpdate` and `componentWillRecieveProps` lifecycles are replaced, as they will be deprecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#330](https://github.com/teamleadercrm/ui/pull/330))
+- `DataGrid`: the `componentWillReceiveProps` lifecycle is replaced, as it will be deprecated in React 17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
+- `Overlay`: the `componentWillUpdate` lifecycle is replaced, as it will be deprecated in React 17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
+- `Menu`: the `componentWillUpdate` and `componentWillRecieveProps` lifecycles are replaced, as they will be deprecated in React 17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#330](https://github.com/teamleadercrm/ui/pull/330))
 
 ## [0.11.2] - 2018-08-01
 


### PR DESCRIPTION
### Description

The main goal of the [refactor of the `Menu` component](https://github.com/teamleadercrm/ui/pull/330), was to remove its soon to be deprecated lifecycles.

I forgot to add these changes to the `CHANGELOG`, hence this extra PR.

#### Screenshot before this PR

Not applicable.

#### Screenshot after this PR

Not applicable.

### Breaking changes

None.
