### PR TITLE
[TU-91] Ability to not render spinner controls on Input fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Input`: implemented `spinner` boolean prop that indicates whether the spinner controls on numeric input fields should render or not. By default it's `true` ([@driesd](https://github.com/driesd) in [#335](https://github.com/teamleadercrm/ui/pull/335))
+
 ### Changed
 
 ### Deprecated

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -155,13 +155,13 @@ export default class Input extends PureComponent {
   }
 
   renderSpinnerControls() {
-    const { disabled, readOnly, type } = this.props;
+    const { disabled, readOnly, spinner, type } = this.props;
 
     const props = {
       disabled: disabled || readOnly,
     };
 
-    if (type === 'number') {
+    if (type === 'number' && spinner) {
       return (
         <div className={theme['spinner']}>
           <Button
@@ -205,7 +205,7 @@ export default class Input extends PureComponent {
       iconPlacement,
       inverse,
       size,
-      type,
+      spinner,
       readOnly,
       ...others
     } = this.props;
@@ -219,8 +219,8 @@ export default class Input extends PureComponent {
         [theme['has-error']]: this.hasError(),
         [theme['has-connected-left']]: connectedLeft,
         [theme['has-connected-right']]: connectedRight,
+        [theme['has-spinner']]: spinner,
         [theme['is-inverse']]: inverse,
-        [theme['is-numeric']]: type === 'number',
         [theme['is-disabled']]: disabled,
         [theme['is-read-only']]: readOnly,
       },
@@ -243,6 +243,8 @@ export default class Input extends PureComponent {
       'onFocus',
       'placeholder',
       'precision',
+      'spinner',
+      'type',
       'updateStep',
       'value',
     ]);
@@ -294,6 +296,8 @@ Input.propTypes = {
   min: PropTypes.number,
   /** Object to provide meta information for redux forms. */
   meta: InputMetaPropTypes,
+  /** Boolean indicating whether to number type input should render spinner controls */
+  spinner: PropTypes.bool,
   /** Object to provide input information for redux forms. */
   input: FieldInputPropTypes,
   /** Callback function that is fired when component is blurred. */
@@ -327,5 +331,6 @@ Input.defaultProps = {
   max: Number.MAX_SAFE_INTEGER,
   readOnly: false,
   size: 'medium',
+  spinner: true,
   step: 1,
 };

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -233,7 +233,7 @@
   }
 }
 
-.is-numeric {
+.has-spinner {
   .input {
     padding-right: calc(var(--spinner-width) + var(--input-horizontal-padding));
   }
@@ -306,7 +306,7 @@
     width: var(--spinner-width-large);
   }
 
-  &.is-numeric {
+  &.has-spinner {
     .input {
       padding-right: calc(var(--spinner-width-large) + var(--input-horizontal-padding));
     }

--- a/stories/input.js
+++ b/stories/input.js
@@ -70,6 +70,7 @@ storiesOf('Inputs', module)
         min={number('Minimum', 0)}
         max={number('Maximum', 10)}
         precision={number('Precision', 2)}
+        spinner={boolean('Render spinner', true)}
         step={number('Step', 1)}
         {...props}
       />


### PR DESCRIPTION
### Description

This PR makes it possible to not render the `spinner controls` on input fields. Therefore I implemented a `spinner` prop which indicates whether the spinner should be rendered or not. By default this is `true`.

#### Screenshot before this PR

![schermafdruk 2018-08-08 16 48 19](https://user-images.githubusercontent.com/5336831/43844849-e929c270-9b2a-11e8-8ace-b9df12d3d07f.png)

#### Screenshot after this PR

![schermafdruk 2018-08-08 16 48 19](https://user-images.githubusercontent.com/5336831/43844849-e929c270-9b2a-11e8-8ace-b9df12d3d07f.png)

![schermafdruk 2018-08-08 16 48 06](https://user-images.githubusercontent.com/5336831/43844869-f4153e3a-9b2a-11e8-87c9-28e13e3cab1a.png)

### Breaking changes

None.
