### PR TITLE
Select: error & help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Select`: added `error` & `helpText` props which renders an error or help text below the input field. ([@driesd](https://github.com/driesd) in [#359](https://github.com/teamleadercrm/ui/pull/359))
+
 ### Changed
 
 ### Deprecated

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -41,10 +41,16 @@ class Select extends PureComponent {
         ...commonStyles,
         backgroundColor: isDisabled ? colors.TEAL_DARK : colors.TEAL,
         '&:hover': {
-          borderColor: colors.TEAL_LIGHT,
+          borderColor: error ? colors.RUBY_LIGHT : colors.TEAL_LIGHT,
         },
-        borderColor: isFocused ? colors.TEAL_LIGHT : isDisabled ? colors.TEAL_DARK : colors.TEAL,
-        boxShadow: isFocused ? `0 0 0 1px ${colors.TEAL_LIGHT}` : 'none',
+        borderColor: error
+          ? colors.RUBY_LIGHT
+          : isFocused
+            ? colors.TEAL_LIGHT
+            : isDisabled
+              ? colors.TEAL_DARK
+              : colors.TEAL,
+        boxShadow: error ? `0 0 0 1px ${colors.RUBY_LIGHT}` : isFocused ? `0 0 0 1px ${colors.TEAL_LIGHT}` : 'none',
       };
     }
 

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -29,7 +29,7 @@ class Select extends PureComponent {
   };
 
   getControlStyles = (base, { isDisabled, isFocused }) => {
-    const { inverse, size } = this.props;
+    const { error, inverse, size } = this.props;
 
     const commonStyles = {
       ...base,
@@ -52,10 +52,16 @@ class Select extends PureComponent {
       ...commonStyles,
       backgroundColor: isDisabled ? colors.NEUTRAL : colors.NEUTRAL_LIGHTEST,
       '&:hover': {
-        borderColor: colors.NEUTRAL_DARKEST,
+        borderColor: error ? colors.RUBY_DARK : colors.NEUTRAL_DARKEST,
       },
-      borderColor: isFocused ? colors.NEUTRAL_DARKEST : isDisabled ? colors.NEUTRAL : colors.NEUTRAL_DARK,
-      boxShadow: isFocused ? `0 0 0 1px ${colors.NEUTRAL_DARKEST}` : 'none',
+      borderColor: error
+        ? colors.RUBY_DARK
+        : isFocused
+          ? colors.NEUTRAL_DARKEST
+          : isDisabled
+            ? colors.NEUTRAL
+            : colors.NEUTRAL_DARK,
+      boxShadow: error ? `0 0 0 1px ${colors.RUBY_DARK}` : isFocused ? `0 0 0 1px ${colors.NEUTRAL_DARKEST}` : 'none',
     };
   };
 

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -284,6 +284,8 @@ class Select extends PureComponent {
 Select.propTypes = {
   /** Override default components with your own. Pass an object with correct the key and its replacing component */
   components: PropTypes.object,
+  /** The text string/element to use as error message below the input. */
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   /** Boolean indicating whether the select should render as inverse. */
   inverse: PropTypes.bool,
   /** Size of the input element. */

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import ReactSelect from 'react-select';
 import PropTypes from 'prop-types';
 import omit from 'lodash.omit';
-import { IconChevronDownSmallOutline } from '@teamleader/ui-icons';
+import { IconChevronDownSmallOutline, IconWarningBadgedSmallFilled } from '@teamleader/ui-icons';
 import Box, { omitBoxProps, pickBoxProps } from '../box';
 import { Button } from '../button';
 import { TextSmall } from '../typography';
@@ -271,8 +271,21 @@ class Select extends PureComponent {
     }
   }
 
+  renderValidationMessage() {
+    return (
+      <TextSmall className={theme['validation-text']} marginTop={2} display="flex">
+        <Box element="span" className={theme['validation-icon']}>
+          <IconWarningBadgedSmallFilled />
+        </Box>
+        <Box element="span" marginLeft={1}>
+          {this.props.error}
+        </Box>
+      </TextSmall>
+    );
+  }
+
   render() {
-    const { components, ...otherProps } = this.props;
+    const { components, error, ...otherProps } = this.props;
 
     const boxProps = pickBoxProps(otherProps);
     const otherPropsWithoutBoxProps = omitBoxProps(otherProps);
@@ -289,7 +302,7 @@ class Select extends PureComponent {
           styles={this.getStyles()}
           {...restProps}
         />
-        {this.renderHelpText()}
+        {error ? this.renderValidationMessage() : this.renderHelpText()}
       </Box>
     );
   }

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -5,6 +5,7 @@ import omit from 'lodash.omit';
 import { IconChevronDownSmallOutline } from '@teamleader/ui-icons';
 import Box, { omitBoxProps, pickBoxProps } from '../box';
 import { Button } from '../button';
+import { TextSmall } from '../typography';
 import { colors } from './constants';
 import theme from './theme.css';
 
@@ -258,6 +259,18 @@ class Select extends PureComponent {
     );
   };
 
+  renderHelpText() {
+    const { helpText, inverse } = this.props;
+
+    if (helpText) {
+      return (
+        <TextSmall color={inverse ? 'white' : 'neutral'} marginTop={1} soft>
+          {helpText}
+        </TextSmall>
+      );
+    }
+  }
+
   render() {
     const { components, ...otherProps } = this.props;
 
@@ -276,6 +289,7 @@ class Select extends PureComponent {
           styles={this.getStyles()}
           {...restProps}
         />
+        {this.renderHelpText()}
       </Box>
     );
   }

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -286,6 +286,8 @@ Select.propTypes = {
   components: PropTypes.object,
   /** The text string/element to use as error message below the input. */
   error: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  /** The text string to use as help text below the input. */
+  helpText: PropTypes.string,
   /** Boolean indicating whether the select should render as inverse. */
   inverse: PropTypes.bool,
   /** Size of the input element. */

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -8,6 +8,7 @@ import { Button } from '../button';
 import { TextSmall } from '../typography';
 import { colors } from './constants';
 import theme from './theme.css';
+import cx from 'classnames';
 
 class Select extends PureComponent {
   getClearIndicatorStyles = base => {
@@ -285,14 +286,19 @@ class Select extends PureComponent {
   }
 
   render() {
-    const { components, error, ...otherProps } = this.props;
+    const { components, error, inverse, ...otherProps } = this.props;
 
     const boxProps = pickBoxProps(otherProps);
     const otherPropsWithoutBoxProps = omitBoxProps(otherProps);
-    const restProps = omit(otherPropsWithoutBoxProps, ['size', 'inverse']);
+    const restProps = omit(otherPropsWithoutBoxProps, ['size']);
+
+    const wrapperClassnames = cx({
+      [theme['has-error']]: error,
+      [theme['is-inverse']]: inverse,
+    });
 
     return (
-      <Box {...boxProps}>
+      <Box className={wrapperClassnames} {...boxProps}>
         <ReactSelect
           className={theme['select']}
           components={{

--- a/components/select/constants.js
+++ b/components/select/constants.js
@@ -4,6 +4,7 @@ export const colors = {
   NEUTRAL: '#e4e4e6',
   NEUTRAL_DARK: '#c0c0c4',
   NEUTRAL_DARKEST: '#82828c',
+  RUBY_DARK: '#e84b17',
   TEAL_LIGHTEST: '#e1ecfa',
   TEAL_LIGHT: '#c1cede',
   TEAL: '#64788f',

--- a/components/select/constants.js
+++ b/components/select/constants.js
@@ -4,6 +4,7 @@ export const colors = {
   NEUTRAL: '#e4e4e6',
   NEUTRAL_DARK: '#c0c0c4',
   NEUTRAL_DARKEST: '#82828c',
+  RUBY_LIGHT: '#ffbca6',
   RUBY_DARK: '#e84b17',
   TEAL_LIGHTEST: '#e1ecfa',
   TEAL_LIGHT: '#c1cede',

--- a/components/select/theme.css
+++ b/components/select/theme.css
@@ -15,3 +15,17 @@
   border-radius: 0 4px 4px 0;
   min-height: 100%;
 }
+
+.validation-icon {
+  margin-top: -1px;
+}
+
+.has-error {
+  &:not(.is-inverse) .validation-text {
+    color: var(--color-ruby-dark);
+  }
+
+  &.is-inverse .validation-text {
+    color: var(--color-ruby-light);
+  }
+}


### PR DESCRIPTION
### Description

This PR implements the `error` & `helpText` prop for the `Select` component, which renders the correct message below the input field.

#### Screenshot before this PR

![schermafdruk 2018-09-14 11 51 03](https://user-images.githubusercontent.com/5336831/45543313-8f6de200-b814-11e8-9639-4a61311eade7.png)

#### Screenshot after this PR

![schermafdruk 2018-09-14 11 50 01](https://user-images.githubusercontent.com/5336831/45543329-94cb2c80-b814-11e8-9320-f479bf929705.png)

![schermafdruk 2018-09-14 11 49 32](https://user-images.githubusercontent.com/5336831/45543334-97c61d00-b814-11e8-8546-2c71ec417e21.png)

### Breaking changes

None.
