### PR TITLE
[TU-88] Button: custom element override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ### Added
 
+- `Button` & `IconButton`: implemented `element` prop which takes an element or string to be visually rendered as a button. ([@driesd](https://github.com/driesd) in [#336](https://github.com/teamleadercrm/ui/pull/336))
 - `Input`: implemented `spinner` boolean prop that indicates whether the spinner controls on numeric input fields should render or not. By default it's `true` ([@driesd](https://github.com/driesd) in [#335](https://github.com/teamleadercrm/ui/pull/335))
 
 ### Changed
+
+- [BREAKING] `Button` & `IconButton`: won't render an anchor tag by only passing the `href` prop anymore. You also need to pass the `element` prop to `'a'`. ([@driesd](https://github.com/driesd) in [#336](https://github.com/teamleadercrm/ui/pull/336))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Changed
 
-- [BREAKING] `Button` & `IconButton`: won't render an anchor tag by only passing the `href` prop anymore. You also need to pass the `element` prop to `'a'`. ([@driesd](https://github.com/driesd) in [#336](https://github.com/teamleadercrm/ui/pull/336))
+- [BREAKING] `Button` & `IconButton`: won't render an anchor tag by only passing the `href` prop anymore. You also need to set the `element` prop to `'a'`. ([@driesd](https://github.com/driesd) in [#336](https://github.com/teamleadercrm/ui/pull/336))
 
 ### Deprecated
 

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -101,7 +101,7 @@ Button.propTypes = {
   /** A class name for the button to give custom styles. */
   className: PropTypes.string,
   /** A custom element to be rendered */
-  element: PropTypes.element,
+  element: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   /** Determines which kind of button to be rendered. */
   level: PropTypes.oneOf(['outline', 'primary', 'secondary', 'destructive']),
   /** If true, component will be disabled. */

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -31,6 +31,7 @@ class Button extends PureComponent {
       className,
       level,
       disabled,
+      element,
       active,
       fullWidth,
       href,
@@ -43,8 +44,6 @@ class Button extends PureComponent {
       processing,
       ...others
     } = this.props;
-
-    const element = href ? 'a' : 'button';
 
     const classNames = cx(
       theme['button'],
@@ -101,6 +100,8 @@ Button.propTypes = {
   children: PropTypes.any,
   /** A class name for the button to give custom styles. */
   className: PropTypes.string,
+  /** A custom element to be rendered */
+  element: PropTypes.element,
   /** Determines which kind of button to be rendered. */
   level: PropTypes.oneOf(['outline', 'primary', 'secondary', 'destructive']),
   /** If true, component will be disabled. */
@@ -133,6 +134,7 @@ Button.propTypes = {
 
 Button.defaultProps = {
   className: '',
+  element: 'button',
   fullWidth: false,
   level: 'secondary',
   iconPlacement: 'left',

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -69,7 +69,7 @@ class Button extends PureComponent {
       disabled,
       onMouseUp: this.handleMouseUp,
       onMouseLeave: this.handleMouseLeave,
-      type: !href ? type : null,
+      type: element === 'button' ? type : null,
       'data-teamleader-ui': 'button',
     };
 

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -34,7 +34,6 @@ class Button extends PureComponent {
       element,
       active,
       fullWidth,
-      href,
       icon,
       iconPlacement,
       inverse,
@@ -61,7 +60,6 @@ class Button extends PureComponent {
 
     const props = {
       ...others,
-      href,
       ref: node => {
         this.buttonNode = node;
       },
@@ -110,8 +108,6 @@ Button.propTypes = {
   active: PropTypes.bool,
   /** If true, component will take the full width available. */
   fullWidth: PropTypes.bool,
-  /** If set, button will be rendered as an anchor element. */
-  href: PropTypes.string,
   /** The icon displayed inside the button. */
   icon: PropTypes.element,
   /** The position of the icon inside the button. */

--- a/components/button/IconButton.js
+++ b/components/button/IconButton.js
@@ -19,7 +19,7 @@ class IconButton extends Component {
   };
 
   render() {
-    const { children, className, disabled, element, href, icon, size, color, type, ...others } = this.props;
+    const { children, className, disabled, element, icon, size, color, type, ...others } = this.props;
 
     const classNames = cx(
       theme['button'],
@@ -33,7 +33,6 @@ class IconButton extends Component {
 
     const props = {
       ...others,
-      href,
       ref: node => {
         this.buttonNode = node;
       },
@@ -55,7 +54,6 @@ IconButton.propTypes = {
   disabled: PropTypes.bool,
   /** A custom element to be rendered */
   element: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
-  href: PropTypes.string,
   icon: PropTypes.element,
   onMouseLeave: PropTypes.func,
   onMouseUp: PropTypes.func,

--- a/components/button/IconButton.js
+++ b/components/button/IconButton.js
@@ -19,9 +19,7 @@ class IconButton extends Component {
   };
 
   render() {
-    const { children, className, disabled, href, icon, size, color, type, ...others } = this.props;
-
-    const element = href ? 'a' : 'button';
+    const { children, className, disabled, element, href, icon, size, color, type, ...others } = this.props;
 
     const classNames = cx(
       theme['button'],
@@ -55,6 +53,8 @@ IconButton.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   disabled: PropTypes.bool,
+  /** A custom element to be rendered */
+  element: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   href: PropTypes.string,
   icon: PropTypes.element,
   onMouseLeave: PropTypes.func,
@@ -66,6 +66,7 @@ IconButton.propTypes = {
 
 IconButton.defaultProps = {
   className: '',
+  element: 'button',
   size: 'medium',
   color: 'neutral',
   type: 'button',

--- a/components/button/IconButton.js
+++ b/components/button/IconButton.js
@@ -41,7 +41,7 @@ class IconButton extends Component {
       disabled,
       onMouseUp: this.handleMouseUp,
       onMouseLeave: this.handleMouseLeave,
-      type: !href ? type : null,
+      type: element === 'button' ? type : null,
       'data-teamleader-ui': 'button',
     };
 

--- a/components/button/LinkButton.js
+++ b/components/button/LinkButton.js
@@ -62,7 +62,8 @@ LinkButton.propTypes = {
   children: PropTypes.any,
   className: PropTypes.string,
   disabled: PropTypes.bool,
-  element: PropTypes.element,
+  /** A custom element to be rendered */
+  element: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   icon: PropTypes.element,
   iconPlacement: PropTypes.oneOf(['left', 'right']),
   inverse: PropTypes.bool,

--- a/components/button/LinkButton.js
+++ b/components/button/LinkButton.js
@@ -21,8 +21,6 @@ class LinkButton extends PureComponent {
   render() {
     const { children, className, disabled, element, icon, iconPlacement, inverse, label, size, ...others } = this.props;
 
-    const Element = element || 'button';
-
     const classNames = cx(
       theme['link-button'],
       {
@@ -46,7 +44,7 @@ class LinkButton extends PureComponent {
     };
 
     return React.createElement(
-      Element,
+      element,
       props,
       icon && iconPlacement === 'left' && icon,
       (label || children) && (
@@ -76,6 +74,7 @@ LinkButton.propTypes = {
 
 LinkButton.defaultProps = {
   className: '',
+  element: 'button',
   iconPlacement: 'left',
   inverse: false,
   size: 'medium',

--- a/stories/button.js
+++ b/stories/button.js
@@ -7,7 +7,7 @@ import { withKnobs, boolean, select } from '@storybook/addon-knobs/react';
 import { IconAddMediumOutline, IconAddSmallOutline } from '@teamleader/ui-icons';
 import { Button } from '../components';
 
-const elements = ['a', 'button', 'div', 'span'];
+const elements = ['a', 'button'];
 const iconPositions = ['left', 'right'];
 const levels = ['primary', 'secondary', 'outline', 'destructive'];
 const sizes = ['small', 'medium', 'large'];

--- a/stories/button.js
+++ b/stories/button.js
@@ -7,6 +7,7 @@ import { withKnobs, boolean, select } from '@storybook/addon-knobs/react';
 import { IconAddMediumOutline, IconAddSmallOutline } from '@teamleader/ui-icons';
 import { Button } from '../components';
 
+const elements = ['a', 'button', 'div', 'span'];
 const iconPositions = ['left', 'right'];
 const levels = ['primary', 'secondary', 'outline', 'destructive'];
 const sizes = ['small', 'medium', 'large'];
@@ -39,6 +40,17 @@ storiesOf('Buttons', module)
     <Button
       icon={select('Size', sizes, 'medium') === 'small' ? <IconAddSmallOutline /> : <IconAddMediumOutline />}
       iconPlacement={select('Icon placement', iconPositions, 'left')}
+      label="Button"
+      level={select('Level', levels, 'secondary')}
+      disabled={boolean('Disabled', false)}
+      fullWidth={boolean('Full width', false)}
+      processing={boolean('Processing', false)}
+      size={select('Size', sizes, 'medium')}
+    />
+  ))
+  .add('with custom element', () => (
+    <Button
+      element={select('Element', elements, 'a')}
       label="Button"
       level={select('Level', levels, 'secondary')}
       disabled={boolean('Disabled', false)}

--- a/stories/iconButton.js
+++ b/stories/iconButton.js
@@ -8,7 +8,7 @@ import { IconAddMediumOutline, IconAddSmallOutline } from '@teamleader/ui-icons'
 import { IconButton } from '../components';
 
 const colors = ['white', 'neutral', 'mint', 'aqua', 'violet', 'teal', 'gold', 'ruby'];
-const elements = ['a', 'button', 'div', 'span'];
+const elements = ['a', 'button'];
 const sizes = ['small', 'medium', 'large'];
 
 storiesOf('IconButtons', module)

--- a/stories/iconButton.js
+++ b/stories/iconButton.js
@@ -8,6 +8,7 @@ import { IconAddMediumOutline, IconAddSmallOutline } from '@teamleader/ui-icons'
 import { IconButton } from '../components';
 
 const colors = ['white', 'neutral', 'mint', 'aqua', 'violet', 'teal', 'gold', 'ruby'];
+const elements = ['a', 'button', 'div', 'span'];
 const sizes = ['small', 'medium', 'large'];
 
 storiesOf('IconButtons', module)
@@ -18,6 +19,15 @@ storiesOf('IconButtons', module)
     <IconButton
       icon={select('Size', sizes, 'medium') === 'small' ? <IconAddSmallOutline /> : <IconAddMediumOutline />}
       color={select('Color', colors, 'neutral')}
+      size={select('Size', sizes, 'medium')}
+      disabled={boolean('Disabled', false)}
+    />
+  ))
+  .add('With custom element', () => (
+    <IconButton
+      icon={select('Size', sizes, 'medium') === 'small' ? <IconAddSmallOutline /> : <IconAddMediumOutline />}
+      color={select('Color', colors, 'neutral')}
+      element={select('Element', elements, 'a')}
       size={select('Size', sizes, 'medium')}
       disabled={boolean('Disabled', false)}
     />

--- a/stories/linkButton.js
+++ b/stories/linkButton.js
@@ -7,7 +7,7 @@ import { withKnobs, boolean, select } from '@storybook/addon-knobs/react';
 import { IconChevronLeftMediumOutline, IconChevronRightMediumOutline } from '@teamleader/ui-icons';
 import { LinkButton } from '../components';
 
-const elements = ['a', 'button', 'div', 'span'];
+const elements = ['a', 'button'];
 const iconPositions = ['left', 'right'];
 const sizes = ['small', 'medium', 'large'];
 

--- a/stories/linkButton.js
+++ b/stories/linkButton.js
@@ -7,6 +7,7 @@ import { withKnobs, boolean, select } from '@storybook/addon-knobs/react';
 import { IconChevronLeftMediumOutline, IconChevronRightMediumOutline } from '@teamleader/ui-icons';
 import { LinkButton } from '../components';
 
+const elements = ['a', 'button', 'div', 'span'];
 const iconPositions = ['left', 'right'];
 const sizes = ['small', 'medium', 'large'];
 
@@ -38,6 +39,15 @@ storiesOf('LinkButtons', module)
       iconPlacement={select('Icon placement', iconPositions, 'left')}
       inverse={boolean('Inverse', false)}
       label="Previous"
+      size={select('Size', sizes, 'medium')}
+    />
+  ))
+  .add('With custom element', () => (
+    <LinkButton
+      disabled={boolean('Disabled', false)}
+      element={select('Element', elements, 'a')}
+      inverse={boolean('Inverse', false)}
+      label="link text"
       size={select('Size', sizes, 'medium')}
     />
   ));


### PR DESCRIPTION
### Description

This PR implements the `element` prop for `Button` and `IconButton` which takes an element or string to be visually rendered as a styled button.

### Breaking changes

`Button` & `IconButton` won't render an anchor tag by only passing the `href` prop anymore. From now on, you also need to set the `element` prop to `'a'`.
