### PR TITLE
Refactor Popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Popover`: renders more accurately, by not blindingly choosing the opposite direction, if it would be rendered off-screen in the given one. In the last case, it chooses for the direction (on the same axis) with the most space and if needed, it becomes scrollable. ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#343](https://github.com/teamleadercrm/ui/pull/331))
+
 ### Deprecated
 
 ### Removed

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -14,7 +14,7 @@ const factory = (axis, calculatePositions, Overlay) => {
   class Popover extends PureComponent {
     popoverRoot = document.createElement('div');
 
-    state = { positioning: { left: 0, top: 0, arrowLeft: 0, arrowTop: 0, maxPopoverHeight: 'inital' } };
+    state = { positioning: { left: 0, top: 0, arrowLeft: 0, arrowTop: 0, maxPopoverHeight: 'initial' } };
 
     componentDidMount() {
       document.body.appendChild(this.popoverRoot);

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -14,29 +14,16 @@ const factory = (axis, calculatePositions, Overlay) => {
   class Popover extends PureComponent {
     popoverRoot = document.createElement('div');
 
-    state = {
-      positioning: {
-        left: 0,
-        top: 0,
-        arrowLeft: 0,
-        arrowTop: 0,
-      },
-    };
+    state = { positioning: { left: 0, top: 0, arrowLeft: 0, arrowTop: 0, maxPopoverHeight: 'inital' } };
 
     componentDidMount() {
       document.body.appendChild(this.popoverRoot);
 
-      events.addEventsToWindow({
-        resize: this.setPlacementThrottled,
-        scroll: this.setPlacementThrottled,
-      });
+      events.addEventsToWindow({ resize: this.setPlacementThrottled, scroll: this.setPlacementThrottled });
     }
 
     componentWillUnmount() {
-      events.removeEventsFromWindow({
-        resize: this.setPlacementThrottled,
-        scroll: this.setPlacementThrottled,
-      });
+      events.removeEventsFromWindow({ resize: this.setPlacementThrottled, scroll: this.setPlacementThrottled });
 
       document.body.removeChild(this.popoverRoot);
     }

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -60,7 +60,7 @@ const factory = (axis, calculatePositions, Overlay) => {
     setPlacementThrottled = throttle(this.setPlacement, 250);
 
     render() {
-      const { left, top, arrowLeft, arrowTop } = this.state.positioning;
+      const { left, top, arrowLeft, arrowTop, maxPopoverHeight } = this.state.positioning;
 
       const {
         active,
@@ -111,7 +111,10 @@ const factory = (axis, calculatePositions, Overlay) => {
                   }}
                 >
                   <div className={theme['arrow']} style={{ left: `${arrowLeft}px`, top: `${arrowTop}px` }} />
-                  <div className={theme['inner']}>
+                  <div
+                    className={theme['inner']}
+                    style={{ maxHeight: maxPopoverHeight ? `${maxPopoverHeight}px` : 'initial' }}
+                  >
                     {children}
                     <ReactResizeDetector handleHeight handleWidth onResize={this.setPlacementThrottled} />
                   </div>

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -7,7 +7,7 @@ import InjectOverlay from '../overlay';
 import Transition from 'react-transition-group/Transition';
 import ReactResizeDetector from 'react-resize-detector';
 import { events } from '../utils';
-import { calculateHorizontalPositions, calculateVerticalPositions } from './positionCalculation';
+import { calculatePositions } from './positionCalculation';
 import theme from './theme.css';
 
 const factory = (axis, calculatePositions, Overlay) => {
@@ -157,6 +157,6 @@ const factory = (axis, calculatePositions, Overlay) => {
   return Popover;
 };
 
-export const PopoverHorizontal = factory('horizontal', calculateHorizontalPositions, InjectOverlay);
+export const PopoverHorizontal = factory('horizontal', calculatePositions, InjectOverlay);
 
-export const PopoverVertical = factory('vertical', calculateVerticalPositions, InjectOverlay);
+export const PopoverVertical = factory('vertical', calculatePositions, InjectOverlay);

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -152,7 +152,7 @@ const factory = (axis, calculatePositions, Overlay) => {
     className: PropTypes.string,
     /** The background colour of the Popover. */
     color: PropTypes.oneOf(['aqua', 'gold', 'mint', 'neutral', 'ruby', 'teal', 'violet']),
-    /** The direction in which the Popover is rendered. */
+    /** The direction in which the Popover is rendered, is overridden with the opposite direction if the Popover cannot be entirely displayed in the current direction. */
     direction: PropTypes.string.isRequired,
     /** The scroll state of the body, if true it will not be scrollable. */
     lockScroll: PropTypes.bool,
@@ -168,7 +168,7 @@ const factory = (axis, calculatePositions, Overlay) => {
     onOverlayMouseMove: PropTypes.func,
     /** The function executed, when the mouse is up on the Overlay. */
     onOverlayMouseUp: PropTypes.func,
-    /** The position in which the Popover is rendered. */
+    /** The position in which the Popover is rendered, is overridden with the another position if the Popover cannot be entirely displayed in the current position. */
     position: PropTypes.string.isRequired,
     /** The tint of the background colour of the Popover. */
     tint: PropTypes.oneOf(['lightest', 'light', 'normal', 'dark', 'darkest']),

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -153,7 +153,7 @@ const factory = (axis, calculatePositions, Overlay) => {
     /** The background colour of the Popover. */
     color: PropTypes.oneOf(['aqua', 'gold', 'mint', 'neutral', 'ruby', 'teal', 'violet']),
     /** The direction in which the Popover is rendered, is overridden with the opposite direction if the Popover cannot be entirely displayed in the current direction. */
-    direction: PropTypes.string.isRequired,
+    direction: PropTypes.oneOf(['north', 'south', 'east', 'west']),
     /** The scroll state of the body, if true it will not be scrollable. */
     lockScroll: PropTypes.bool,
     /** The amount of extra translation on the Popover (has no effect if position is "middle" or "center"). */
@@ -169,7 +169,7 @@ const factory = (axis, calculatePositions, Overlay) => {
     /** The function executed, when the mouse is up on the Overlay. */
     onOverlayMouseUp: PropTypes.func,
     /** The position in which the Popover is rendered, is overridden with the another position if the Popover cannot be entirely displayed in the current position. */
-    position: PropTypes.string.isRequired,
+    position: PropTypes.oneOf(['top', 'middle', 'bottom', 'left', 'center', 'right']),
     /** The tint of the background colour of the Popover. */
     tint: PropTypes.oneOf(['lightest', 'light', 'normal', 'dark', 'darkest']),
   };

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -140,21 +140,37 @@ const factory = (axis, calculatePositions, Overlay) => {
   }
 
   Popover.propTypes = {
+    /** The state of the Popover, when true the Popover is rendered otherwise it is not. */
     active: PropTypes.bool,
+    /** The Popovers anchor element. */
     anchorEl: PropTypes.object,
+    /** The background colour of the Overlay. */
     backdrop: PropTypes.string,
+    /** The component wrapped by the Popover. */
     children: PropTypes.node,
+    /** The class names for the wrapper to apply custom styling. */
     className: PropTypes.string,
+    /** The background colour of the Popover. */
     color: PropTypes.oneOf(['aqua', 'gold', 'mint', 'neutral', 'ruby', 'teal', 'violet']),
+    /** The direction in which the Popover is rendered. */
     direction: PropTypes.string.isRequired,
+    /** The scroll state of the body, if true it will not be scrollable. */
     lockScroll: PropTypes.bool,
+    /** The amount of extra translation on the Popover (has no effect if position is "middle" or "center"). */
     offsetCorrection: PropTypes.number,
+    /** The function executed, when the "ESC" key is down. */
     onEscKeyDown: PropTypes.func,
+    /** The function executed, when the Overlay is clicked. */
     onOverlayClick: PropTypes.func,
+    /** The function executed, when the mouse is down on the Overlay. */
     onOverlayMouseDown: PropTypes.func,
+    /** The function executed, when the mouse is being moved over the Overlay. */
     onOverlayMouseMove: PropTypes.func,
+    /** The function executed, when the mouse is up on the Overlay. */
     onOverlayMouseUp: PropTypes.func,
+    /** The position in which the Popover is rendered. */
     position: PropTypes.string.isRequired,
+    /** The tint of the background colour of the Popover. */
     tint: PropTypes.oneOf(['lightest', 'light', 'normal', 'dark', 'darkest']),
   };
 

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -52,7 +52,14 @@ const factory = (axis, calculatePositions, Overlay) => {
 
       if (this.popoverNode) {
         this.setState({
-          positioning: calculatePositions(anchorEl, this.popoverNode, direction, position, offsetCorrection),
+          positioning: calculatePositions(
+            anchorEl,
+            this.popoverNode,
+            this.popoverContentNode,
+            direction,
+            position,
+            offsetCorrection,
+          ),
         });
       }
     };
@@ -111,11 +118,14 @@ const factory = (axis, calculatePositions, Overlay) => {
                   }}
                 >
                   <div className={theme['arrow']} style={{ left: `${arrowLeft}px`, top: `${arrowTop}px` }} />
-                  <div
-                    className={theme['inner']}
-                    style={{ maxHeight: maxPopoverHeight ? `${maxPopoverHeight}px` : 'initial' }}
-                  >
-                    {children}
+                  <div className={theme['inner']} style={{ maxHeight: maxPopoverHeight }}>
+                    <div
+                      ref={node => {
+                        this.popoverContentNode = node;
+                      }}
+                    >
+                      {children}
+                    </div>
                     <ReactResizeDetector handleHeight handleWidth onResize={this.setPlacementThrottled} />
                   </div>
                 </div>

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -156,20 +156,20 @@ export const calculateHorizontalPositions = (
 ) => {
   const anchorPosition = getAnchorPosition(anchorEl);
   const targetPosition = getTargetPosition(targetEl);
-  const directionToRender = updateHorizontalDirectionIfNeeded(inputDirection, anchorPosition, targetPosition);
-  const positionToRender = updateHorizontalPositionIfNeeded(inputPosition, anchorPosition, targetPosition);
+  const renderDirection = updateHorizontalDirectionIfNeeded(inputDirection, anchorPosition, targetPosition);
+  const renderPosition = updateHorizontalPositionIfNeeded(inputPosition, anchorPosition, targetPosition);
 
   let direction;
-  if (directionToRender === 'west') {
+  if (renderDirection === 'west') {
     direction = directionWest(anchorPosition, targetPosition);
   } else {
     direction = directionEast(anchorPosition, targetPosition);
   }
 
   let position;
-  if (positionToRender === 'top') {
+  if (renderPosition === 'top') {
     position = positionTop(anchorPosition, targetPosition, inputOffsetCorrection);
-  } else if (positionToRender === 'middle') {
+  } else if (renderPosition === 'middle') {
     position = positionMiddle(anchorPosition, targetPosition);
   } else {
     position = positionBottom(anchorPosition, targetPosition, inputOffsetCorrection);
@@ -188,20 +188,20 @@ export const calculateVerticalPositions = (
   const anchorPosition = getAnchorPosition(anchorEl);
   const targetPosition = getTargetPosition(targetEl);
 
-  const directionToRender = updateDirectionIfNeeded(inputDirection, anchorPosition, targetPosition);
-  const positionToRender = updatePositionIfNeeded(inputPosition, anchorPosition, targetPosition);
+  const renderDirection = updateDirectionIfNeeded(inputDirection, anchorPosition, targetPosition);
+  const renderPosition = updatePositionIfNeeded(inputPosition, anchorPosition, targetPosition);
 
   let direction;
-  if (directionToRender === 'north') {
+  if (renderDirection === 'north') {
     direction = directionNorth(anchorPosition, targetPosition);
   } else {
     direction = directionSouth(anchorPosition, targetPosition);
   }
 
   let position;
-  if (positionToRender === 'left') {
+  if (renderPosition === 'left') {
     position = positionLeft(anchorPosition, targetPosition, inputOffsetCorrection);
-  } else if (positionToRender === 'center') {
+  } else if (renderPosition === 'center') {
     position = positionCenter(anchorPosition, targetPosition);
   } else {
     position = positionRight(anchorPosition, targetPosition, inputOffsetCorrection);

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -16,7 +16,7 @@ const getAnchorPositionValues = anchorEl => {
   };
 };
 
-const getTargetPosition = targetEl => {
+const getTargetPositionValues = targetEl => {
   const { width, height } = targetEl.getBoundingClientRect();
 
   return {
@@ -165,7 +165,7 @@ export const calculateHorizontalPositions = (
   inputOffsetCorrection,
 ) => {
   const anchorPosition = getAnchorPositionValues(anchorEl);
-  const targetPosition = getTargetPosition(targetEl);
+  const targetPosition = getTargetPositionValues(targetEl);
   const renderDirection = updateHorizontalDirectionIfNeeded(inputDirection, anchorPosition, targetPosition);
   const renderPosition = updateHorizontalPositionIfNeeded(inputPosition, anchorPosition, targetPosition);
 
@@ -196,7 +196,7 @@ export const calculateVerticalPositions = (
   inputOffsetCorrection,
 ) => {
   const anchorPosition = getAnchorPositionValues(anchorEl);
-  const targetPosition = getTargetPosition(targetEl);
+  const targetPosition = getTargetPositionValues(targetEl);
 
   const renderDirection = updateDirectionIfNeeded(inputDirection, anchorPosition, targetPosition);
   const renderPosition = updatePositionIfNeeded(inputPosition, anchorPosition, targetPosition);

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -19,8 +19,6 @@ const getElementDimensionValues = element => {
   return { width, height };
 };
 
-const getElementHeightValue = element => element.getBoundingClientRect().height;
-
 const getVerticalDirectionPositionValues = ({
   direction,
   position,
@@ -260,12 +258,12 @@ const getMaxPopoverHeight = ({ direction, anchorPosition, popoverContentEl }) =>
   const directionContentRendersOnScreen = isInViewport({
     direction,
     anchorPosition,
-    popoverDimensions: { height: getElementHeightValue(popoverContentEl) },
+    popoverDimensions: getElementDimensionValues(popoverContentEl),
   });
   const oppositeDirectionContentRendersOnScreen = isInViewport({
     direction: getOppositeDirection(direction),
     anchorPosition,
-    popoverDimensions: { height: getElementHeightValue(popoverContentEl) },
+    popoverDimensions: getElementDimensionValues(popoverContentEl),
   });
 
   if (!directionContentRendersOnScreen && !oppositeDirectionContentRendersOnScreen) {

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -1,22 +1,19 @@
 const ARROW_OFFSET = 7;
 const POPUP_OFFSET = 12;
 
-const getAnchorPosition = anchorEl => {
-  const anchorRect = anchorEl.getBoundingClientRect();
+const getAnchorPositionValues = anchorEl => {
+  const { top, left, right, bottom, width, height } = anchorEl.getBoundingClientRect();
 
-  const anchorPosition = {
-    top: anchorRect.top,
-    left: anchorRect.left,
-    width: Math.round(anchorRect.width),
-    height: Math.round(anchorRect.height),
+  return {
+    top,
+    left,
+    width,
+    height,
+    right: right || left + width,
+    bottom: bottom || top + height,
+    middle: top + (bottom - top) / 2,
+    center: left + (right - left) / 2,
   };
-
-  anchorPosition.right = anchorRect.right || anchorPosition.left + anchorPosition.width;
-  anchorPosition.bottom = anchorRect.bottom || anchorPosition.top + anchorPosition.height;
-  anchorPosition.center = anchorPosition.left + (anchorPosition.right - anchorPosition.left) / 2;
-  anchorPosition.middle = anchorPosition.top + (anchorPosition.bottom - anchorPosition.top) / 2;
-
-  return anchorPosition;
 };
 
 const getTargetPosition = targetEl => {
@@ -161,7 +158,7 @@ export const calculateHorizontalPositions = (
   inputPosition,
   inputOffsetCorrection,
 ) => {
-  const anchorPosition = getAnchorPosition(anchorEl);
+  const anchorPosition = getAnchorPositionValues(anchorEl);
   const targetPosition = getTargetPosition(targetEl);
   const renderDirection = updateHorizontalDirectionIfNeeded(inputDirection, anchorPosition, targetPosition);
   const renderPosition = updateHorizontalPositionIfNeeded(inputPosition, anchorPosition, targetPosition);
@@ -192,7 +189,7 @@ export const calculateVerticalPositions = (
   inputPosition,
   inputOffsetCorrection,
 ) => {
-  const anchorPosition = getAnchorPosition(anchorEl);
+  const anchorPosition = getAnchorPositionValues(anchorEl);
   const targetPosition = getTargetPosition(targetEl);
 
   const renderDirection = updateDirectionIfNeeded(inputDirection, anchorPosition, targetPosition);

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -190,13 +190,10 @@ const getOppositeDirection = direction => {
   }
 };
 
-const getOppositeDirectionRendersOnScreen = ({ direction, anchorPosition, popoverPosition }) =>
-  isInViewport({ direction: getOppositeDirection(direction), anchorPosition, popoverPosition });
-
 const getDirection = ({ direction, anchorPosition, popoverPosition }) => {
   const inputDirectionRendersOnScreen = isInViewport({ direction, anchorPosition, popoverPosition });
-  const oppositeDirectionRendersOnScreen = getOppositeDirectionRendersOnScreen({
-    direction,
+  const oppositeDirectionRendersOnScreen = isInViewport({
+    direction: getOppositeDirection(direction),
     anchorPosition,
     popoverPosition,
   });

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -91,8 +91,8 @@ const updateHorizontalPositionIfNeeded = (position, anchorPosition, targetPositi
 // VERTICAL
 const getVerticalDirectionPositionTopValue = ({ direction, anchorPosition, targetPosition }) =>
   direction === 'north'
-    ? anchorPosition.Top - targetPosition.height - POPUP_OFFSET
-    : anchorPosition.top + targetPosition.height + POPUP_OFFSET;
+    ? anchorPosition.top - targetPosition.height - POPUP_OFFSET
+    : anchorPosition.top + anchorPosition.height + POPUP_OFFSET;
 
 const getVerticalDirectionPositionLeftValue = ({
   renderPosition,

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -31,6 +31,8 @@ const getPopoverPositionValues = popoverEl => {
   };
 };
 
+const getElementHeightValue = element => element.getBoundingClientRect().height;
+
 const getVerticalDirectionPositionValues = ({
   direction,
   position,
@@ -275,15 +277,40 @@ const getMaxPopoverHeightValue = ({ direction, anchorPosition }) => {
   }
 };
 
-export const calculatePositions = (anchorEl, popoverEl, inputDirection, inputPosition, inputOffsetCorrection) => {
+export const calculatePositions = (
+  anchorEl,
+  popoverEl,
+  popoverContentEl,
+  inputDirection,
+  inputPosition,
+  inputOffsetCorrection,
+) => {
   const anchorPosition = getAnchorPositionValues(anchorEl);
   const popoverPosition = getPopoverPositionValues(popoverEl);
 
   const direction = getDirection({ direction: inputDirection, anchorPosition, popoverPosition });
   const position = getPosition({ position: inputPosition, anchorPosition, popoverPosition });
 
+  const inputDirectionContentRendersOnScreen = isInViewport({
+    direction: inputDirection,
+    anchorPosition,
+    popoverPosition: { height: getElementHeightValue(popoverContentEl) },
+  });
+  const oppositeDirectionContentRendersOnScreen = isInViewport({
+    direction: getOppositeDirection(inputDirection),
+    anchorPosition,
+    popoverPosition: { height: getElementHeightValue(popoverContentEl) },
+  });
+  let maxPopoverHeight = 'initial';
+  if (!inputDirectionContentRendersOnScreen && !oppositeDirectionContentRendersOnScreen) {
+    maxPopoverHeight = getMaxPopoverHeightValue({
+      direction,
+      anchorPosition,
+    });
+  }
+
   return {
-    maxPopoverHeight: getMaxPopoverHeightValue({ direction, anchorPosition }),
+    maxPopoverHeight,
     ...getPositionValues({
       direction,
       position,

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -16,8 +16,8 @@ const getAnchorPositionValues = anchorEl => {
   };
 };
 
-const getTargetPositionValues = targetEl => {
-  const { width, height } = targetEl.getBoundingClientRect();
+const getPopoverPositionValues = popoverEl => {
+  const { width, height } = popoverEl.getBoundingClientRect();
 
   return {
     width,
@@ -35,54 +35,60 @@ const getVerticalDirectionPositionValues = ({
   direction,
   position,
   anchorPosition,
-  targetPosition,
+  popoverPosition,
   inputOffsetCorrection,
 }) => ({
   top: getVerticalDirectionPositionTopValue({
     direction,
     anchorPosition,
-    targetPosition,
+    popoverPosition,
   }),
-  arrowTop: getVerticalDirectionArrowPositionTopValue({ direction, targetPosition }),
+  arrowTop: getVerticalDirectionArrowPositionTopValue({ direction, popoverPosition }),
   left: getVerticalDirectionPositionLeftValue({
     position,
     anchorPosition,
-    targetPosition,
+    popoverPosition,
     inputOffsetCorrection,
   }),
-  arrowLeft: getVerticalDirectionArrowPositionLeftValue({ position, targetPosition }),
+  arrowLeft: getVerticalDirectionArrowPositionLeftValue({ position, popoverPosition }),
 });
 
 const getHorizontalDirectionPositionValues = ({
   direction,
   position,
   anchorPosition,
-  targetPosition,
+  popoverPosition,
   inputOffsetCorrection,
 }) => ({
   top: getHorizontalDirectionPositionTopValue({
     position,
     anchorPosition,
-    targetPosition,
+    popoverPosition,
     inputOffsetCorrection,
   }),
-  arrowTop: getHorizontalDirectionArrowPositionTopValue({ position, targetPosition }),
-  left: getHorizontalDirectionPositionLeftValue({ direction, anchorPosition, targetPosition }),
+  arrowTop: getHorizontalDirectionArrowPositionTopValue({ position, popoverPosition }),
+  left: getHorizontalDirectionPositionLeftValue({ direction, anchorPosition, popoverPosition }),
   arrowLeft: getHorizontalDirectionArrowPositionLeftValue({
     direction,
     anchorPosition,
-    targetPosition,
+    popoverPosition,
   }),
 });
 
-const getPositionValues = ({ direction, position, anchorPosition, targetPosition, inputOffsetCorrection }) =>
+const getPositionValues = ({ direction, position, anchorPosition, popoverPosition, inputOffsetCorrection }) =>
   direction === 'north' || direction === 'south'
-    ? getVerticalDirectionPositionValues({ direction, position, anchorPosition, targetPosition, inputOffsetCorrection })
+    ? getVerticalDirectionPositionValues({
+        direction,
+        position,
+        anchorPosition,
+        popoverPosition,
+        inputOffsetCorrection,
+      })
     : getHorizontalDirectionPositionValues({
         direction,
         position,
         anchorPosition,
-        targetPosition,
+        popoverPosition,
         inputOffsetCorrection,
       });
 
@@ -90,79 +96,84 @@ const getPositionValues = ({ direction, position, anchorPosition, targetPosition
 const getHorizontalDirectionPositionTopValue = ({
   position,
   anchorPosition,
-  targetPosition,
+  popoverPosition,
   inputOffsetCorrection,
 }) => {
   switch (position) {
     case 'middle':
-      return anchorPosition.middle - targetPosition.height / 2;
+      return anchorPosition.middle - popoverPosition.height / 2;
     case 'top':
       return anchorPosition.top - POPUP_OFFSET * 0.75 - inputOffsetCorrection;
     case 'bottom':
-      return anchorPosition.bottom - targetPosition.height + POPUP_OFFSET * 0.75 + inputOffsetCorrection;
+      return anchorPosition.bottom - popoverPosition.height + POPUP_OFFSET * 0.75 + inputOffsetCorrection;
   }
 };
 
-const getHorizontalDirectionPositionLeftValue = ({ direction, anchorPosition, targetPosition }) =>
+const getHorizontalDirectionPositionLeftValue = ({ direction, anchorPosition, popoverPosition }) =>
   direction === 'west'
-    ? anchorPosition.left - targetPosition.width - POPUP_OFFSET
+    ? anchorPosition.left - popoverPosition.width - POPUP_OFFSET
     : anchorPosition.right + POPUP_OFFSET;
 
-const getHorizontalDirectionArrowPositionTopValue = ({ position, targetPosition }) => {
+const getHorizontalDirectionArrowPositionTopValue = ({ position, popoverPosition }) => {
   switch (position) {
     case 'middle':
-      return targetPosition.height / 2 - ARROW_OFFSET;
+      return popoverPosition.height / 2 - ARROW_OFFSET;
     case 'top':
       return ARROW_OFFSET * 2.35;
     case 'bottom':
-      return targetPosition.height - ARROW_OFFSET * 4.5;
+      return popoverPosition.height - ARROW_OFFSET * 4.5;
   }
 };
 
-const getHorizontalDirectionArrowPositionLeftValue = ({ direction, targetPosition }) =>
-  direction === 'west' ? targetPosition.width - ARROW_OFFSET : -ARROW_OFFSET;
+const getHorizontalDirectionArrowPositionLeftValue = ({ direction, popoverPosition }) =>
+  direction === 'west' ? popoverPosition.width - ARROW_OFFSET : -ARROW_OFFSET;
 
 // VERTICAL
-const getVerticalDirectionPositionTopValue = ({ direction, anchorPosition, targetPosition }) =>
+const getVerticalDirectionPositionTopValue = ({ direction, anchorPosition, popoverPosition }) =>
   direction === 'north'
-    ? anchorPosition.top - targetPosition.height - POPUP_OFFSET
+    ? anchorPosition.top - popoverPosition.height - POPUP_OFFSET
     : anchorPosition.top + anchorPosition.height + POPUP_OFFSET;
 
-const getVerticalDirectionPositionLeftValue = ({ position, anchorPosition, targetPosition, inputOffsetCorrection }) => {
+const getVerticalDirectionPositionLeftValue = ({
+  position,
+  anchorPosition,
+  popoverPosition,
+  inputOffsetCorrection,
+}) => {
   switch (position) {
     case 'center':
-      return anchorPosition.center - targetPosition.width / 2;
+      return anchorPosition.center - popoverPosition.width / 2;
     case 'left':
       return anchorPosition.left - inputOffsetCorrection;
     case 'right':
-      return anchorPosition.right - targetPosition.width + inputOffsetCorrection;
+      return anchorPosition.right - popoverPosition.width + inputOffsetCorrection;
   }
 };
 
-const getVerticalDirectionArrowPositionTopValue = ({ direction, targetPosition }) =>
-  direction === 'north' ? targetPosition.height - ARROW_OFFSET : -ARROW_OFFSET;
+const getVerticalDirectionArrowPositionTopValue = ({ direction, popoverPosition }) =>
+  direction === 'north' ? popoverPosition.height - ARROW_OFFSET : -ARROW_OFFSET;
 
-const getVerticalDirectionArrowPositionLeftValue = ({ position, targetPosition }) => {
+const getVerticalDirectionArrowPositionLeftValue = ({ position, popoverPosition }) => {
   switch (position) {
     case 'center':
-      return targetPosition.width / 2 - ARROW_OFFSET;
+      return popoverPosition.width / 2 - ARROW_OFFSET;
     case 'left':
       return 2 * POPUP_OFFSET;
     case 'right':
-      return targetPosition.width - POPUP_OFFSET * 3;
+      return popoverPosition.width - POPUP_OFFSET * 3;
   }
 };
 
-const isInViewport = ({ direction, anchorPosition, targetPosition }) => {
+const isInViewport = ({ direction, anchorPosition, popoverPosition }) => {
   switch (direction) {
     case 'north':
-      return anchorPosition.top - targetPosition.height - POPUP_OFFSET > 0;
+      return anchorPosition.top - popoverPosition.height - POPUP_OFFSET > 0;
     case 'south':
-      return anchorPosition.bottom + targetPosition.height + POPUP_OFFSET < window.innerHeight;
+      return anchorPosition.bottom + popoverPosition.height + POPUP_OFFSET < window.innerHeight;
     case 'east':
-      return anchorPosition.right + targetPosition.width + POPUP_OFFSET < window.innerWidth;
+      return anchorPosition.right + popoverPosition.width + POPUP_OFFSET < window.innerWidth;
     case 'west':
-      return anchorPosition.left - targetPosition.width - POPUP_OFFSET > 0;
+      return anchorPosition.left - popoverPosition.width - POPUP_OFFSET > 0;
   }
 };
 
@@ -179,41 +190,41 @@ const getOppositeDirection = direction => {
   }
 };
 
-const getOppositeDirectionRendersOnScreen = ({ direction, anchorPosition, targetPosition }) =>
-  isInViewport({ direction: getOppositeDirection(direction), anchorPosition, targetPosition });
+const getOppositeDirectionRendersOnScreen = ({ direction, anchorPosition, popoverPosition }) =>
+  isInViewport({ direction: getOppositeDirection(direction), anchorPosition, popoverPosition });
 
-const getRenderDirection = ({ direction, anchorPosition, targetPosition }) => {
-  const inputDirectionRendersOnScreen = isInViewport({ direction, anchorPosition, targetPosition });
+const getRenderDirection = ({ direction, anchorPosition, popoverPosition }) => {
+  const inputDirectionRendersOnScreen = isInViewport({ direction, anchorPosition, popoverPosition });
   const oppositeDirectionRendersOnScreen = getOppositeDirectionRendersOnScreen({
     direction,
     anchorPosition,
-    targetPosition,
+    popoverPosition,
   });
   return !inputDirectionRendersOnScreen && oppositeDirectionRendersOnScreen
     ? getOppositeDirection(direction)
     : direction;
 };
 
-const isPositionPossible = (position, anchorPosition, targetPosition) => {
+const isPositionPossible = (position, anchorPosition, popoverPosition) => {
   switch (position) {
     case 'middle':
       return (
-        anchorPosition.middle + targetPosition.height / 2 < window.innerHeight &&
-        anchorPosition.middle - targetPosition.height / 2 > 0
+        anchorPosition.middle + popoverPosition.height / 2 < window.innerHeight &&
+        anchorPosition.middle - popoverPosition.height / 2 > 0
       );
     case 'top':
-      return anchorPosition.top + targetPosition.height < window.innerHeight;
+      return anchorPosition.top + popoverPosition.height < window.innerHeight;
     case 'bottom':
-      return anchorPosition.bottom - targetPosition.height > 0;
+      return anchorPosition.bottom - popoverPosition.height > 0;
     case 'center':
       return (
-        anchorPosition.center + targetPosition.width / 2 < window.innerWidth &&
-        anchorPosition.center - targetPosition.width / 2 > 0
+        anchorPosition.center + popoverPosition.width / 2 < window.innerWidth &&
+        anchorPosition.center - popoverPosition.width / 2 > 0
       );
     case 'left':
-      return anchorPosition.left + targetPosition.width < window.innerWidth;
+      return anchorPosition.left + popoverPosition.width < window.innerWidth;
     case 'right':
-      return anchorPosition.right - targetPosition.width > 0;
+      return anchorPosition.right - popoverPosition.width > 0;
   }
 };
 
@@ -230,39 +241,39 @@ const getOppositePosition = direction => {
   }
 };
 
-const getRenderPosition = ({ position, anchorPosition, targetPosition }) => {
-  if (isPositionPossible(position, anchorPosition, targetPosition)) {
+const getRenderPosition = ({ position, anchorPosition, popoverPosition }) => {
+  if (isPositionPossible(position, anchorPosition, popoverPosition)) {
     return position;
   }
 
   switch (position) {
     case 'middle':
-      return isPositionPossible('top', anchorPosition, targetPosition)
+      return isPositionPossible('top', anchorPosition, popoverPosition)
         ? 'top'
-        : isPositionPossible('bottom', anchorPosition, targetPosition)
+        : isPositionPossible('bottom', anchorPosition, popoverPosition)
           ? 'bottom'
           : position;
     case 'center':
-      return isPositionPossible('left', anchorPosition, targetPosition)
+      return isPositionPossible('left', anchorPosition, popoverPosition)
         ? 'left'
-        : isPositionPossible('right', anchorPosition, targetPosition)
+        : isPositionPossible('right', anchorPosition, popoverPosition)
           ? 'right'
           : position;
     case 'top':
     case 'bottom':
-      return isPositionPossible('middle', anchorPosition, targetPosition) ? 'middle' : getOppositePosition(position);
+      return isPositionPossible('middle', anchorPosition, popoverPosition) ? 'middle' : getOppositePosition(position);
     case 'left':
     case 'right':
-      return isPositionPossible('center', anchorPosition, targetPosition) ? 'center' : getOppositePosition(position);
+      return isPositionPossible('center', anchorPosition, popoverPosition) ? 'center' : getOppositePosition(position);
   }
 };
 
-export const calculatePositions = (anchorEl, targetEl, inputDirection, inputPosition, inputOffsetCorrection) => {
+export const calculatePositions = (anchorEl, popoverEl, inputDirection, inputPosition, inputOffsetCorrection) => {
   const anchorPosition = getAnchorPositionValues(anchorEl);
-  const targetPosition = getTargetPositionValues(targetEl);
+  const popoverPosition = getPopoverPositionValues(popoverEl);
 
-  const direction = getRenderDirection({ direction: inputDirection, anchorPosition, targetPosition });
-  const position = getRenderPosition({ position: inputPosition, anchorPosition, targetPosition });
+  const direction = getRenderDirection({ direction: inputDirection, anchorPosition, popoverPosition });
+  const position = getRenderPosition({ position: inputPosition, anchorPosition, popoverPosition });
 
-  return getPositionValues({ direction, position, anchorPosition, targetPosition, inputOffsetCorrection });
+  return getPositionValues({ direction, position, anchorPosition, popoverPosition, inputOffsetCorrection });
 };

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -16,19 +16,9 @@ const getAnchorPositionValues = anchorEl => {
   };
 };
 
-const getPopoverPositionValues = popoverEl => {
-  const { width, height } = popoverEl.getBoundingClientRect();
-
-  return {
-    width,
-    height,
-    top: 0,
-    left: 0,
-    right: width,
-    bottom: height,
-    middle: width / 2,
-    center: height / 2,
-  };
+const getElementDimensions = element => {
+  const { width, height } = element.getBoundingClientRect();
+  return { width, height };
 };
 
 const getElementHeightValue = element => element.getBoundingClientRect().height;
@@ -37,60 +27,60 @@ const getVerticalDirectionPositionValues = ({
   direction,
   position,
   anchorPosition,
-  popoverPosition,
+  popoverDimensions,
   inputOffsetCorrection,
 }) => ({
   top: getVerticalDirectionPositionTopValue({
     direction,
     anchorPosition,
-    popoverPosition,
+    popoverDimensions,
   }),
-  arrowTop: getVerticalDirectionArrowPositionTopValue({ direction, popoverPosition }),
+  arrowTop: getVerticalDirectionArrowPositionTopValue({ direction, popoverDimensions }),
   left: getVerticalDirectionPositionLeftValue({
     position,
     anchorPosition,
-    popoverPosition,
+    popoverDimensions,
     inputOffsetCorrection,
   }),
-  arrowLeft: getVerticalDirectionArrowPositionLeftValue({ position, popoverPosition }),
+  arrowLeft: getVerticalDirectionArrowPositionLeftValue({ position, popoverDimensions }),
 });
 
 const getHorizontalDirectionPositionValues = ({
   direction,
   position,
   anchorPosition,
-  popoverPosition,
+  popoverDimensions,
   inputOffsetCorrection,
 }) => ({
   top: getHorizontalDirectionPositionTopValue({
     position,
     anchorPosition,
-    popoverPosition,
+    popoverDimensions,
     inputOffsetCorrection,
   }),
-  arrowTop: getHorizontalDirectionArrowPositionTopValue({ position, popoverPosition }),
-  left: getHorizontalDirectionPositionLeftValue({ direction, anchorPosition, popoverPosition }),
+  arrowTop: getHorizontalDirectionArrowPositionTopValue({ position, popoverDimensions }),
+  left: getHorizontalDirectionPositionLeftValue({ direction, anchorPosition, popoverDimensions }),
   arrowLeft: getHorizontalDirectionArrowPositionLeftValue({
     direction,
     anchorPosition,
-    popoverPosition,
+    popoverDimensions,
   }),
 });
 
-const getPositionValues = ({ direction, position, anchorPosition, popoverPosition, inputOffsetCorrection }) =>
+const getPositionValues = ({ direction, position, anchorPosition, popoverDimensions, inputOffsetCorrection }) =>
   direction === 'north' || direction === 'south'
     ? getVerticalDirectionPositionValues({
         direction,
         position,
         anchorPosition,
-        popoverPosition,
+        popoverDimensions,
         inputOffsetCorrection,
       })
     : getHorizontalDirectionPositionValues({
         direction,
         position,
         anchorPosition,
-        popoverPosition,
+        popoverDimensions,
         inputOffsetCorrection,
       });
 
@@ -98,84 +88,84 @@ const getPositionValues = ({ direction, position, anchorPosition, popoverPositio
 const getHorizontalDirectionPositionTopValue = ({
   position,
   anchorPosition,
-  popoverPosition,
+  popoverDimensions,
   inputOffsetCorrection,
 }) => {
   switch (position) {
     case 'middle':
-      return anchorPosition.middle - popoverPosition.height / 2;
+      return anchorPosition.middle - popoverDimensions.height / 2;
     case 'top':
       return anchorPosition.top - POPUP_OFFSET * 0.75 - inputOffsetCorrection;
     case 'bottom':
-      return anchorPosition.bottom - popoverPosition.height + POPUP_OFFSET * 0.75 + inputOffsetCorrection;
+      return anchorPosition.bottom - popoverDimensions.height + POPUP_OFFSET * 0.75 + inputOffsetCorrection;
   }
 };
 
-const getHorizontalDirectionPositionLeftValue = ({ direction, anchorPosition, popoverPosition }) =>
+const getHorizontalDirectionPositionLeftValue = ({ direction, anchorPosition, popoverDimensions }) =>
   direction === 'west'
-    ? anchorPosition.left - popoverPosition.width - POPUP_OFFSET
+    ? anchorPosition.left - popoverDimensions.width - POPUP_OFFSET
     : anchorPosition.right + POPUP_OFFSET;
 
-const getHorizontalDirectionArrowPositionTopValue = ({ position, popoverPosition }) => {
+const getHorizontalDirectionArrowPositionTopValue = ({ position, popoverDimensions }) => {
   switch (position) {
     case 'middle':
-      return popoverPosition.height / 2 - ARROW_OFFSET;
+      return popoverDimensions.height / 2 - ARROW_OFFSET;
     case 'top':
       return ARROW_OFFSET * 2.35;
     case 'bottom':
-      return popoverPosition.height - ARROW_OFFSET * 4.5;
+      return popoverDimensions.height - ARROW_OFFSET * 4.5;
   }
 };
 
-const getHorizontalDirectionArrowPositionLeftValue = ({ direction, popoverPosition }) =>
-  direction === 'west' ? popoverPosition.width - ARROW_OFFSET : -ARROW_OFFSET;
+const getHorizontalDirectionArrowPositionLeftValue = ({ direction, popoverDimensions }) =>
+  direction === 'west' ? popoverDimensions.width - ARROW_OFFSET : -ARROW_OFFSET;
 
 // VERTICAL
-const getVerticalDirectionPositionTopValue = ({ direction, anchorPosition, popoverPosition }) =>
+const getVerticalDirectionPositionTopValue = ({ direction, anchorPosition, popoverDimensions }) =>
   direction === 'north'
-    ? anchorPosition.top - popoverPosition.height - POPUP_OFFSET
+    ? anchorPosition.top - popoverDimensions.height - POPUP_OFFSET
     : anchorPosition.top + anchorPosition.height + POPUP_OFFSET;
 
 const getVerticalDirectionPositionLeftValue = ({
   position,
   anchorPosition,
-  popoverPosition,
+  popoverDimensions,
   inputOffsetCorrection,
 }) => {
   switch (position) {
     case 'center':
-      return anchorPosition.center - popoverPosition.width / 2;
+      return anchorPosition.center - popoverDimensions.width / 2;
     case 'left':
       return anchorPosition.left - inputOffsetCorrection;
     case 'right':
-      return anchorPosition.right - popoverPosition.width + inputOffsetCorrection;
+      return anchorPosition.right - popoverDimensions.width + inputOffsetCorrection;
   }
 };
 
-const getVerticalDirectionArrowPositionTopValue = ({ direction, popoverPosition }) =>
-  direction === 'north' ? popoverPosition.height - ARROW_OFFSET : -ARROW_OFFSET;
+const getVerticalDirectionArrowPositionTopValue = ({ direction, popoverDimensions }) =>
+  direction === 'north' ? popoverDimensions.height - ARROW_OFFSET : -ARROW_OFFSET;
 
-const getVerticalDirectionArrowPositionLeftValue = ({ position, popoverPosition }) => {
+const getVerticalDirectionArrowPositionLeftValue = ({ position, popoverDimensions }) => {
   switch (position) {
     case 'center':
-      return popoverPosition.width / 2 - ARROW_OFFSET;
+      return popoverDimensions.width / 2 - ARROW_OFFSET;
     case 'left':
       return 2 * POPUP_OFFSET;
     case 'right':
-      return popoverPosition.width - POPUP_OFFSET * 3;
+      return popoverDimensions.width - POPUP_OFFSET * 3;
   }
 };
 
-const isInViewport = ({ direction, anchorPosition, popoverPosition }) => {
+const isInViewport = ({ direction, anchorPosition, popoverDimensions }) => {
   switch (direction) {
     case 'north':
-      return anchorPosition.top - popoverPosition.height - POPUP_OFFSET > 0;
+      return anchorPosition.top - popoverDimensions.height - POPUP_OFFSET > 0;
     case 'south':
-      return anchorPosition.bottom + popoverPosition.height + POPUP_OFFSET < window.innerHeight;
+      return anchorPosition.bottom + popoverDimensions.height + POPUP_OFFSET < window.innerHeight;
     case 'east':
-      return anchorPosition.right + popoverPosition.width + POPUP_OFFSET < window.innerWidth;
+      return anchorPosition.right + popoverDimensions.width + POPUP_OFFSET < window.innerWidth;
     case 'west':
-      return anchorPosition.left - popoverPosition.width - POPUP_OFFSET > 0;
+      return anchorPosition.left - popoverDimensions.width - POPUP_OFFSET > 0;
   }
 };
 
@@ -192,12 +182,12 @@ const getOppositeDirection = direction => {
   }
 };
 
-const getDirection = ({ direction, anchorPosition, popoverPosition }) => {
-  const inputDirectionRendersOnScreen = isInViewport({ direction, anchorPosition, popoverPosition });
+const getDirection = ({ direction, anchorPosition, popoverDimensions }) => {
+  const inputDirectionRendersOnScreen = isInViewport({ direction, anchorPosition, popoverDimensions });
   const oppositeDirectionRendersOnScreen = isInViewport({
     direction: getOppositeDirection(direction),
     anchorPosition,
-    popoverPosition,
+    popoverDimensions,
   });
 
   return !inputDirectionRendersOnScreen && oppositeDirectionRendersOnScreen
@@ -205,26 +195,26 @@ const getDirection = ({ direction, anchorPosition, popoverPosition }) => {
     : direction;
 };
 
-const isPositionPossible = (position, anchorPosition, popoverPosition) => {
+const isPositionPossible = (position, anchorPosition, popoverDimensions) => {
   switch (position) {
     case 'middle':
       return (
-        anchorPosition.middle + popoverPosition.height / 2 < window.innerHeight &&
-        anchorPosition.middle - popoverPosition.height / 2 > 0
+        anchorPosition.middle + popoverDimensions.height / 2 < window.innerHeight &&
+        anchorPosition.middle - popoverDimensions.height / 2 > 0
       );
     case 'top':
-      return anchorPosition.top + popoverPosition.height < window.innerHeight;
+      return anchorPosition.top + popoverDimensions.height < window.innerHeight;
     case 'bottom':
-      return anchorPosition.bottom - popoverPosition.height > 0;
+      return anchorPosition.bottom - popoverDimensions.height > 0;
     case 'center':
       return (
-        anchorPosition.center + popoverPosition.width / 2 < window.innerWidth &&
-        anchorPosition.center - popoverPosition.width / 2 > 0
+        anchorPosition.center + popoverDimensions.width / 2 < window.innerWidth &&
+        anchorPosition.center - popoverDimensions.width / 2 > 0
       );
     case 'left':
-      return anchorPosition.left + popoverPosition.width < window.innerWidth;
+      return anchorPosition.left + popoverDimensions.width < window.innerWidth;
     case 'right':
-      return anchorPosition.right - popoverPosition.width > 0;
+      return anchorPosition.right - popoverDimensions.width > 0;
   }
 };
 
@@ -241,30 +231,30 @@ const getOppositePosition = direction => {
   }
 };
 
-const getPosition = ({ position, anchorPosition, popoverPosition }) => {
-  if (isPositionPossible(position, anchorPosition, popoverPosition)) {
+const getPosition = ({ position, anchorPosition, popoverDimensions }) => {
+  if (isPositionPossible(position, anchorPosition, popoverDimensions)) {
     return position;
   }
 
   switch (position) {
     case 'middle':
-      return isPositionPossible('top', anchorPosition, popoverPosition)
+      return isPositionPossible('top', anchorPosition, popoverDimensions)
         ? 'top'
-        : isPositionPossible('bottom', anchorPosition, popoverPosition)
+        : isPositionPossible('bottom', anchorPosition, popoverDimensions)
           ? 'bottom'
           : position;
     case 'center':
-      return isPositionPossible('left', anchorPosition, popoverPosition)
+      return isPositionPossible('left', anchorPosition, popoverDimensions)
         ? 'left'
-        : isPositionPossible('right', anchorPosition, popoverPosition)
+        : isPositionPossible('right', anchorPosition, popoverDimensions)
           ? 'right'
           : position;
     case 'top':
     case 'bottom':
-      return isPositionPossible('middle', anchorPosition, popoverPosition) ? 'middle' : getOppositePosition(position);
+      return isPositionPossible('middle', anchorPosition, popoverDimensions) ? 'middle' : getOppositePosition(position);
     case 'left':
     case 'right':
-      return isPositionPossible('center', anchorPosition, popoverPosition) ? 'center' : getOppositePosition(position);
+      return isPositionPossible('center', anchorPosition, popoverDimensions) ? 'center' : getOppositePosition(position);
   }
 };
 
@@ -272,12 +262,12 @@ const getMaxPopoverHeight = ({ direction, anchorPosition, popoverContentEl }) =>
   const directionContentRendersOnScreen = isInViewport({
     direction,
     anchorPosition,
-    popoverPosition: { height: getElementHeightValue(popoverContentEl) },
+    popoverDimensions: { height: getElementHeightValue(popoverContentEl) },
   });
   const oppositeDirectionContentRendersOnScreen = isInViewport({
     direction: getOppositeDirection(direction),
     anchorPosition,
-    popoverPosition: { height: getElementHeightValue(popoverContentEl) },
+    popoverDimensions: { height: getElementHeightValue(popoverContentEl) },
   });
 
   if (!directionContentRendersOnScreen && !oppositeDirectionContentRendersOnScreen) {
@@ -308,10 +298,10 @@ export const calculatePositions = (
   inputOffsetCorrection,
 ) => {
   const anchorPosition = getAnchorPositionValues(anchorEl);
-  const popoverPosition = getPopoverPositionValues(popoverEl);
+  const popoverDimensions = getElementDimensions(popoverEl);
 
-  const direction = getDirection({ direction: inputDirection, anchorPosition, popoverPosition });
-  const position = getPosition({ position: inputPosition, anchorPosition, popoverPosition });
+  const direction = getDirection({ direction: inputDirection, anchorPosition, popoverDimensions });
+  const position = getPosition({ position: inputPosition, anchorPosition, popoverDimensions });
 
   return {
     maxPopoverHeight: getMaxPopoverHeight({
@@ -323,7 +313,7 @@ export const calculatePositions = (
       direction,
       position,
       anchorPosition,
-      popoverPosition,
+      popoverDimensions,
       inputOffsetCorrection,
     }),
   };

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -14,7 +14,7 @@ const getElementPositionValues = element => {
   };
 };
 
-const getElementDimensions = element => {
+const getElementDimensionValues = element => {
   const { width, height } = element.getBoundingClientRect();
   return { width, height };
 };
@@ -296,7 +296,7 @@ export const calculatePositions = (
   inputOffsetCorrection,
 ) => {
   const anchorPosition = getElementPositionValues(anchorEl);
-  const popoverDimensions = getElementDimensions(popoverEl);
+  const popoverDimensions = getElementDimensionValues(popoverEl);
 
   const direction = getDirection({ direction: inputDirection, anchorPosition, popoverDimensions });
   const position = getPosition({ position: inputPosition, anchorPosition, popoverDimensions });

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -268,6 +268,28 @@ const getPosition = ({ position, anchorPosition, popoverPosition }) => {
   }
 };
 
+const getMaxPopoverHeight = ({ direction, anchorPosition, popoverContentEl }) => {
+  const directionContentRendersOnScreen = isInViewport({
+    direction,
+    anchorPosition,
+    popoverPosition: { height: getElementHeightValue(popoverContentEl) },
+  });
+  const oppositeDirectionContentRendersOnScreen = isInViewport({
+    direction: getOppositeDirection(direction),
+    anchorPosition,
+    popoverPosition: { height: getElementHeightValue(popoverContentEl) },
+  });
+
+  if (!directionContentRendersOnScreen && !oppositeDirectionContentRendersOnScreen) {
+    return getMaxPopoverHeightValue({
+      direction,
+      anchorPosition,
+    });
+  }
+
+  return 'initial';
+};
+
 const getMaxPopoverHeightValue = ({ direction, anchorPosition }) => {
   switch (direction) {
     case 'north':
@@ -291,26 +313,12 @@ export const calculatePositions = (
   const direction = getDirection({ direction: inputDirection, anchorPosition, popoverPosition });
   const position = getPosition({ position: inputPosition, anchorPosition, popoverPosition });
 
-  const inputDirectionContentRendersOnScreen = isInViewport({
-    direction: inputDirection,
-    anchorPosition,
-    popoverPosition: { height: getElementHeightValue(popoverContentEl) },
-  });
-  const oppositeDirectionContentRendersOnScreen = isInViewport({
-    direction: getOppositeDirection(inputDirection),
-    anchorPosition,
-    popoverPosition: { height: getElementHeightValue(popoverContentEl) },
-  });
-  let maxPopoverHeight = 'initial';
-  if (!inputDirectionContentRendersOnScreen && !oppositeDirectionContentRendersOnScreen) {
-    maxPopoverHeight = getMaxPopoverHeightValue({
+  return {
+    maxPopoverHeight: getMaxPopoverHeight({
       direction,
       anchorPosition,
-    });
-  }
-
-  return {
-    maxPopoverHeight,
+      popoverContentEl,
+    }),
     ...getPositionValues({
       direction,
       position,

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -79,14 +79,10 @@ const updateHorizontalPositionIfNeeded = (position, anchorPosition, targetPositi
 };
 
 // VERTICAL
-const getPositionTopValue = ({ renderDirection, anchorPosition, targetPosition }) => {
-  switch (renderDirection) {
-    case 'north':
-      return anchorPosition.top - targetPosition.height - POPUP_OFFSET;
-    case 'south':
-      return anchorPosition.top + anchorPosition.height + POPUP_OFFSET;
-  }
-};
+const getPositionTopValue = ({ direction, anchorPosition, targetPosition }) =>
+  direction === 'north'
+    ? anchorPosition.Top - targetPosition.height - POPUP_OFFSET
+    : anchorPosition.top + targetPosition.height + POPUP_OFFSET;
 
 const getPositionLeftValue = ({ renderPosition, anchorPosition, targetPosition, inputOffsetCorrection }) => {
   switch (renderPosition) {
@@ -99,14 +95,8 @@ const getPositionLeftValue = ({ renderPosition, anchorPosition, targetPosition, 
   }
 };
 
-const getArrowPositionTopValue = ({ renderDirection, renderPosition, targetPosition }) => {
-  switch (renderDirection) {
-    case 'north':
-      return targetPosition.height - ARROW_OFFSET;
-    case 'south':
-      return -ARROW_OFFSET;
-  }
-};
+const getArrowPositionTopValue = ({ direction, targetPosition }) =>
+  direction === 'north' ? targetPosition.height - ARROW_OFFSET : -ARROW_OFFSET;
 
 const getArrowPositionLeftValue = ({ renderPosition, targetPosition }) => {
   switch (renderPosition) {
@@ -227,7 +217,7 @@ export const calculateVerticalPositions = (
   const renderDirection = getRenderDirection({ direction: inputDirection, anchorPosition, targetPosition });
   const renderPosition = updatePositionIfNeeded(inputPosition, anchorPosition, targetPosition);
 
-  const top = getPositionTopValue({ renderDirection, anchorPosition, targetPosition });
+  const top = getPositionTopValue({ direction: renderDirection, anchorPosition, targetPosition });
   const arrowTop = getArrowPositionTopValue({
     renderDirection,
     renderPosition,
@@ -240,7 +230,6 @@ export const calculateVerticalPositions = (
     targetPosition,
     inputOffsetCorrection,
   });
-
   const arrowLeft = getArrowPositionLeftValue({ renderPosition, targetPosition });
 
   return { top, arrowTop, left, arrowLeft };

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -193,7 +193,7 @@ const getOppositeDirection = direction => {
 const getOppositeDirectionRendersOnScreen = ({ direction, anchorPosition, popoverPosition }) =>
   isInViewport({ direction: getOppositeDirection(direction), anchorPosition, popoverPosition });
 
-const getRenderDirection = ({ direction, anchorPosition, popoverPosition }) => {
+const getDirection = ({ direction, anchorPosition, popoverPosition }) => {
   const inputDirectionRendersOnScreen = isInViewport({ direction, anchorPosition, popoverPosition });
   const oppositeDirectionRendersOnScreen = getOppositeDirectionRendersOnScreen({
     direction,
@@ -241,7 +241,7 @@ const getOppositePosition = direction => {
   }
 };
 
-const getRenderPosition = ({ position, anchorPosition, popoverPosition }) => {
+const getPosition = ({ position, anchorPosition, popoverPosition }) => {
   if (isPositionPossible(position, anchorPosition, popoverPosition)) {
     return position;
   }
@@ -272,8 +272,8 @@ export const calculatePositions = (anchorEl, popoverEl, inputDirection, inputPos
   const anchorPosition = getAnchorPositionValues(anchorEl);
   const popoverPosition = getPopoverPositionValues(popoverEl);
 
-  const direction = getRenderDirection({ direction: inputDirection, anchorPosition, popoverPosition });
-  const position = getRenderPosition({ position: inputPosition, anchorPosition, popoverPosition });
+  const direction = getDirection({ direction: inputDirection, anchorPosition, popoverPosition });
+  const position = getPosition({ position: inputPosition, anchorPosition, popoverPosition });
 
   return getPositionValues({ direction, position, anchorPosition, popoverPosition, inputOffsetCorrection });
 };

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -200,6 +200,7 @@ const getDirection = ({ direction, anchorPosition, popoverPosition }) => {
     anchorPosition,
     popoverPosition,
   });
+
   return !inputDirectionRendersOnScreen && oppositeDirectionRendersOnScreen
     ? getOppositeDirection(direction)
     : direction;
@@ -268,6 +269,15 @@ const getPosition = ({ position, anchorPosition, popoverPosition }) => {
   }
 };
 
+const getMaxPopoverHeightValue = ({ direction, anchorPosition }) => {
+  switch (direction) {
+    case 'north':
+      return anchorPosition.top - POPUP_OFFSET * 2;
+    case 'south':
+      return window.innerHeight - anchorPosition.bottom - POPUP_OFFSET * 2;
+  }
+};
+
 export const calculatePositions = (anchorEl, popoverEl, inputDirection, inputPosition, inputOffsetCorrection) => {
   const anchorPosition = getAnchorPositionValues(anchorEl);
   const popoverPosition = getPopoverPositionValues(popoverEl);
@@ -275,5 +285,14 @@ export const calculatePositions = (anchorEl, popoverEl, inputDirection, inputPos
   const direction = getDirection({ direction: inputDirection, anchorPosition, popoverPosition });
   const position = getPosition({ position: inputPosition, anchorPosition, popoverPosition });
 
-  return getPositionValues({ direction, position, anchorPosition, popoverPosition, inputOffsetCorrection });
+  return {
+    maxPopoverHeight: getMaxPopoverHeightValue({ direction, anchorPosition }),
+    ...getPositionValues({
+      direction,
+      position,
+      anchorPosition,
+      popoverPosition,
+      inputOffsetCorrection,
+    }),
+  };
 };

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -160,14 +160,6 @@ const getRenderDirection = ({ direction, anchorPosition, targetPosition }) => {
     : direction;
 };
 
-const updateDirectionIfNeeded = (direction, anchorPosition, targetPosition) => {
-  if (direction === 'north') {
-    return anchorPosition.top - targetPosition.height - POPUP_OFFSET < 0 ? 'south' : 'north';
-  }
-
-  return anchorPosition.bottom + targetPosition.height + POPUP_OFFSET > window.innerHeight ? 'north' : 'south';
-};
-
 const updatePositionIfNeeded = (position, anchorPosition, targetPosition) => {
   const leftIsPossible = anchorPosition.left + targetPosition.width < window.innerWidth;
 

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -92,20 +92,27 @@ const updateHorizontalPositionIfNeeded = (position, anchorPosition, targetPositi
 };
 
 // VERTICAL
-const positionCenter = (anchorPosition, targetPosition) => ({
-  left: anchorPosition.center - targetPosition.width / 2,
-  arrowLeft: targetPosition.width / 2 - ARROW_OFFSET,
-});
+const getPositionLeftValue = ({ renderPosition, anchorPosition, targetPosition, inputOffsetCorrection }) => {
+  switch (renderPosition) {
+    case 'center':
+      return anchorPosition.center - targetPosition.width / 2;
+    case 'left':
+      return anchorPosition.left - inputOffsetCorrection;
+    case 'right':
+      return anchorPosition.right - targetPosition.width + inputOffsetCorrection;
+  }
+};
 
-const positionLeft = (anchorPosition, targetPosition, offsetCorrection) => ({
-  left: anchorPosition.left - offsetCorrection,
-  arrowLeft: 2 * POPUP_OFFSET,
-});
-
-const positionRight = (anchorPosition, targetPosition, offsetCorrection) => ({
-  left: anchorPosition.right - targetPosition.width + offsetCorrection,
-  arrowLeft: targetPosition.width - POPUP_OFFSET * 3,
-});
+const getArrowPositionLeftValue = ({ renderPosition, targetPosition }) => {
+  switch (renderPosition) {
+    case 'center':
+      return targetPosition.width / 2 - ARROW_OFFSET;
+    case 'left':
+      return 2 * POPUP_OFFSET;
+    case 'right':
+      return targetPosition.width - POPUP_OFFSET * 3;
+  }
+};
 
 const directionNorth = (anchorPosition, targetPosition) => ({
   top: anchorPosition.top - targetPosition.height - POPUP_OFFSET,
@@ -198,14 +205,14 @@ export const calculateVerticalPositions = (
     direction = directionSouth(anchorPosition, targetPosition);
   }
 
-  let position;
-  if (renderPosition === 'left') {
-    position = positionLeft(anchorPosition, targetPosition, inputOffsetCorrection);
-  } else if (renderPosition === 'center') {
-    position = positionCenter(anchorPosition, targetPosition);
-  } else {
-    position = positionRight(anchorPosition, targetPosition, inputOffsetCorrection);
-  }
+  const left = getPositionLeftValue({
+    renderPosition,
+    anchorPosition,
+    targetPosition,
+    inputOffsetCorrection,
+  });
 
-  return { ...direction, ...position };
+  const arrowLeft = getArrowPositionLeftValue({ renderPosition, targetPosition });
+
+  return { ...direction, left, arrowLeft };
 };

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -31,6 +31,61 @@ const getTargetPositionValues = targetEl => {
   };
 };
 
+const getVerticalDirectionPositionValues = ({
+  direction,
+  position,
+  anchorPosition,
+  targetPosition,
+  inputOffsetCorrection,
+}) => ({
+  top: getVerticalDirectionPositionTopValue({
+    direction,
+    anchorPosition,
+    targetPosition,
+  }),
+  arrowTop: getVerticalDirectionArrowPositionTopValue({ direction, targetPosition }),
+  left: getVerticalDirectionPositionLeftValue({
+    position,
+    anchorPosition,
+    targetPosition,
+    inputOffsetCorrection,
+  }),
+  arrowLeft: getVerticalDirectionArrowPositionLeftValue({ position, targetPosition }),
+});
+
+const getHorizontalDirectionPositionValues = ({
+  direction,
+  position,
+  anchorPosition,
+  targetPosition,
+  inputOffsetCorrection,
+}) => ({
+  top: getHorizontalDirectionPositionTopValue({
+    position,
+    anchorPosition,
+    targetPosition,
+    inputOffsetCorrection,
+  }),
+  arrowTop: getHorizontalDirectionArrowPositionTopValue({ position, targetPosition }),
+  left: getHorizontalDirectionPositionLeftValue({ direction, anchorPosition, targetPosition }),
+  arrowLeft: getHorizontalDirectionArrowPositionLeftValue({
+    direction,
+    anchorPosition,
+    targetPosition,
+  }),
+});
+
+const getPositionValues = ({ direction, position, anchorPosition, targetPosition, inputOffsetCorrection }) =>
+  direction === 'north' || direction === 'south'
+    ? getVerticalDirectionPositionValues({ direction, position, anchorPosition, targetPosition, inputOffsetCorrection })
+    : getHorizontalDirectionPositionValues({
+        direction,
+        position,
+        anchorPosition,
+        targetPosition,
+        inputOffsetCorrection,
+      });
+
 // HORIZONTAL
 const getHorizontalDirectionPositionTopValue = ({
   position,
@@ -73,13 +128,8 @@ const getVerticalDirectionPositionTopValue = ({ direction, anchorPosition, targe
     ? anchorPosition.top - targetPosition.height - POPUP_OFFSET
     : anchorPosition.top + anchorPosition.height + POPUP_OFFSET;
 
-const getVerticalDirectionPositionLeftValue = ({
-  renderPosition,
-  anchorPosition,
-  targetPosition,
-  inputOffsetCorrection,
-}) => {
-  switch (renderPosition) {
+const getVerticalDirectionPositionLeftValue = ({ position, anchorPosition, targetPosition, inputOffsetCorrection }) => {
+  switch (position) {
     case 'center':
       return anchorPosition.center - targetPosition.width / 2;
     case 'left':
@@ -92,8 +142,8 @@ const getVerticalDirectionPositionLeftValue = ({
 const getVerticalDirectionArrowPositionTopValue = ({ direction, targetPosition }) =>
   direction === 'north' ? targetPosition.height - ARROW_OFFSET : -ARROW_OFFSET;
 
-const getVerticalDirectionArrowPositionLeftValue = ({ renderPosition, targetPosition }) => {
-  switch (renderPosition) {
+const getVerticalDirectionArrowPositionLeftValue = ({ position, targetPosition }) => {
+  switch (position) {
     case 'center':
       return targetPosition.width / 2 - ARROW_OFFSET;
     case 'left':
@@ -207,65 +257,12 @@ const getRenderPosition = ({ position, anchorPosition, targetPosition }) => {
   }
 };
 
-// EXPORT
-export const calculateHorizontalPositions = (
-  anchorEl,
-  targetEl,
-  inputDirection,
-  inputPosition,
-  inputOffsetCorrection,
-) => {
+export const calculatePositions = (anchorEl, targetEl, inputDirection, inputPosition, inputOffsetCorrection) => {
   const anchorPosition = getAnchorPositionValues(anchorEl);
   const targetPosition = getTargetPositionValues(targetEl);
 
-  const renderDirection = getRenderDirection({ direction: inputDirection, anchorPosition, targetPosition });
-  const renderPosition = getRenderPosition({ position: inputPosition, anchorPosition, targetPosition });
+  const direction = getRenderDirection({ direction: inputDirection, anchorPosition, targetPosition });
+  const position = getRenderPosition({ position: inputPosition, anchorPosition, targetPosition });
 
-  const top = getHorizontalDirectionPositionTopValue({
-    position: renderPosition,
-    anchorPosition,
-    targetPosition,
-    inputOffsetCorrection,
-  });
-  const arrowTop = getHorizontalDirectionArrowPositionTopValue({
-    position: renderPosition,
-    targetPosition,
-    inputOffsetCorrection,
-  });
-
-  const left = getHorizontalDirectionPositionLeftValue({ direction: renderDirection, anchorPosition, targetPosition });
-  const arrowLeft = getHorizontalDirectionArrowPositionLeftValue({
-    direction: renderDirection,
-    anchorPosition,
-    targetPosition,
-  });
-
-  return { top, arrowTop, left, arrowLeft };
-};
-
-export const calculateVerticalPositions = (
-  anchorEl,
-  targetEl,
-  inputDirection,
-  inputPosition,
-  inputOffsetCorrection,
-) => {
-  const anchorPosition = getAnchorPositionValues(anchorEl);
-  const targetPosition = getTargetPositionValues(targetEl);
-
-  const renderDirection = getRenderDirection({ direction: inputDirection, anchorPosition, targetPosition });
-  const renderPosition = getRenderPosition({ position: inputPosition, anchorPosition, targetPosition });
-
-  const top = getVerticalDirectionPositionTopValue({ direction: renderDirection, anchorPosition, targetPosition });
-  const arrowTop = getVerticalDirectionArrowPositionTopValue({ renderDirection, renderPosition, targetPosition });
-
-  const left = getVerticalDirectionPositionLeftValue({
-    renderPosition,
-    anchorPosition,
-    targetPosition,
-    inputOffsetCorrection,
-  });
-  const arrowLeft = getVerticalDirectionArrowPositionLeftValue({ renderPosition, targetPosition });
-
-  return { top, arrowTop, left, arrowLeft };
+  return getPositionValues({ direction, position, anchorPosition, targetPosition, inputOffsetCorrection });
 };

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -48,6 +48,11 @@ const getHorizontalDirectionPositionTopValue = ({
   }
 };
 
+const getHorizontalDirectionPositionLeftValue = ({ direction, anchorPosition, targetPosition }) =>
+  direction === 'west'
+    ? anchorPosition.left - targetPosition.width - POPUP_OFFSET
+    : anchorPosition.right + POPUP_OFFSET;
+
 const getHorizontalDirectionArrowPositionTopValue = ({ position, targetPosition }) => {
   switch (position) {
     case 'middle':
@@ -59,15 +64,8 @@ const getHorizontalDirectionArrowPositionTopValue = ({ position, targetPosition 
   }
 };
 
-const directionWest = (anchorPosition, targetPosition) => ({
-  left: anchorPosition.left - targetPosition.width - POPUP_OFFSET,
-  arrowLeft: targetPosition.width - ARROW_OFFSET,
-});
-
-const directionEast = anchorPosition => ({
-  left: anchorPosition.right + POPUP_OFFSET,
-  arrowLeft: -ARROW_OFFSET,
-});
+const getHorizontalDirectionArrowPositionLeftValue = ({ direction, targetPosition }) =>
+  direction === 'west' ? targetPosition.width - ARROW_OFFSET : -ARROW_OFFSET;
 
 const updateHorizontalPositionIfNeeded = (position, anchorPosition, targetPosition) => {
   const topIsPossible = anchorPosition.top + targetPosition.height < window.innerHeight;
@@ -96,7 +94,12 @@ const getVerticalDirectionPositionTopValue = ({ direction, anchorPosition, targe
     ? anchorPosition.Top - targetPosition.height - POPUP_OFFSET
     : anchorPosition.top + targetPosition.height + POPUP_OFFSET;
 
-const getPositionLeftValue = ({ renderPosition, anchorPosition, targetPosition, inputOffsetCorrection }) => {
+const getVerticalDirectionPositionLeftValue = ({
+  renderPosition,
+  anchorPosition,
+  targetPosition,
+  inputOffsetCorrection,
+}) => {
   switch (renderPosition) {
     case 'center':
       return anchorPosition.center - targetPosition.width / 2;
@@ -110,7 +113,7 @@ const getPositionLeftValue = ({ renderPosition, anchorPosition, targetPosition, 
 const getVerticalDirectionArrowPositionTopValue = ({ direction, targetPosition }) =>
   direction === 'north' ? targetPosition.height - ARROW_OFFSET : -ARROW_OFFSET;
 
-const getArrowPositionLeftValue = ({ renderPosition, targetPosition }) => {
+const getVerticalDirectionArrowPositionLeftValue = ({ renderPosition, targetPosition }) => {
   switch (renderPosition) {
     case 'center':
       return targetPosition.width / 2 - ARROW_OFFSET;
@@ -197,13 +200,6 @@ export const calculateHorizontalPositions = (
   const renderDirection = getRenderDirection({ direction: inputDirection, anchorPosition, targetPosition });
   const renderPosition = updateHorizontalPositionIfNeeded(inputPosition, anchorPosition, targetPosition);
 
-  let direction;
-  if (renderDirection === 'west') {
-    direction = directionWest(anchorPosition, targetPosition);
-  } else {
-    direction = directionEast(anchorPosition, targetPosition);
-  }
-
   const top = getHorizontalDirectionPositionTopValue({
     position: renderPosition,
     anchorPosition,
@@ -216,7 +212,14 @@ export const calculateHorizontalPositions = (
     inputOffsetCorrection,
   });
 
-  return { ...direction, top, arrowTop };
+  const left = getHorizontalDirectionPositionLeftValue({ direction: renderDirection, anchorPosition, targetPosition });
+  const arrowLeft = getHorizontalDirectionArrowPositionLeftValue({
+    direction: renderDirection,
+    anchorPosition,
+    targetPosition,
+  });
+
+  return { top, arrowTop, left, arrowLeft };
 };
 
 export const calculateVerticalPositions = (
@@ -235,13 +238,13 @@ export const calculateVerticalPositions = (
   const top = getVerticalDirectionPositionTopValue({ direction: renderDirection, anchorPosition, targetPosition });
   const arrowTop = getVerticalDirectionArrowPositionTopValue({ renderDirection, renderPosition, targetPosition });
 
-  const left = getPositionLeftValue({
+  const left = getVerticalDirectionPositionLeftValue({
     renderPosition,
     anchorPosition,
     targetPosition,
     inputOffsetCorrection,
   });
-  const arrowLeft = getArrowPositionLeftValue({ renderPosition, targetPosition });
+  const arrowLeft = getVerticalDirectionArrowPositionLeftValue({ renderPosition, targetPosition });
 
   return { top, arrowTop, left, arrowLeft };
 };

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -1,7 +1,7 @@
 const ARROW_OFFSET = 7;
 const POPUP_OFFSET = 12;
 
-function getAnchorPosition(anchorEl) {
+const getAnchorPosition = anchorEl => {
   const anchorRect = anchorEl.getBoundingClientRect();
 
   const anchorPosition = {
@@ -17,9 +17,9 @@ function getAnchorPosition(anchorEl) {
   anchorPosition.middle = anchorPosition.top + (anchorPosition.bottom - anchorPosition.top) / 2;
 
   return anchorPosition;
-}
+};
 
-function getTargetPosition(targetEl) {
+const getTargetPosition = targetEl => {
   const targetRect = targetEl.getBoundingClientRect();
   const width = Math.round(targetRect.width);
   const height = Math.round(targetRect.height);
@@ -34,7 +34,7 @@ function getTargetPosition(targetEl) {
     width: width,
     height: height,
   };
-}
+};
 
 // HORIZONTAL
 const positionMiddle = (anchorPosition, targetPosition) => ({
@@ -147,7 +147,13 @@ const updatePositionIfNeeded = (position, anchorPosition, targetPosition) => {
 };
 
 // EXPORT
-export function calculateHorizontalPositions(anchorEl, targetEl, inputDirection, inputPosition, inputOffsetCorrection) {
+export const calculateHorizontalPositions = (
+  anchorEl,
+  targetEl,
+  inputDirection,
+  inputPosition,
+  inputOffsetCorrection,
+) => {
   const anchorPosition = getAnchorPosition(anchorEl);
   const targetPosition = getTargetPosition(targetEl);
   const directionToRender = updateHorizontalDirectionIfNeeded(inputDirection, anchorPosition, targetPosition);
@@ -170,9 +176,15 @@ export function calculateHorizontalPositions(anchorEl, targetEl, inputDirection,
   }
 
   return { ...direction, ...position };
-}
+};
 
-export function calculateVerticalPositions(anchorEl, targetEl, inputDirection, inputPosition, inputOffsetCorrection) {
+export const calculateVerticalPositions = (
+  anchorEl,
+  targetEl,
+  inputDirection,
+  inputPosition,
+  inputOffsetCorrection,
+) => {
   const anchorPosition = getAnchorPosition(anchorEl);
   const targetPosition = getTargetPosition(targetEl);
 
@@ -196,4 +208,4 @@ export function calculateVerticalPositions(anchorEl, targetEl, inputDirection, i
   }
 
   return { ...direction, ...position };
-}
+};

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -57,14 +57,6 @@ const directionEast = anchorPosition => ({
   arrowLeft: -ARROW_OFFSET,
 });
 
-const updateHorizontalDirectionIfNeeded = (direction, anchorPosition, targetPosition) => {
-  if (direction === 'west') {
-    return anchorPosition.left - targetPosition.width - POPUP_OFFSET < 0 ? 'east' : 'west';
-  }
-
-  return anchorPosition.right + targetPosition.width + POPUP_OFFSET < window.innerWidth ? 'east' : 'west';
-};
-
 const updateHorizontalPositionIfNeeded = (position, anchorPosition, targetPosition) => {
   const topIsPossible = anchorPosition.top + targetPosition.height < window.innerHeight;
 
@@ -127,6 +119,47 @@ const getArrowPositionLeftValue = ({ renderPosition, targetPosition }) => {
   }
 };
 
+const getDirectionRendersOnScreen = ({ direction, anchorPosition, targetPosition }) => {
+  switch (direction) {
+    case 'north':
+      return anchorPosition.top - targetPosition.height - POPUP_OFFSET > 0;
+    case 'south':
+      return anchorPosition.bottom + targetPosition.height + POPUP_OFFSET < window.innerHeight;
+    case 'east':
+      return anchorPosition.right + targetPosition.width + POPUP_OFFSET < window.innerWidth;
+    case 'west':
+      return anchorPosition.left - targetPosition.width - POPUP_OFFSET > 0;
+  }
+};
+
+const getOppositeDirection = direction => {
+  switch (direction) {
+    case 'north':
+      return 'south';
+    case 'south':
+      return 'north';
+    case 'east':
+      return 'west';
+    case 'west':
+      return 'east';
+  }
+};
+
+const getOppositeDirectionRendersOnScreen = ({ direction, anchorPosition, targetPosition }) =>
+  getDirectionRendersOnScreen({ direction: getOppositeDirection(direction), anchorPosition, targetPosition });
+
+const getRenderDirection = ({ direction, anchorPosition, targetPosition }) => {
+  const inputDirectionRendersOnScreen = getDirectionRendersOnScreen({ direction, anchorPosition, targetPosition });
+  const oppositeDirectionRendersOnScreen = getOppositeDirectionRendersOnScreen({
+    direction,
+    anchorPosition,
+    targetPosition,
+  });
+  return !inputDirectionRendersOnScreen && oppositeDirectionRendersOnScreen
+    ? getOppositeDirection(direction)
+    : direction;
+};
+
 const updateDirectionIfNeeded = (direction, anchorPosition, targetPosition) => {
   if (direction === 'north') {
     return anchorPosition.top - targetPosition.height - POPUP_OFFSET < 0 ? 'south' : 'north';
@@ -166,7 +199,8 @@ export const calculateHorizontalPositions = (
 ) => {
   const anchorPosition = getAnchorPositionValues(anchorEl);
   const targetPosition = getTargetPositionValues(targetEl);
-  const renderDirection = updateHorizontalDirectionIfNeeded(inputDirection, anchorPosition, targetPosition);
+
+  const renderDirection = getRenderDirection({ direction: inputDirection, anchorPosition, targetPosition });
   const renderPosition = updateHorizontalPositionIfNeeded(inputPosition, anchorPosition, targetPosition);
 
   let direction;
@@ -198,7 +232,7 @@ export const calculateVerticalPositions = (
   const anchorPosition = getAnchorPositionValues(anchorEl);
   const targetPosition = getTargetPositionValues(targetEl);
 
-  const renderDirection = updateDirectionIfNeeded(inputDirection, anchorPosition, targetPosition);
+  const renderDirection = getRenderDirection({ direction: inputDirection, anchorPosition, targetPosition });
   const renderPosition = updatePositionIfNeeded(inputPosition, anchorPosition, targetPosition);
 
   const top = getPositionTopValue({ renderDirection, anchorPosition, targetPosition });

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -32,20 +32,32 @@ const getTargetPositionValues = targetEl => {
 };
 
 // HORIZONTAL
-const positionMiddle = (anchorPosition, targetPosition) => ({
-  top: anchorPosition.middle - targetPosition.height / 2,
-  arrowTop: targetPosition.height / 2 - ARROW_OFFSET,
-});
+const getHorizontalDirectionPositionTopValue = ({
+  position,
+  anchorPosition,
+  targetPosition,
+  inputOffsetCorrection,
+}) => {
+  switch (position) {
+    case 'middle':
+      return anchorPosition.middle - targetPosition.height / 2;
+    case 'top':
+      return anchorPosition.top - POPUP_OFFSET * 0.75 - inputOffsetCorrection;
+    case 'bottom':
+      return anchorPosition.bottom - targetPosition.height + POPUP_OFFSET * 0.75 + inputOffsetCorrection;
+  }
+};
 
-const positionTop = (anchorPosition, targetPosition, offsetCorrection) => ({
-  top: anchorPosition.top - POPUP_OFFSET * 0.75 - offsetCorrection,
-  arrowTop: ARROW_OFFSET * 2.35,
-});
-
-const positionBottom = (anchorPosition, targetPosition, offsetCorrection) => ({
-  top: anchorPosition.bottom - targetPosition.height + POPUP_OFFSET * 0.75 + offsetCorrection,
-  arrowTop: targetPosition.height - ARROW_OFFSET * 4.5,
-});
+const getHorizontalDirectionArrowPositionTopValue = ({ position, targetPosition }) => {
+  switch (position) {
+    case 'middle':
+      return targetPosition.height / 2 - ARROW_OFFSET;
+    case 'top':
+      return ARROW_OFFSET * 2.35;
+    case 'bottom':
+      return targetPosition.height - ARROW_OFFSET * 4.5;
+  }
+};
 
 const directionWest = (anchorPosition, targetPosition) => ({
   left: anchorPosition.left - targetPosition.width - POPUP_OFFSET,
@@ -79,7 +91,7 @@ const updateHorizontalPositionIfNeeded = (position, anchorPosition, targetPositi
 };
 
 // VERTICAL
-const getPositionTopValue = ({ direction, anchorPosition, targetPosition }) =>
+const getVerticalDirectionPositionTopValue = ({ direction, anchorPosition, targetPosition }) =>
   direction === 'north'
     ? anchorPosition.Top - targetPosition.height - POPUP_OFFSET
     : anchorPosition.top + targetPosition.height + POPUP_OFFSET;
@@ -95,7 +107,7 @@ const getPositionLeftValue = ({ renderPosition, anchorPosition, targetPosition, 
   }
 };
 
-const getArrowPositionTopValue = ({ direction, targetPosition }) =>
+const getVerticalDirectionArrowPositionTopValue = ({ direction, targetPosition }) =>
   direction === 'north' ? targetPosition.height - ARROW_OFFSET : -ARROW_OFFSET;
 
 const getArrowPositionLeftValue = ({ renderPosition, targetPosition }) => {
@@ -192,16 +204,19 @@ export const calculateHorizontalPositions = (
     direction = directionEast(anchorPosition, targetPosition);
   }
 
-  let position;
-  if (renderPosition === 'top') {
-    position = positionTop(anchorPosition, targetPosition, inputOffsetCorrection);
-  } else if (renderPosition === 'middle') {
-    position = positionMiddle(anchorPosition, targetPosition);
-  } else {
-    position = positionBottom(anchorPosition, targetPosition, inputOffsetCorrection);
-  }
+  const top = getHorizontalDirectionPositionTopValue({
+    position: renderPosition,
+    anchorPosition,
+    targetPosition,
+    inputOffsetCorrection,
+  });
+  const arrowTop = getHorizontalDirectionArrowPositionTopValue({
+    position: renderPosition,
+    targetPosition,
+    inputOffsetCorrection,
+  });
 
-  return { ...direction, ...position };
+  return { ...direction, top, arrowTop };
 };
 
 export const calculateVerticalPositions = (
@@ -217,12 +232,8 @@ export const calculateVerticalPositions = (
   const renderDirection = getRenderDirection({ direction: inputDirection, anchorPosition, targetPosition });
   const renderPosition = updatePositionIfNeeded(inputPosition, anchorPosition, targetPosition);
 
-  const top = getPositionTopValue({ direction: renderDirection, anchorPosition, targetPosition });
-  const arrowTop = getArrowPositionTopValue({
-    renderDirection,
-    renderPosition,
-    targetPosition,
-  });
+  const top = getVerticalDirectionPositionTopValue({ direction: renderDirection, anchorPosition, targetPosition });
+  const arrowTop = getVerticalDirectionArrowPositionTopValue({ renderDirection, renderPosition, targetPosition });
 
   const left = getPositionLeftValue({
     renderPosition,

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -17,19 +17,17 @@ const getAnchorPositionValues = anchorEl => {
 };
 
 const getTargetPosition = targetEl => {
-  const targetRect = targetEl.getBoundingClientRect();
-  const width = Math.round(targetRect.width);
-  const height = Math.round(targetRect.height);
+  const { width, height } = targetEl.getBoundingClientRect();
 
   return {
+    width,
+    height,
     top: 0,
-    center: height / 2,
-    bottom: height,
     left: 0,
-    middle: width / 2,
     right: width,
-    width: width,
-    height: height,
+    bottom: height,
+    middle: width / 2,
+    center: height / 2,
   };
 };
 
@@ -89,6 +87,15 @@ const updateHorizontalPositionIfNeeded = (position, anchorPosition, targetPositi
 };
 
 // VERTICAL
+const getPositionTopValue = ({ renderDirection, anchorPosition, targetPosition }) => {
+  switch (renderDirection) {
+    case 'north':
+      return anchorPosition.top - targetPosition.height - POPUP_OFFSET;
+    case 'south':
+      return anchorPosition.top + anchorPosition.height + POPUP_OFFSET;
+  }
+};
+
 const getPositionLeftValue = ({ renderPosition, anchorPosition, targetPosition, inputOffsetCorrection }) => {
   switch (renderPosition) {
     case 'center':
@@ -97,6 +104,15 @@ const getPositionLeftValue = ({ renderPosition, anchorPosition, targetPosition, 
       return anchorPosition.left - inputOffsetCorrection;
     case 'right':
       return anchorPosition.right - targetPosition.width + inputOffsetCorrection;
+  }
+};
+
+const getArrowPositionTopValue = ({ renderDirection, renderPosition, targetPosition }) => {
+  switch (renderDirection) {
+    case 'north':
+      return targetPosition.height - ARROW_OFFSET;
+    case 'south':
+      return -ARROW_OFFSET;
   }
 };
 
@@ -110,16 +126,6 @@ const getArrowPositionLeftValue = ({ renderPosition, targetPosition }) => {
       return targetPosition.width - POPUP_OFFSET * 3;
   }
 };
-
-const directionNorth = (anchorPosition, targetPosition) => ({
-  top: anchorPosition.top - targetPosition.height - POPUP_OFFSET,
-  arrowTop: targetPosition.height - ARROW_OFFSET,
-});
-
-const directionSouth = anchorPosition => ({
-  top: anchorPosition.top + anchorPosition.height + POPUP_OFFSET,
-  arrowTop: -ARROW_OFFSET,
-});
 
 const updateDirectionIfNeeded = (direction, anchorPosition, targetPosition) => {
   if (direction === 'north') {
@@ -195,12 +201,12 @@ export const calculateVerticalPositions = (
   const renderDirection = updateDirectionIfNeeded(inputDirection, anchorPosition, targetPosition);
   const renderPosition = updatePositionIfNeeded(inputPosition, anchorPosition, targetPosition);
 
-  let direction;
-  if (renderDirection === 'north') {
-    direction = directionNorth(anchorPosition, targetPosition);
-  } else {
-    direction = directionSouth(anchorPosition, targetPosition);
-  }
+  const top = getPositionTopValue({ renderDirection, anchorPosition, targetPosition });
+  const arrowTop = getArrowPositionTopValue({
+    renderDirection,
+    renderPosition,
+    targetPosition,
+  });
 
   const left = getPositionLeftValue({
     renderPosition,
@@ -211,5 +217,5 @@ export const calculateVerticalPositions = (
 
   const arrowLeft = getArrowPositionLeftValue({ renderPosition, targetPosition });
 
-  return { ...direction, left, arrowLeft };
+  return { top, arrowTop, left, arrowLeft };
 };

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -1,16 +1,14 @@
 const ARROW_OFFSET = 7;
 const POPUP_OFFSET = 12;
 
-const getAnchorPositionValues = anchorEl => {
-  const { top, left, right, bottom, width, height } = anchorEl.getBoundingClientRect();
+const getElementPositionValues = element => {
+  const { top, left, right, bottom } = element.getBoundingClientRect();
 
   return {
     top,
     left,
-    width,
-    height,
-    right: right || left + width,
-    bottom: bottom || top + height,
+    right,
+    bottom,
     middle: top + (bottom - top) / 2,
     center: left + (right - left) / 2,
   };
@@ -124,7 +122,7 @@ const getHorizontalDirectionArrowPositionLeftValue = ({ direction, popoverDimens
 const getVerticalDirectionPositionTopValue = ({ direction, anchorPosition, popoverDimensions }) =>
   direction === 'north'
     ? anchorPosition.top - popoverDimensions.height - POPUP_OFFSET
-    : anchorPosition.top + anchorPosition.height + POPUP_OFFSET;
+    : anchorPosition.bottom + POPUP_OFFSET;
 
 const getVerticalDirectionPositionLeftValue = ({
   position,
@@ -297,7 +295,7 @@ export const calculatePositions = (
   inputPosition,
   inputOffsetCorrection,
 ) => {
-  const anchorPosition = getAnchorPositionValues(anchorEl);
+  const anchorPosition = getElementPositionValues(anchorEl);
   const popoverDimensions = getElementDimensions(popoverEl);
 
   const direction = getDirection({ direction: inputDirection, anchorPosition, popoverDimensions });

--- a/components/popover/theme.css
+++ b/components/popover/theme.css
@@ -52,9 +52,8 @@
   background: var(--color-white);
   border: 1px solid;
   border-radius: var(--popover-border-radius);
-  overflow: hidden;
+  overflow: auto;
   position: relative;
-  overflow-y: auto;
 }
 
 .neutral {

--- a/components/popover/theme.css
+++ b/components/popover/theme.css
@@ -54,6 +54,7 @@
   border-radius: var(--popover-border-radius);
   overflow: hidden;
   position: relative;
+  overflow-y: auto;
 }
 
 .neutral {

--- a/components/popover/theme.css
+++ b/components/popover/theme.css
@@ -27,7 +27,6 @@
   position: absolute;
   transition: opacity var(--animation-duration) var(--animation-curve-default);
   max-width: 50vw;
-  min-width: 300px;
 }
 
 .is-entering .popover {
@@ -54,7 +53,8 @@
   border-radius: var(--popover-border-radius);
   overflow: auto;
   position: relative;
-  min-height: var(--spacer-regular);
+  min-height: calc(2.4 * var(--unit));
+  min-width: calc(2.4 * var(--unit));
 }
 
 .neutral {

--- a/components/popover/theme.css
+++ b/components/popover/theme.css
@@ -54,6 +54,7 @@
   border-radius: var(--popover-border-radius);
   overflow: auto;
   position: relative;
+  min-height: var(--spacer-regular);
 }
 
 .neutral {

--- a/stories/popover.js
+++ b/stories/popover.js
@@ -47,6 +47,48 @@ const contentBoxWithSingleTextLine = (
       </Link>{' '}
       inside
     </TextBody>
+    <TextBody>
+      This is the popover content with a{' '}
+      <Link href="#" inherit={false}>
+        link
+      </Link>{' '}
+      inside
+    </TextBody>
+    <TextBody>
+      This is the popover content with a{' '}
+      <Link href="#" inherit={false}>
+        link
+      </Link>{' '}
+      inside
+    </TextBody>
+    <TextBody>
+      This is the popover content with a{' '}
+      <Link href="#" inherit={false}>
+        link
+      </Link>{' '}
+      inside
+    </TextBody>
+    <TextBody>
+      This is the popover content with a{' '}
+      <Link href="#" inherit={false}>
+        link
+      </Link>{' '}
+      inside
+    </TextBody>
+    <TextBody>
+      This is the popover content with a{' '}
+      <Link href="#" inherit={false}>
+        link
+      </Link>{' '}
+      inside
+    </TextBody>
+    <TextBody>
+      This is the popover content with a{' '}
+      <Link href="#" inherit={false}>
+        link
+      </Link>{' '}
+      inside
+    </TextBody>
   </Box>
 );
 
@@ -72,7 +114,7 @@ storiesOf('Popover', module)
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
-          lockScroll={boolean('Lock scroll', false)}
+          lockScroll={boolean('Lock scroll', true)}
           offsetCorrection={number('Offset correction', 0)}
         >
           {contentBoxWithSingleTextLine}
@@ -93,7 +135,7 @@ storiesOf('Popover', module)
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
-          lockScroll={boolean('Lock scroll', false)}
+          lockScroll={boolean('Lock scroll', true)}
           offsetCorrection={number('Offset correction', 0)}
         >
           {contentBoxWithSingleTextLine}
@@ -114,7 +156,7 @@ storiesOf('Popover', module)
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
-          lockScroll={boolean('Lock scroll', false)}
+          lockScroll={boolean('Lock scroll', true)}
           offsetCorrection={number('Offset correction', 0)}
         >
           <Banner fullWidth>
@@ -138,7 +180,7 @@ storiesOf('Popover', module)
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
-          lockScroll={boolean('Lock scroll', false)}
+          lockScroll={boolean('Lock scroll', true)}
           offsetCorrection={number('Offset correction', 0)}
         >
           <Banner color="neutral" fullWidth>
@@ -163,7 +205,7 @@ storiesOf('Popover', module)
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
-          lockScroll={boolean('Lock scroll', false)}
+          lockScroll={boolean('Lock scroll', true)}
           offsetCorrection={number('Offset correction', 0)}
         >
           <Banner onClose={handleCloseClick} fullWidth>
@@ -187,7 +229,7 @@ storiesOf('Popover', module)
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
-          lockScroll={boolean('Lock scroll', false)}
+          lockScroll={boolean('Lock scroll', true)}
           offsetCorrection={number('Offset correction', 0)}
         >
           {contentBoxWithSingleTextLine}
@@ -212,7 +254,7 @@ storiesOf('Popover', module)
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
-          lockScroll={boolean('Lock scroll', false)}
+          lockScroll={boolean('Lock scroll', true)}
           offsetCorrection={number('Offset correction', 0)}
         >
           <Box padding={4}>
@@ -239,7 +281,7 @@ storiesOf('Popover', module)
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
-          lockScroll={boolean('Lock scroll', false)}
+          lockScroll={boolean('Lock scroll', true)}
           offsetCorrection={number('Offset correction', 0)}
         >
           <Box padding={4}>

--- a/stories/popover.js
+++ b/stories/popover.js
@@ -72,6 +72,7 @@ storiesOf('Popover', module)
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
+          lockScroll={boolean('Lock scroll', false)}
           offsetCorrection={number('Offset correction', 0)}
         >
           {contentBoxWithSingleTextLine}

--- a/stories/popover.js
+++ b/stories/popover.js
@@ -198,27 +198,6 @@ storiesOf('Popover', module)
       </State>
     </Box>
   ))
-  .add('with dark backdrop', () => (
-    <Box>
-      <Button onClick={handleButtonClick} label="Open a Popover with dark backdrop" />
-      <State store={store}>
-        <PopoverVertical
-          active={false}
-          backdrop="dark"
-          color={select('Color', colors, 'neutral')}
-          direction={select('Direction', verticalDirections, 'south')}
-          position={select('Position', verticalPositions, 'center')}
-          onEscKeyDown={handleCloseClick}
-          onOverlayClick={handleCloseClick}
-          tint={select('Tint', tints, 'lightest')}
-          lockScroll={boolean('Lock scroll', false)}
-          offsetCorrection={number('Offset correction', 0)}
-        >
-          {contentBoxWithSingleTextLine}
-        </PopoverVertical>
-      </State>
-    </Box>
-  ))
   .add('experiment 1', () => (
     <Box>
       <Button onClick={handleButtonClick} label="Open a experimental Popover" />

--- a/stories/popover.js
+++ b/stories/popover.js
@@ -16,7 +16,7 @@ import {
   TextBody,
   TextSmall,
 } from '../components';
-import { withKnobs, select } from '@storybook/addon-knobs/react';
+import { withKnobs, select, boolean, number } from '@storybook/addon-knobs/react';
 
 const store = new Store({
   active: false,
@@ -24,6 +24,11 @@ const store = new Store({
 
 const colors = ['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'teal'];
 const tints = ['lightest', 'light', 'normal', 'dark', 'darkest'];
+const backdrops = ['transparent', 'dark'];
+const horizontalDirections = ['east', 'west'];
+const verticalDirections = ['north', 'south'];
+const horizontalPositions = ['top', 'middle', 'bottom'];
+const verticalPositions = ['left', 'center', 'right'];
 
 const handleButtonClick = event => {
   store.set({ anchorEl: event.currentTarget, active: true });
@@ -60,13 +65,14 @@ storiesOf('Popover', module)
       <State store={store}>
         <PopoverHorizontal
           active={false}
-          backdrop="transparent"
+          backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
-          direction="west"
-          position="middle"
+          direction={select('Direction', horizontalDirections, 'west')}
+          position={select('Position', horizontalPositions, 'middle')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
+          offsetCorrection={number('Offset correction', 0)}
         >
           {contentBoxWithSingleTextLine}
         </PopoverHorizontal>
@@ -79,13 +85,15 @@ storiesOf('Popover', module)
       <State store={store}>
         <PopoverVertical
           active={false}
-          backdrop="transparent"
+          backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
-          direction="south"
-          position="center"
+          direction={select('Direction', verticalDirections, 'south')}
+          position={select('Position', verticalPositions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
+          lockScroll={boolean('Lock scroll', false)}
+          offsetCorrection={number('Offset correction', 0)}
         >
           {contentBoxWithSingleTextLine}
         </PopoverVertical>
@@ -98,13 +106,15 @@ storiesOf('Popover', module)
       <State store={store}>
         <PopoverVertical
           active={false}
-          backdrop="transparent"
+          backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
-          direction="south"
-          position="center"
+          direction={select('Direction', verticalDirections, 'south')}
+          position={select('Position', verticalPositions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
+          lockScroll={boolean('Lock scroll', false)}
+          offsetCorrection={number('Offset correction', 0)}
         >
           <Banner fullWidth>
             <Heading3>Popover Title</Heading3>
@@ -120,13 +130,15 @@ storiesOf('Popover', module)
       <State store={store}>
         <PopoverVertical
           active={false}
-          backdrop="transparent"
+          backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
-          direction="south"
-          position="center"
+          direction={select('Direction', verticalDirections, 'south')}
+          position={select('Position', verticalPositions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
+          lockScroll={boolean('Lock scroll', false)}
+          offsetCorrection={number('Offset correction', 0)}
         >
           <Banner color="neutral" fullWidth>
             <Heading3>Popover Title</Heading3>
@@ -143,13 +155,15 @@ storiesOf('Popover', module)
       <State store={store}>
         <PopoverVertical
           active={false}
-          backdrop="transparent"
+          backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
           direction="south"
-          position="center"
+          position={select('Position', verticalPositions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
+          lockScroll={boolean('Lock scroll', false)}
+          offsetCorrection={number('Offset correction', 0)}
         >
           <Banner onClose={handleCloseClick} fullWidth>
             <Heading3>I am a heading 3</Heading3>
@@ -165,13 +179,15 @@ storiesOf('Popover', module)
       <State store={store}>
         <PopoverVertical
           active={false}
-          backdrop="transparent"
+          backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
-          direction="south"
-          position="center"
+          direction={select('Direction', verticalDirections, 'south')}
+          position={select('Position', verticalPositions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
+          lockScroll={boolean('Lock scroll', false)}
+          offsetCorrection={number('Offset correction', 0)}
         >
           {contentBoxWithSingleTextLine}
           <ButtonGroup justifyContent="flex-end" padding={4}>
@@ -190,11 +206,13 @@ storiesOf('Popover', module)
           active={false}
           backdrop="dark"
           color={select('Color', colors, 'neutral')}
-          direction="south"
-          position="center"
+          direction={select('Direction', verticalDirections, 'south')}
+          position={select('Position', verticalPositions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
+          lockScroll={boolean('Lock scroll', false)}
+          offsetCorrection={number('Offset correction', 0)}
         >
           {contentBoxWithSingleTextLine}
         </PopoverVertical>
@@ -207,13 +225,15 @@ storiesOf('Popover', module)
       <State store={store}>
         <PopoverVertical
           active={false}
-          backdrop="transparent"
+          backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
-          direction="south"
-          position="center"
+          direction={select('Direction', verticalDirections, 'south')}
+          position={select('Position', verticalPositions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
+          lockScroll={boolean('Lock scroll', false)}
+          offsetCorrection={number('Offset correction', 0)}
         >
           <Box padding={4}>
             <Heading3>I am a heading 3</Heading3>
@@ -232,13 +252,15 @@ storiesOf('Popover', module)
       <State store={store}>
         <PopoverVertical
           active={false}
-          backdrop="transparent"
+          backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
-          direction="south"
-          position="center"
+          direction={select('Direction', verticalDirections, 'south')}
+          position={select('Position', verticalPositions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
+          lockScroll={boolean('Lock scroll', false)}
+          offsetCorrection={number('Offset correction', 0)}
         >
           <Box padding={4}>
             <ul>


### PR DESCRIPTION
### Description

This PR refactors the [`Popover` component](https://components.teamleader.design/?knob-Locale=nl&knob-Size=medium&knob-Color=neutral&knob-Tint=lightest&selectedKind=Popover&selectedStory=vertical&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs).

And solves the issue #303: it now renders more accurately, by not blindingly choosing the opposite `direction`, if it would be rendered off-screen in the given one. 
In the last case, it chooses for the direction with the most space and if needed, it becomes vertically scrollable.

### Screenshots

In this example, the `direction` is set to `'south'`.

_When `Popover` fits in viewport, following the given `direction`:_
![screen shot 2018-09-03 at 18 01 25](https://user-images.githubusercontent.com/23736202/44995502-8888d900-afa3-11e8-82be-6f2561f8d018.png)

_When `Popover` does not fit in the viewport, following both the given and its opposite `direction` (and there is more space in the current direction):_
![screen shot 2018-09-03 at 18 01 37](https://user-images.githubusercontent.com/23736202/44995505-8aeb3300-afa3-11e8-8157-1489ec2b8e0d.png)

_When `Popover` does not fit in the viewport, following both the given and its opposite `direction` (and there's more space in the opposite direction):_
![screen shot 2018-09-03 at 18 01 51](https://user-images.githubusercontent.com/23736202/44995509-8cb4f680-afa3-11e8-890e-0f163a7ecf65.png)


### Breaking changes

None.
