### PR TITLE
Input: remove precision prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@
 
 ### Removed
 
-- [BREAKING] `Input`: removed `precision` prop due to buggy behavior.
+- [BREAKING] `Input`: removed `precision` prop due to buggy behavior. ([@driesd](https://github.com/driesd) in [#346](https://github.com/teamleadercrm/ui/pull/346))
 
 ### Fixed
 
+- `Input`: it's now possible to type either a dot or a comma in a number type input field ([@driesd](https://github.com/driesd) in [#346](https://github.com/teamleadercrm/ui/pull/346))
+- `Input`: fixed the buggy formatting behavior when typing into a number type input field ([@driesd](https://github.com/driesd) in [#346](https://github.com/teamleadercrm/ui/pull/346))
 - `LinkButton`: set the appropriate padding, when only containing an icon, so it displays as a square ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#341](https://github.com/teamleadercrm/ui/pull/341)).
 
 ## [0.12.1] - 2018-08-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Removed
 
+- [BREAKING] `Input`: removed `precision` prop due to buggy behavior.
+
 ### Fixed
 
 - `LinkButton`: set the appropriate padding, when only containing an icon, so it displays as a square ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#341](https://github.com/teamleadercrm/ui/pull/341)).

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -35,21 +35,18 @@ export default class Input extends PureComponent {
     return finalValue || '';
   }
 
-  static parseValue(value, { type, min, max, precision }) {
-    return type === 'number' ? Input.toNumber(value, min, max, precision) : value;
+  static parseValue(value, { type, min, max }) {
+    return type === 'number' ? Input.toNumber(value, min, max) : value;
   }
 
-  static toNumber(number, min, max, precision) {
+  static toNumber(number, min, max) {
     let float = parseFloat(number);
 
     if (isNaN(float) || !isFinite(float)) {
       float = 0;
     }
 
-    const baseExponent = Math.pow(10, precision === null ? 10 : precision);
-
     float = Math.min(Math.max(float, min), max);
-    float = Math.round(float * baseExponent) / baseExponent;
 
     return float;
   }
@@ -93,13 +90,9 @@ export default class Input extends PureComponent {
   }
 
   formatNumber(number) {
-    const { min, max, precision } = this.props;
+    const { min, max } = this.props;
 
-    let formattedNumber = Input.toNumber(number, min, max, precision);
-
-    if (precision !== null) {
-      formattedNumber = number.toFixed(precision);
-    }
+    let formattedNumber = Input.toNumber(number, min, max);
 
     return String(formattedNumber);
   }
@@ -131,7 +124,6 @@ export default class Input extends PureComponent {
       'inverse',
       'meta',
       'onChange',
-      'precision',
       'size',
       'spinner',
       'value',
@@ -304,7 +296,6 @@ Input.propTypes = {
   input: FieldInputPropTypes,
   /** Callback function that is fired when the component's value changes. */
   onChange: PropTypes.func,
-  precision: PropTypes.number,
   /** Boolean indicating whether the input should render as read only. */
   readOnly: PropTypes.bool,
   /** Size of the input element. */
@@ -321,7 +312,6 @@ Input.defaultProps = {
   iconPlacement: 'left',
   inverse: false,
   disabled: false,
-  precision: null,
   min: Number.MIN_SAFE_INTEGER,
   max: Number.MAX_SAFE_INTEGER,
   readOnly: false,

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -91,10 +91,7 @@ export default class Input extends PureComponent {
 
   formatNumber(number) {
     const { min, max } = this.props;
-
-    let formattedNumber = Input.toNumber(number, min, max);
-
-    return String(formattedNumber);
+    return String(Input.toNumber(number, min, max));
   }
 
   updateStep(event, n) {

--- a/stories/input.js
+++ b/stories/input.js
@@ -69,7 +69,6 @@ storiesOf('Inputs', module)
         readOnly={boolean('Read only', false)}
         min={number('Minimum', 0)}
         max={number('Maximum', 10)}
-        precision={number('Precision', 2)}
         spinner={boolean('Render spinner', true)}
         step={number('Step', 1)}
         {...props}


### PR DESCRIPTION
### Description

Due to buggy behaviour with number type input fields, we removed the `precision` prop.

This PR actually solves two issues:
* Can't type a dot in an Input with type=number ([TU-99](https://teamleader.atlassian.net/browse/TU-99))
* Difficult to change number input value with certain min/max combinations ([TU-107](https://teamleader.atlassian.net/browse/TU-107))

### Breaking changes

- We removed the `precision` prop
