### PR TITLE
Prevent double borders on input fields with connected buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Fixed
 
 - `DataGrid`: the `componentWillReceiveProps` lifecycle is replaced, as it will be decrecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
-- `Input`: unwanted double borders on input fields with connected buttons ([@driesd](https://github.com/driesd) in [#334](https://github.com/teamleadercrm/ui/pull/334))
+- `Input`: removed unwanted double borders on input fields with connected buttons ([@driesd](https://github.com/driesd) in [#334](https://github.com/teamleadercrm/ui/pull/334))
 - `Overlay`: the `componentWillUpdate` lifecycle is replaced, as it will be decrecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
 
 ## [0.11.2] - 2018-08-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - `DataGrid`: the `componentWillReceiveProps` lifecycle is replaced, as it will be decrecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
+- `Input`: unwanted double borders on input fields with connected buttons ([@driesd](https://github.com/driesd) in [#334](https://github.com/teamleadercrm/ui/pull/334))
 - `Overlay`: the `componentWillUpdate` lifecycle is replaced, as it will be decrecated in react v17 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#331](https://github.com/teamleadercrm/ui/pull/331))
 
 ## [0.11.2] - 2018-08-01

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -172,8 +172,16 @@
     border-radius: var(--input-border-radius) 0 0 var(--input-border-radius);
   }
 
+  > *:first-child:not(.input-inner-wrapper) {
+    border-right: 0;
+  }
+
   > *:last-child {
     border-radius: 0 var(--input-border-radius) var(--input-border-radius) 0;
+  }
+
+  > *:last-child:not(.input-inner-wrapper) {
+    border-left: 0;
   }
 }
 


### PR DESCRIPTION
### Description

This PR fixes the double borders on input fields with connected buttons (see [Jira issue](https://teamleader.atlassian.net/browse/TU-92)).

#### Screenshot before this PR

![schermafdruk 2018-08-07 14 07 54](https://user-images.githubusercontent.com/5336831/43775100-cdccbe4a-9a4b-11e8-8cb1-3be660c76ef7.png)

#### Screenshot after this PR

![schermafdruk 2018-08-07 14 07 07](https://user-images.githubusercontent.com/5336831/43775106-d33d2dce-9a4b-11e8-8f02-f68c389410a7.png)

### Breaking changes

None.
