### PR TITLE
Update Input

### DIFF
--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -111,15 +111,15 @@ export default class Input extends PureComponent {
   }
 
   renderInput() {
-    const { bold, max, min, step, type, ...others } = this.props;
+    const { bold, max, min, step, type, ...otherProps } = this.props;
     const { value } = this.state;
 
     const classNames = cx(theme['input'], {
       [theme['is-bold']]: bold,
     });
 
-    const propsWithoutBoxProps = omitBoxProps(others);
-    const restProps = omit(propsWithoutBoxProps, [
+    const otherPropsWithoutBoxProps = omitBoxProps(otherProps);
+    const restProps = omit(otherPropsWithoutBoxProps, [
       'className',
       'connectedLeft',
       'connectedRight',

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -297,8 +297,6 @@ Input.propTypes = {
   id: PropTypes.string,
   /** Boolean indicating whether the input should render as inverse. */
   inverse: PropTypes.bool,
-  /** The text string to use as input name */
-  name: PropTypes.string,
   max: PropTypes.number,
   min: PropTypes.number,
   /** Object to provide meta information for redux forms. */

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -305,8 +305,6 @@ Input.propTypes = {
   input: FieldInputPropTypes,
   /** Callback function that is fired when the component's value changes. */
   onChange: PropTypes.func,
-  /** Callback function that is fired when component is focused. */
-  onFocus: PropTypes.func,
   precision: PropTypes.number,
   /** Boolean indicating whether the input should render as read only. */
   readOnly: PropTypes.bool,

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -279,7 +279,7 @@ Input.propTypes = {
   autoFocus: PropTypes.bool,
   /** Boolean indicating whether the input text should render in bold. */
   bold: PropTypes.bool,
-  /** Sets a class name to give custom styles. */
+  /** Sets a class name for the wrapper to give custom styles. */
   className: PropTypes.string,
   connectedLeft: PropTypes.element,
   connectedRight: PropTypes.element,

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -303,8 +303,6 @@ Input.propTypes = {
   spinner: PropTypes.bool,
   /** Object to provide input information for redux forms. */
   input: FieldInputPropTypes,
-  /** Callback function that is fired when component is blurred. */
-  onBlur: PropTypes.func,
   /** Callback function that is fired when the component's value changes. */
   onChange: PropTypes.func,
   /** Callback function that is fired when component is focused. */

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -9,7 +9,7 @@ import {
 } from '@teamleader/ui-icons';
 import InputMetaPropTypes from './InputMetaPropTypes';
 import FieldInputPropTypes from './FieldInputPropTypes';
-import Box from '../box';
+import Box, { pickBoxProps } from '../box';
 import Button from '../button';
 import Counter from '../counter';
 import { TextSmall } from '../typography';
@@ -231,23 +231,7 @@ export default class Input extends PureComponent {
       [theme['has-error']]: this.hasError(),
     });
 
-    const rest = omit(others, [
-      'bold',
-      'id',
-      'helpText',
-      'max',
-      'meta',
-      'min',
-      'onBlur',
-      'onChange',
-      'onFocus',
-      'placeholder',
-      'precision',
-      'spinner',
-      'type',
-      'updateStep',
-      'value',
-    ]);
+    const rest = pickBoxProps(others);
 
     return (
       <Box className={classNames} {...rest}>

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -9,7 +9,7 @@ import {
 } from '@teamleader/ui-icons';
 import InputMetaPropTypes from './InputMetaPropTypes';
 import FieldInputPropTypes from './FieldInputPropTypes';
-import Box, { pickBoxProps } from '../box';
+import Box, { omitBoxProps, pickBoxProps } from '../box';
 import Button from '../button';
 import Counter from '../counter';
 import { TextSmall } from '../typography';
@@ -133,6 +133,26 @@ export default class Input extends PureComponent {
       [theme['is-bold']]: bold,
     });
 
+    const propsWithoutBoxProps = omitBoxProps(this.props);
+    const restProps = omit(propsWithoutBoxProps, [
+      'bold',
+      'className',
+      'connectedLeft',
+      'connectedRight',
+      'counter',
+      'helpText',
+      'icon',
+      'iconPlacement',
+      'input',
+      'inverse',
+      'meta',
+      'onChange',
+      'precision',
+      'size',
+      'spinner',
+      'value',
+    ]);
+
     const numberTypeProps = {
       max,
       min,
@@ -141,18 +161,11 @@ export default class Input extends PureComponent {
     };
 
     const props = {
-      autoFocus,
       className: classNames,
-      disabled: disabled,
-      id,
-      name,
-      onBlur: onBlur,
       onChange: this.handleChange,
-      onFocus: onFocus,
-      placeholder,
-      readOnly,
       type,
       value,
+      ...restProps,
       ...(type === 'number' && numberTypeProps),
     };
 

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -111,21 +111,7 @@ export default class Input extends PureComponent {
   }
 
   renderInput() {
-    const {
-      autoFocus,
-      bold,
-      disabled,
-      id,
-      name,
-      max,
-      min,
-      onBlur,
-      onFocus,
-      placeholder,
-      readOnly,
-      step,
-      type,
-    } = this.props;
+    const { bold, max, min, step, type } = this.props;
 
     const { value } = this.state;
 

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -293,8 +293,6 @@ Input.propTypes = {
   icon: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
   /** The position of the icon inside the input. */
   iconPlacement: PropTypes.oneOf(['left', 'right']),
-  /** The text string to use as input identifier. */
-  id: PropTypes.string,
   /** Boolean indicating whether the input should render as inverse. */
   inverse: PropTypes.bool,
   max: PropTypes.number,

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -207,6 +207,7 @@ export default class Input extends PureComponent {
       size,
       spinner,
       readOnly,
+      type,
       ...others
     } = this.props;
 
@@ -219,7 +220,7 @@ export default class Input extends PureComponent {
         [theme['has-error']]: this.hasError(),
         [theme['has-connected-left']]: connectedLeft,
         [theme['has-connected-right']]: connectedRight,
-        [theme['has-spinner']]: spinner,
+        [theme['has-spinner']]: type === 'number' && spinner,
         [theme['is-inverse']]: inverse,
         [theme['is-disabled']]: disabled,
         [theme['is-read-only']]: readOnly,

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -112,6 +112,8 @@ export default class Input extends PureComponent {
 
   renderInput() {
     const { autoFocus, bold, disabled, id, max, min, onBlur, onFocus, placeholder, readOnly, step, type } = this.props;
+    const { value } = this.state;
+
     const classNames = cx(theme['input'], {
       [theme['is-bold']]: bold,
     });
@@ -133,7 +135,7 @@ export default class Input extends PureComponent {
       placeholder,
       readOnly,
       type,
-      value: type === 'number' && this.state.value ? this.formatNumber(this.state.value) : this.state.value,
+      value: type === 'number' && value ? this.formatNumber(value) : value,
       ...(type === 'number' && numberTypeProps),
     };
 

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -122,6 +122,7 @@ export default class Input extends PureComponent {
       max,
       min,
       step,
+      value: value && this.formatNumber(value),
     };
 
     const props = {
@@ -135,7 +136,7 @@ export default class Input extends PureComponent {
       placeholder,
       readOnly,
       type,
-      value: type === 'number' && value ? this.formatNumber(value) : value,
+      value,
       ...(type === 'number' && numberTypeProps),
     };
 

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -309,8 +309,6 @@ Input.propTypes = {
   onChange: PropTypes.func,
   /** Callback function that is fired when component is focused. */
   onFocus: PropTypes.func,
-  /** The text string to use as placeholder. */
-  placeholder: PropTypes.string,
   precision: PropTypes.number,
   /** Boolean indicating whether the input should render as read only. */
   readOnly: PropTypes.bool,
@@ -328,7 +326,6 @@ Input.defaultProps = {
   iconPlacement: 'left',
   inverse: false,
   disabled: false,
-  placeholder: '',
   precision: null,
   min: Number.MIN_SAFE_INTEGER,
   max: Number.MAX_SAFE_INTEGER,

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -111,7 +111,22 @@ export default class Input extends PureComponent {
   }
 
   renderInput() {
-    const { autoFocus, bold, disabled, id, max, min, onBlur, onFocus, placeholder, readOnly, step, type } = this.props;
+    const {
+      autoFocus,
+      bold,
+      disabled,
+      id,
+      name,
+      max,
+      min,
+      onBlur,
+      onFocus,
+      placeholder,
+      readOnly,
+      step,
+      type,
+    } = this.props;
+
     const { value } = this.state;
 
     const classNames = cx(theme['input'], {
@@ -130,6 +145,7 @@ export default class Input extends PureComponent {
       className: classNames,
       disabled: disabled,
       id,
+      name,
       onBlur: onBlur,
       onChange: this.handleChange,
       onFocus: onFocus,
@@ -284,6 +300,8 @@ Input.propTypes = {
   id: PropTypes.string,
   /** Boolean indicating whether the input should render as inverse. */
   inverse: PropTypes.bool,
+  /** The text string to use as input name */
+  name: PropTypes.string,
   max: PropTypes.number,
   min: PropTypes.number,
   /** Object to provide meta information for redux forms. */

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -276,7 +276,6 @@ export default class Input extends PureComponent {
 }
 
 Input.propTypes = {
-  autoFocus: PropTypes.bool,
   /** Boolean indicating whether the input text should render in bold. */
   bold: PropTypes.bool,
   /** Sets a class name for the wrapper to give custom styles. */

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -116,21 +116,25 @@ export default class Input extends PureComponent {
       [theme['is-bold']]: bold,
     });
 
+    const numberTypeProps = {
+      max,
+      min,
+      step,
+    };
+
     const props = {
       autoFocus,
       className: classNames,
       disabled: disabled,
       id,
-      max,
-      min,
       onBlur: onBlur,
       onChange: this.handleChange,
       onFocus: onFocus,
       placeholder,
       readOnly,
-      step,
       type,
       value: type === 'number' && this.state.value ? this.formatNumber(this.state.value) : this.state.value,
+      ...(type === 'number' && numberTypeProps),
     };
 
     return <input {...props} />;

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -111,17 +111,15 @@ export default class Input extends PureComponent {
   }
 
   renderInput() {
-    const { bold, max, min, step, type } = this.props;
-
+    const { bold, max, min, step, type, ...others } = this.props;
     const { value } = this.state;
 
     const classNames = cx(theme['input'], {
       [theme['is-bold']]: bold,
     });
 
-    const propsWithoutBoxProps = omitBoxProps(this.props);
+    const propsWithoutBoxProps = omitBoxProps(others);
     const restProps = omit(propsWithoutBoxProps, [
-      'bold',
       'className',
       'connectedLeft',
       'connectedRight',


### PR DESCRIPTION
### Description

This PR:
* makes sure we only render `number type attributes` to `number type input tags`;
* only applies `has-spinner` css class when input type is number;
* allows the `name` and any other input attributes to be rendered on input tags;
* removes props that are not used in the component, they will be rendered by the restProps.

### Breaking changes

None.
