### PR TITLE
Select: add a Box wrapper with boxProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `DatePicker`, `DatePickerInput`, `DatePickerRange` & `DatePickerInputRange`: added a Box wrapper with box props applied to it ([@driesd](https://github.com/driesd) in [#347](https://github.com/teamleadercrm/ui/pull/347))
 - `Input`: added `error` prop which replaces the old `meta.error`. ([@driesd](https://github.com/driesd) in [#349](https://github.com/teamleadercrm/ui/pull/349))
+- `Select`: added a Box wrapper with box props applied to it ([@driesd](https://github.com/driesd) in [#354](https://github.com/teamleadercrm/ui/pull/354))
 
 ### Changed
 

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -3,6 +3,7 @@ import ReactSelect from 'react-select';
 import PropTypes from 'prop-types';
 import omit from 'lodash.omit';
 import { IconChevronDownSmallOutline } from '@teamleader/ui-icons';
+import Box from '../box';
 import { Button } from '../button';
 import { colors } from './constants';
 import theme from './theme.css';
@@ -262,15 +263,17 @@ class Select extends PureComponent {
     const restProps = omit(otherProps, ['size', 'inverse']);
 
     return (
-      <ReactSelect
-        className={theme['select']}
-        components={{
-          DropdownIndicator: this.getDropDownIndicator(),
-          ...components,
-        }}
-        styles={this.getStyles()}
-        {...restProps}
-      />
+      <Box>
+        <ReactSelect
+          className={theme['select']}
+          components={{
+            DropdownIndicator: this.getDropDownIndicator(),
+            ...components,
+          }}
+          styles={this.getStyles()}
+          {...restProps}
+        />
+      </Box>
     );
   }
 }

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -259,7 +259,7 @@ class Select extends PureComponent {
 
   render() {
     const { components, ...otherProps } = this.props;
-    const rest = omit(otherProps, ['size', 'inverse']);
+    const restProps = omit(otherProps, ['size', 'inverse']);
 
     return (
       <ReactSelect
@@ -269,7 +269,7 @@ class Select extends PureComponent {
           ...components,
         }}
         styles={this.getStyles()}
-        {...rest}
+        {...restProps}
       />
     );
   }

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -3,7 +3,7 @@ import ReactSelect from 'react-select';
 import PropTypes from 'prop-types';
 import omit from 'lodash.omit';
 import { IconChevronDownSmallOutline } from '@teamleader/ui-icons';
-import Box, { pickBoxProps } from '../box';
+import Box, { omitBoxProps, pickBoxProps } from '../box';
 import { Button } from '../button';
 import { colors } from './constants';
 import theme from './theme.css';
@@ -262,7 +262,8 @@ class Select extends PureComponent {
     const { components, ...otherProps } = this.props;
 
     const boxProps = pickBoxProps(otherProps);
-    const restProps = omit(otherProps, ['size', 'inverse']);
+    const otherPropsWithoutBoxProps = omitBoxProps(otherProps);
+    const restProps = omit(otherPropsWithoutBoxProps, ['size', 'inverse']);
 
     return (
       <Box {...boxProps}>

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -258,8 +258,8 @@ class Select extends PureComponent {
   };
 
   render() {
-    const { components, ...others } = this.props;
-    const rest = omit(others, ['size', 'inverse']);
+    const { components, ...otherProps } = this.props;
+    const rest = omit(otherProps, ['size', 'inverse']);
 
     return (
       <ReactSelect

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -3,7 +3,7 @@ import ReactSelect from 'react-select';
 import PropTypes from 'prop-types';
 import omit from 'lodash.omit';
 import { IconChevronDownSmallOutline } from '@teamleader/ui-icons';
-import Box from '../box';
+import Box, { pickBoxProps } from '../box';
 import { Button } from '../button';
 import { colors } from './constants';
 import theme from './theme.css';
@@ -260,10 +260,12 @@ class Select extends PureComponent {
 
   render() {
     const { components, ...otherProps } = this.props;
+
+    const boxProps = pickBoxProps(otherProps);
     const restProps = omit(otherProps, ['size', 'inverse']);
 
     return (
-      <Box>
+      <Box {...boxProps}>
         <ReactSelect
           className={theme['select']}
           components={{


### PR DESCRIPTION
### Description

This PR makes it possible to apply `boxProps` to the `Select` component. It also makes sure these props won't be passed down to the child component.

#### Screenshot before this PR

![schermafdruk 2018-09-12 09 18 03](https://user-images.githubusercontent.com/5336831/45408509-d28d5100-b66c-11e8-8345-6bb70c40257c.png)

#### Screenshot after this PR

![schermafdruk 2018-09-12 09 17 37](https://user-images.githubusercontent.com/5336831/45408523-d91bc880-b66c-11e8-925a-182ba176c21c.png)

### Breaking changes

None.
