### PR TITLE
Bugfix: extra icon margin on tooltipped buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `Input`: it's now possible to type either a dot or a comma in a number type input field ([@driesd](https://github.com/driesd) in [#346](https://github.com/teamleadercrm/ui/pull/346))
 - `Input`: fixed the buggy formatting behavior when typing into a number type input field ([@driesd](https://github.com/driesd) in [#346](https://github.com/teamleadercrm/ui/pull/346))
 - `LinkButton`: set the appropriate padding, when only containing an icon, so it displays as a square ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#341](https://github.com/teamleadercrm/ui/pull/341)).
+- `Button` & `LinkButton`: fixed the unwanted extra icon margin on tooltipped buttons ([@driesd](https://github.com/driesd) in [#348](https://github.com/teamleadercrm/ui/pull/348))
 
 ## [0.12.1] - 2018-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - `Input`: it's now possible to type either a dot or a comma in a number type input field ([@driesd](https://github.com/driesd) in [#346](https://github.com/teamleadercrm/ui/pull/346))
 - `Input`: fixed the buggy formatting behavior when typing into a number type input field ([@driesd](https://github.com/driesd) in [#346](https://github.com/teamleadercrm/ui/pull/346))
 - `LinkButton`: set the appropriate padding, when only containing an icon, so it displays as a square ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#341](https://github.com/teamleadercrm/ui/pull/341)).
-- `Button` & `LinkButton`: fixed the unwanted extra icon margin on tooltipped buttons ([@driesd](https://github.com/driesd) in [#348](https://github.com/teamleadercrm/ui/pull/348))
+- `Button` & `LinkButton`: fixed the unwanted extra icon margin on tooltipped buttons when only containing an icon ([@driesd](https://github.com/driesd) in [#348](https://github.com/teamleadercrm/ui/pull/348))
 
 ## [0.12.1] - 2018-08-21
 

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -48,7 +48,7 @@ class Button extends PureComponent {
       theme['button'],
       theme[level],
       {
-        [theme['has-icon-only']]: !label && !children,
+        [theme['has-icon-only']]: (!children && !label) || (Array.isArray(children) && !children[0] && !label),
         [theme['inverse']]: inverse && level === 'outline',
         [theme['is-disabled']]: disabled,
         [theme['is-full-width']]: fullWidth,
@@ -75,21 +75,21 @@ class Button extends PureComponent {
     return React.createElement(
       element,
       props,
-      icon && iconPlacement === 'left' ? icon : null,
-      label || children ? (
-        <span className={theme['children']}>
+      icon && iconPlacement === 'left' && icon,
+      (label || children) && (
+        <span>
           {label}
           {children}
         </span>
-      ) : null,
-      icon && iconPlacement === 'right' ? icon : null,
-      processing ? (
+      ),
+      icon && iconPlacement === 'right' && icon,
+      processing && (
         <LoadingSpinner
           className={theme['spinner']}
           color={this.getSpinnerColor()}
           size={size === 'small' ? 'small' : 'medium'}
         />
-      ) : null,
+      ),
     );
   }
 }

--- a/components/button/LinkButton.js
+++ b/components/button/LinkButton.js
@@ -24,7 +24,7 @@ class LinkButton extends PureComponent {
     const classNames = cx(
       theme['link-button'],
       {
-        [theme['has-icon-only']]: !label && !children,
+        [theme['has-icon-only']]: (!children && !label) || (Array.isArray(children) && !children[0] && !label),
         [theme['is-disabled']]: disabled,
         [theme['is-inverse']]: inverse,
         [theme[size]]: theme[size],
@@ -49,7 +49,7 @@ class LinkButton extends PureComponent {
       props,
       icon && iconPlacement === 'left' && icon,
       (label || children) && (
-        <span className={theme['children']}>
+        <span>
           {label}
           {children}
         </span>

--- a/components/button/theme.css
+++ b/components/button/theme.css
@@ -39,9 +39,11 @@
     pointer-events: none;
   }
 
-  * + .children,
-  .children + *:not(.spinner) {
-    margin-left: var(--button-icon-children-margin);
+  &:not(.has-icon-only) {
+    * + svg,
+    svg + *:not(.spinner) {
+      margin-left: var(--button-icon-children-margin);
+    }
   }
 
   &::-moz-focus-inner {


### PR DESCRIPTION
### Description

This PR prevents extra icon margin on `tooltipped` `Button` and `LinkButton` when only containing an icon.

#### Screenshot before this PR

![schermafdruk 2018-09-04 11 23 29](https://user-images.githubusercontent.com/5336831/45022615-f9c49c80-b034-11e8-84e7-35d6c3c9c6f2.png)

#### Screenshot after this PR

![schermafdruk 2018-09-04 11 21 55](https://user-images.githubusercontent.com/5336831/45022532-c97cfe00-b034-11e8-9cb5-a6a1167158c9.png)

### Breaking changes

None.
