### PR TITLE
IslandGroup: vertical segmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `DatePickerInput` & `DatePickerInputRange`: added `error` prop which replaces the old `meta.error`. ([@driesd](https://github.com/driesd) in [#353](https://github.com/teamleadercrm/ui/pull/353))
 - `Input`: added `error` prop which replaces the old `meta.error`. ([@driesd](https://github.com/driesd) in [#349](https://github.com/teamleadercrm/ui/pull/349))
 - `IslandGroup`: applied box props to the Box wrapper ([@driesd](https://github.com/driesd) in [#357](https://github.com/teamleadercrm/ui/pull/357))
+- `IslandGroup`: added `direction` prop for vertical `Island` segmentation ([@driesd](https://github.com/driesd) in [#358](https://github.com/teamleadercrm/ui/pull/358))
 - `Select`: added a Box wrapper with box props applied to it ([@driesd](https://github.com/driesd) in [#354](https://github.com/teamleadercrm/ui/pull/354))
 
 ### Changed

--- a/components/island/IslandGroup.js
+++ b/components/island/IslandGroup.js
@@ -8,12 +8,21 @@ import { elementIsDark } from '../utils/utils';
 
 class IslandGroup extends PureComponent {
   render() {
-    const { children, className, color, dark, size, ...otherProps } = this.props;
+    const { children, className, color, dark, direction, size, ...otherProps } = this.props;
 
     const boxProps = pickBoxProps(otherProps);
     const isDark = elementIsDark(color, dark);
 
-    const classNames = cx(theme['segmented'], theme['island'], theme[color], { [theme['dark']]: isDark }, className);
+    const classNames = cx(
+      theme[`direction-${direction}`],
+      theme['island'],
+      theme['segmented'],
+      theme[color],
+      {
+        [theme['dark']]: isDark,
+      },
+      className,
+    );
 
     return (
       <Box {...boxProps} className={classNames} padding={0}>
@@ -34,11 +43,13 @@ IslandGroup.propTypes = {
   className: PropTypes.string,
   color: PropTypes.oneOf(['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'white']),
   dark: PropTypes.bool,
+  direction: PropTypes.oneOf(['horizontal', 'vertical']),
   size: PropTypes.oneOf(['small', 'medium', 'large']),
 };
 
 IslandGroup.defaultProps = {
   color: 'white',
+  direction: 'horizontal',
 };
 
 export default IslandGroup;

--- a/components/island/theme.css
+++ b/components/island/theme.css
@@ -63,14 +63,11 @@
 .segmented {
   align-items: stretch;
   display: flex;
-  flex-direction: row;
   justify-content: center;
   text-align: center;
 
   .island {
     align-items: center;
-    border-top: 0;
-    border-bottom: 0;
     display: flex;
     flex: 1;
     flex-direction: column;
@@ -80,6 +77,15 @@
     &:not(:last-child) {
       border-radius: 0;
     }
+  }
+}
+
+.direction-horizontal {
+  flex-direction: row;
+
+  .island {
+    border-top: 0;
+    border-bottom: 0;
 
     &:not(:first-child) {
       border-right: 0;
@@ -94,6 +100,30 @@
     }
     &:last-child {
       border-radius: 0 var(--border-radius) var(--border-radius) 0;
+    }
+  }
+}
+
+.direction-vertical {
+  flex-direction: column;
+
+  .island {
+    border-left: 0;
+    border-right: 0;
+
+    &:not(:first-child) {
+      border-bottom: 0;
+    }
+
+    &:not(:last-child) {
+      border-top: 0;
+    }
+
+    &:first-child {
+      border-radius: var(--border-radius) var(--border-radius) 0 0;
+    }
+    &:last-child {
+      border-radius: 0 0 var(--border-radius) var(--border-radius);
     }
   }
 }

--- a/stories/island.js
+++ b/stories/island.js
@@ -12,6 +12,7 @@ import {
 } from '@teamleader/ui-illustrations';
 
 const colors = ['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'white'];
+const directions = ['horizontal', 'vertical'];
 const sizes = ['small', 'medium', 'large'];
 
 storiesOf('Island', module)
@@ -42,6 +43,7 @@ storiesOf('Island', module)
     <IslandGroup
       dark={boolean('Dark', false)}
       color={select('Color', colors, 'white')}
+      direction={select('Direction', directions, 'horizontal')}
       size={select('Size', sizes, 'medium')}
     >
       <Island>


### PR DESCRIPTION
### Description

This PR introduces the `direction` prop for our `IslandGroup` component. It enables vertical segmentation for multiple `Island` components.

#### Screenshot before this PR

![schermafdruk 2018-09-13 14 46 09](https://user-images.githubusercontent.com/5336831/45489297-35154880-b764-11e8-9026-f390e0a5a5f0.png)

#### Screenshot after this PR

![schermafdruk 2018-09-13 14 47 48](https://user-images.githubusercontent.com/5336831/45489279-2b8be080-b764-11e8-8191-34b6170cc4ab.png)

### Breaking changes

None.
