### PR TITLE
Datagrid: first and last cell extra padding

### DIFF
--- a/components/datagrid/theme.css
+++ b/components/datagrid/theme.css
@@ -18,11 +18,11 @@
   flex-direction: column;
 
   &:first-child .row .cell:first-child {
-    padding: var(--spacer-smaller) var(--spacer-small) var(--spacer-smaller) var(--spacer-medium);
+    padding-left: var(--spacer-medium);
   }
 
   &:last-child .row .cell:last-child {
-    padding: var(--spacer-smaller) var(--spacer-medium) var(--spacer-smaller) var(--spacer-small);
+    padding-right: var(--spacer-medium);
   }
 }
 

--- a/components/datagrid/theme.css
+++ b/components/datagrid/theme.css
@@ -20,6 +20,10 @@
   &:first-child .row .cell:first-child {
     padding: var(--spacer-smaller) var(--spacer-small) var(--spacer-smaller) var(--spacer-medium);
   }
+
+  &:last-child .row .cell:last-child {
+    padding: var(--spacer-smaller) var(--spacer-medium) var(--spacer-smaller) var(--spacer-small);
+  }
 }
 
 .row {

--- a/components/datagrid/theme.css
+++ b/components/datagrid/theme.css
@@ -16,6 +16,10 @@
 .section {
   display: flex;
   flex-direction: column;
+
+  &:first-child .row .cell:first-child {
+    padding: var(--spacer-smaller) var(--spacer-small) var(--spacer-smaller) var(--spacer-medium);
+  }
 }
 
 .row {


### PR DESCRIPTION
### Description

This PR doubles the paddings for:
* the left padding for every first cell in every row of the first section
* the right padding for every last cell in every row of the last section

#### Screenshot before this PR

![schermafdruk 2018-09-12 16 00 34](https://user-images.githubusercontent.com/5336831/45430176-11d79400-b6a5-11e8-9b0c-f138c80c861d.png)

![schermafdruk 2018-09-12 16 00 16](https://user-images.githubusercontent.com/5336831/45430182-156b1b00-b6a5-11e8-99ba-3754eee4e695.png)

#### Screenshot after this PR

![schermafdruk 2018-09-12 15 59 12](https://user-images.githubusercontent.com/5336831/45430192-1e5bec80-b6a5-11e8-8bd5-08d3f33c79f3.png)

![schermafdruk 2018-09-12 15 59 42](https://user-images.githubusercontent.com/5336831/45430196-21ef7380-b6a5-11e8-9a8b-a52c949f2aa8.png)

### Breaking changes

None.
