### PR TITLE
Add an Async select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `AsyncSelect`: A new select component that will load its options asynchronously and optionally paginate them.
+
 ### Changed
 
 ### Deprecated

--- a/components/index.js
+++ b/components/index.js
@@ -23,7 +23,7 @@ import Pagination from './pagination';
 import { PopoverHorizontal, PopoverVertical } from './popover';
 import { RadioButton, RadioGroup } from './radio';
 import Section from './section';
-import Select from './select';
+import Select, { AsyncSelect } from './select';
 import { Island, IslandGroup } from './island';
 import StatusBullet from './statusBullet';
 import StatusLabel from './statusLabel';
@@ -39,6 +39,7 @@ import ProgressTracker from './progressTracker';
 export {
   Avatar,
   AvatarStack,
+  AsyncSelect,
   Badge,
   Banner,
   Box,

--- a/components/select/AsyncSelect.js
+++ b/components/select/AsyncSelect.js
@@ -1,0 +1,168 @@
+import React, { PureComponent } from 'react';
+import omit from 'lodash.omit';
+import Select from './Select';
+import PropTypes from 'prop-types';
+
+class AsyncSelect extends PureComponent {
+  state = {
+    searchTerm: '',
+    pageNumber: 1,
+    options: [],
+    isLastPage: false,
+    loading: false,
+    cache: {},
+  };
+
+  componentDidMount() {
+    this.loadOptions();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.getPageSize() !== this.getPageSize(prevProps)) {
+      this.setState(
+        state => ({
+          ...state,
+          options: [],
+          cache: {},
+          pageNumber: 1,
+        }),
+        this.loadOptions,
+      );
+    }
+  }
+
+  handleInputChange = searchTerm => {
+    if (this.props.onInputChange) {
+      this.props.onInputChange(searchTerm);
+    }
+    if (searchTerm === this.state.searchTerm) {
+      return;
+    }
+    if (this.props.cacheOptions === true && this.state.cache[searchTerm]) {
+      return this.setState({
+        ...this.state.cache[searchTerm],
+        searchTerm,
+        loading: false,
+      });
+    }
+
+    this.setState(
+      {
+        options: [],
+        pageNumber: 1,
+        isLastPage: false,
+        searchTerm,
+      },
+      this.loadOptions,
+    );
+  };
+
+  invalidateCache() {
+    this.setState({
+      cache: {},
+    });
+  }
+
+  getPageSize(props = this.props) {
+    return props.pageSize || 10;
+  }
+
+  handleBlur = () => {
+    this.invalidateCache();
+  };
+
+  handleOptionsLoaded(options, cache) {
+    this.setState(state => {
+      const newOptions = state.options.concat(options);
+      const isLastPage = options.length < this.getPageSize();
+
+      return {
+        options: newOptions,
+        isLastPage,
+        loading: false,
+        cache:
+          cache !== true
+            ? {}
+            : {
+                ...state.cache,
+                [state.searchTerm]: {
+                  options: newOptions,
+                  isLastPage,
+                },
+              },
+      };
+    });
+  }
+
+  loadOptions = () => {
+    const { loadOptions, cacheOptions } = this.props;
+    const { pageNumber, searchTerm } = this.state;
+    const pageSize = this.getPageSize();
+
+    this.setState(
+      {
+        loading: true,
+      },
+      () => {
+        loadOptions(searchTerm, ...(this.props.paginate ? [pageSize, pageNumber] : [])).then(
+          options => {
+            if (
+              searchTerm !== this.state.searchTerm ||
+              pageSize !== this.getPageSize() ||
+              pageNumber !== this.state.pageNumber
+            ) {
+              return;
+            }
+            this.handleOptionsLoaded(options, cacheOptions);
+          },
+          () => {},
+        );
+      },
+    );
+  };
+
+  handleMenuScrollToBottom = () => {
+    if (this.props.onMenuScrollToBottom) {
+      this.props.onMenuScrollToBottom();
+    }
+    if (this.state.isLastPage || !this.props.paginate) {
+      return;
+    }
+
+    this.setState(
+      {
+        pageNumber: this.state.pageNumber + 1,
+      },
+      () => {
+        this.loadOptions();
+      },
+    );
+  };
+
+  render() {
+    const { loadOptions, ...restProps } = this.props;
+    const { options, loading } = this.state;
+    return (
+      <Select
+        {...omit(restProps, ['loadOptions', 'options'])}
+        isSearchable
+        isLoading={loading}
+        onMenuScrollToBottom={this.handleMenuScrollToBottom}
+        options={options}
+        onInputChange={this.handleInputChange}
+        onBlur={this.handleBlur}
+      />
+    );
+  }
+}
+
+AsyncSelect.propTypes = {
+  loadOptions: PropTypes.func.isRequired,
+  onMenuScrollToBottom: PropTypes.func,
+  onInputChange: PropTypes.func,
+  paginate: PropTypes.bool,
+  pageSize: PropTypes.number,
+  cacheOptions: PropTypes.bool,
+};
+
+export default AsyncSelect;

