### PR TITLE
IslandGroup: apply box props to the Box wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `DatePicker`, `DatePickerInput`, `DatePickerRange` & `DatePickerInputRange`: added a Box wrapper with box props applied to it ([@driesd](https://github.com/driesd) in [#347](https://github.com/teamleadercrm/ui/pull/347))
 - `DatePickerInput` & `DatePickerInputRange`: added `error` prop which replaces the old `meta.error`. ([@driesd](https://github.com/driesd) in [#353](https://github.com/teamleadercrm/ui/pull/353))
 - `Input`: added `error` prop which replaces the old `meta.error`. ([@driesd](https://github.com/driesd) in [#349](https://github.com/teamleadercrm/ui/pull/349))
+- `IslandGroup`: applied box props to the Box wrapper ([@driesd](https://github.com/driesd) in [#357](https://github.com/teamleadercrm/ui/pull/357))
 - `Select`: added a Box wrapper with box props applied to it ([@driesd](https://github.com/driesd) in [#354](https://github.com/teamleadercrm/ui/pull/354))
 
 ### Changed

--- a/components/island/IslandGroup.js
+++ b/components/island/IslandGroup.js
@@ -1,21 +1,22 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import Box from '../box';
+import Box, { pickBoxProps } from '../box';
 import theme from './theme.css';
 import Island from './Island';
 import { elementIsDark } from '../utils/utils';
 
 class IslandGroup extends PureComponent {
   render() {
-    const { children, className, color, dark, size } = this.props;
+    const { children, className, color, dark, size, ...otherProps } = this.props;
 
+    const boxProps = pickBoxProps(otherProps);
     const isDark = elementIsDark(color, dark);
 
     const classNames = cx(theme['segmented'], theme['island'], theme[color], { [theme['dark']]: isDark }, className);
 
     return (
-      <Box className={classNames} padding={0}>
+      <Box {...boxProps} className={classNames} padding={0}>
         {React.Children.map(children, child => {
           return (
             <Island {...child.props} color={color} dark={isDark} size={size}>


### PR DESCRIPTION
### Description

This PR applies `boxProps` to the `Box` wrapper of our `IslandGroup`.

#### Screenshot before this PR

![schermafdruk 2018-09-13 13 14 35](https://user-images.githubusercontent.com/5336831/45485196-0349b500-b757-11e8-827c-34e30cf6a765.png)

#### Screenshot after this PR

![schermafdruk 2018-09-13 13 14 13](https://user-images.githubusercontent.com/5336831/45485210-0d6bb380-b757-11e8-8b31-e272559c0afb.png)

### Breaking changes

None.
