### PR TITLE
[TU-105] LinkButton display as square

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `LinkButton`: set the appropriate padding, when only containing an icon, so it displays as a square ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#341](https://github.com/teamleadercrm/ui/pull/341)).
+
 ## [0.12.1] - 2018-08-21
 
 ### Added

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -48,7 +48,7 @@ class Button extends PureComponent {
       theme['button'],
       theme[level],
       {
-        [theme['icon-only']]: !label && !children,
+        [theme['has-icon-only']]: !label && !children,
         [theme['inverse']]: inverse && level === 'outline',
         [theme['is-disabled']]: disabled,
         [theme['is-full-width']]: fullWidth,

--- a/components/button/LinkButton.js
+++ b/components/button/LinkButton.js
@@ -24,7 +24,7 @@ class LinkButton extends PureComponent {
     const classNames = cx(
       theme['link-button'],
       {
-        [theme['has-icon-only']]: !label && !children,
+        [theme['icon-only']]: !label && !children,
         [theme['is-disabled']]: disabled,
         [theme['is-inverse']]: inverse,
         [theme[size]]: theme[size],

--- a/components/button/LinkButton.js
+++ b/components/button/LinkButton.js
@@ -24,7 +24,7 @@ class LinkButton extends PureComponent {
     const classNames = cx(
       theme['link-button'],
       {
-        [theme['icon-only']]: !label && !children,
+        [theme['has-icon-only']]: !label && !children,
         [theme['is-disabled']]: disabled,
         [theme['is-inverse']]: inverse,
         [theme[size]]: theme[size],

--- a/components/button/theme.css
+++ b/components/button/theme.css
@@ -266,7 +266,7 @@
     pointer-events: none;
   }
 
-  &.icon-only:hover {
+  &.has-icon-only:hover {
     background: color(var(--color-neutral-darkest) a(0.24));
   }
 }
@@ -442,7 +442,7 @@
   min-width: calc(3 * var(--unit));
   padding: 0 calc(1.2 * var(--unit));
 
-  &.icon-only {
+  &.has-icon-only {
     padding: 0 calc(0.7 * var(--unit));
   }
 
@@ -460,7 +460,7 @@
   min-width: calc(3.6 * var(--unit));
   padding: 0 calc(1.2 * var(--unit));
 
-  &.icon-only {
+  &.has-icon-only {
     padding: 0 calc(0.5 * var(--unit));
   }
 
@@ -478,7 +478,7 @@
   min-width: calc(4.8 * var(--unit));
   padding: 0 calc(1.8 * var(--unit));
 
-  &.icon-only {
+  &.has-icon-only {
     padding: 0 calc(1.1 * var(--unit));
   }
 }

--- a/components/button/theme.css
+++ b/components/button/theme.css
@@ -266,7 +266,7 @@
     pointer-events: none;
   }
 
-  &.has-icon-only:hover {
+  &.icon-only:hover {
     background: color(var(--color-neutral-darkest) a(0.24));
   }
 }

--- a/stories/linkButton.js
+++ b/stories/linkButton.js
@@ -4,7 +4,12 @@ import { storiesOf } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
 import { withInfo } from '@storybook/addon-info';
 import { withKnobs, boolean, select } from '@storybook/addon-knobs/react';
-import { IconChevronLeftMediumOutline, IconChevronRightMediumOutline } from '@teamleader/ui-icons';
+import {
+  IconChevronLeftSmallOutline,
+  IconChevronLeftMediumOutline,
+  IconChevronRightSmallOutline,
+  IconChevronRightMediumOutline,
+} from '@teamleader/ui-icons';
 import { LinkButton } from '../components';
 
 const elements = ['a', 'button'];
@@ -26,7 +31,14 @@ storiesOf('LinkButtons', module)
   .add('With icon', () => (
     <LinkButton
       disabled={boolean('Disabled', false)}
-      icon={<IconChevronRightMediumOutline />}
+      // icon={<IconChevronRightMediumOutline />}
+      icon={
+        select('Size', sizes, 'medium') === 'small' ? (
+          <IconChevronRightSmallOutline />
+        ) : (
+          <IconChevronRightMediumOutline />
+        )
+      }
       iconPlacement={select('Icon placement', iconPositions, 'left')}
       inverse={boolean('Inverse', false)}
       size={select('Size', sizes, 'medium')}
@@ -35,7 +47,10 @@ storiesOf('LinkButtons', module)
   .add('With text and icon', () => (
     <LinkButton
       disabled={boolean('Disabled', false)}
-      icon={<IconChevronLeftMediumOutline />}
+      // icon={<IconChevronLeftMediumOutline />}
+      icon={
+        select('Size', sizes, 'medium') === 'small' ? <IconChevronLeftSmallOutline /> : <IconChevronLeftMediumOutline />
+      }
       iconPlacement={select('Icon placement', iconPositions, 'left')}
       inverse={boolean('Inverse', false)}
       label="Previous"

--- a/stories/linkButton.js
+++ b/stories/linkButton.js
@@ -31,7 +31,6 @@ storiesOf('LinkButtons', module)
   .add('With icon', () => (
     <LinkButton
       disabled={boolean('Disabled', false)}
-      // icon={<IconChevronRightMediumOutline />}
       icon={
         select('Size', sizes, 'medium') === 'small' ? (
           <IconChevronRightSmallOutline />
@@ -47,7 +46,6 @@ storiesOf('LinkButtons', module)
   .add('With text and icon', () => (
     <LinkButton
       disabled={boolean('Disabled', false)}
-      // icon={<IconChevronLeftMediumOutline />}
       icon={
         select('Size', sizes, 'medium') === 'small' ? <IconChevronLeftSmallOutline /> : <IconChevronLeftMediumOutline />
       }


### PR DESCRIPTION
### Description

This PR updates the styling of the `LinkButton` component, as it didn't display as a square when only containing an icon, due to wrong padding.

#### Screenshot before this PR

![screen shot 2018-08-22 at 10 41 08](https://user-images.githubusercontent.com/23736202/44452871-ed355280-a5f7-11e8-86b9-b4e730d51619.png)

#### Screenshot after this PR

![screen shot 2018-08-22 at 10 41 42](https://user-images.githubusercontent.com/23736202/44452899-01794f80-a5f8-11e8-9175-8f72214b02b9.png)

### Breaking changes

None.