--- a/components/select/AsyncSelect.js
+++ b/components/select/AsyncSelect.js
@@ -18,7 +18,7 @@ class AsyncSelect extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.getPageSize() !== this.getPageSize(prevProps)) {
+    if (this.props.pageSize !== prevProps.pageSize) {
       this.setState(
         state => ({
           ...state,
@@ -63,10 +63,6 @@ class AsyncSelect extends PureComponent {
     });
   }
 
-  getPageSize(props = this.props) {
-    return props.pageSize || 10;
-  }
-
   handleBlur = () => {
     this.invalidateCache();
   };
@@ -74,7 +70,7 @@ class AsyncSelect extends PureComponent {
   handleOptionsLoaded(options, cache) {
     this.setState(state => {
       const newOptions = state.options.concat(options);
-      const isLastPage = options.length < this.getPageSize();
+      const isLastPage = options.length < this.props.pageSize;
 
       return {
         options: newOptions,
@@ -97,7 +93,7 @@ class AsyncSelect extends PureComponent {
   loadOptions = () => {
     const { loadOptions, cacheOptions } = this.props;
     const { pageNumber, searchTerm } = this.state;
-    const pageSize = this.getPageSize();
+    const pageSize = this.props.pageSize;
 
     this.setState(
       {
@@ -108,7 +104,7 @@ class AsyncSelect extends PureComponent {
           options => {
             if (
               searchTerm !== this.state.searchTerm ||
-              pageSize !== this.getPageSize() ||
+              pageSize !== this.props.pageSize ||
               pageNumber !== this.state.pageNumber
             ) {
               return;
@@ -163,6 +159,10 @@ AsyncSelect.propTypes = {
   paginate: PropTypes.bool,
   pageSize: PropTypes.number,
   cacheOptions: PropTypes.bool,
+};
+
+AsyncSelect.defaultProps = {
+  pageSize: 10,
 };
 
 export default AsyncSelect;

--- a/components/select/index.js
+++ b/components/select/index.js
@@ -1,3 +1,6 @@
 import Select from './Select';
+import AsyncSelect from './AsyncSelect';
+
+export { Select, AsyncSelect };
 
 export default Select;

--- a/stories/select.js
+++ b/stories/select.js
@@ -3,9 +3,9 @@ import PropTable from './components/propTable';
 import { storiesOf } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
 import { withInfo } from '@storybook/addon-info';
-import { withKnobs, boolean, select } from '@storybook/addon-knobs/react';
-import { Avatar, Box, Label, Select, TextBody } from '../components';
-import { customOptions, groupedOptions, options } from "../static/data/select";
+import { withKnobs, boolean, select, number } from '@storybook/addon-knobs/react';
+import { Avatar, Box, Label, Select, AsyncSelect, TextBody } from '../components';
+import { customOptions, groupedOptions, options } from '../static/data/select';
 
 const sizes = ['small', 'medium', 'large'];
 
@@ -99,4 +99,39 @@ storiesOf('Select', module)
         hideSelectedOptions={boolean('Hide selected options', true)}
       />
     </Label>
-  ));
+  ))
+  .add('Async', () => {
+    const loadOptions = (searchTerm, pageSize = 10, pageNumber = 1) => {
+      return new Promise(resolve => {
+        setTimeout(() => {
+          const options = [];
+          for (let i = 0; i < pageSize; i += 1) {
+            const optionNr = (pageNumber - 1) * pageSize + i + 1;
+            options.push({
+              value: `${searchTerm}${optionNr}`,
+              label: `${searchTerm} ${optionNr}`,
+            });
+          }
+          resolve(options);
+        }, 500);
+      });
+    };
+
+    return (
+      <AsyncSelect
+        loadOptions={loadOptions}
+        cacheOptions={boolean('cacheOptions', true)}
+        paginate={boolean('paginate', true)}
+        pageSize={number('pageSize', 10)}
+        closeMenuOnSelect={boolean('closeMenuOnSelectj', true)}
+        inverse={boolean('inverse', false)}
+        isClearable={boolean('isClearable', false)}
+        isDisabled={boolean('isDisabled', false)}
+        isMulti={boolean('isMulti', false)}
+        options={options}
+        placeholder="Select your favourite(s)"
+        size={select('size', sizes, 'medium')}
+        hideSelectedOptions={boolean('hideSelectedOptions', true)}
+      />
+    );
+  });


### PR DESCRIPTION
### Description

A new select component that will load its options asynchronously and optionally paginate them.

It will load its options by calling a function `loadOptions` which is passed through props. This function is called with the current query that the user has typed and optionally the pageSize and pageNumber if options are supposed to be paginated (also configurable through props).