### PR TITLE
IslandGroup: refactor to solve multiple small bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- `IslandGroup`: fixes unwanted center alignment of children when direction is vertical ([@driesd](https://github.com/driesd) in [#361](https://github.com/teamleadercrm/ui/pull/361))
+- `IslandGroup`: fixes weird `border-radius` & `border-width` behaviour when containing less or more then 3 Islands ([@driesd](https://github.com/driesd) in [#361](https://github.com/teamleadercrm/ui/pull/361))
+- `IslandGroup`: fixes background color overflow bug with rounded corners ([@driesd](https://github.com/driesd) in [#361](https://github.com/teamleadercrm/ui/pull/361))
+
 ## [0.14.0] - 2018-09-13
 
 ### Added

--- a/components/island/IslandGroup.js
+++ b/components/island/IslandGroup.js
@@ -3,26 +3,24 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Box, { pickBoxProps } from '../box';
 import theme from './theme.css';
-import Island from './Island';
-import { elementIsDark } from '../utils/utils';
 
 class IslandGroup extends PureComponent {
   render() {
     const { children, className, color, dark, direction, size, ...otherProps } = this.props;
 
     const boxProps = pickBoxProps(otherProps);
-    const isDark = elementIsDark(color, dark);
 
     const classNames = cx(theme[`direction-${direction}`], theme['island-group'], className);
 
     return (
       <Box {...boxProps} className={classNames}>
         {React.Children.map(children, child => {
-          return (
-            <Island {...child.props} color={color} dark={isDark} size={size}>
-              {child.props.children}
-            </Island>
-          );
+          return React.cloneElement(child, {
+            ...child.props,
+            color: color || child.props.color,
+            dark: dark || child.props.dark,
+            size: size || child.props.size,
+          });
         })}
       </Box>
     );
@@ -39,7 +37,6 @@ IslandGroup.propTypes = {
 };
 
 IslandGroup.defaultProps = {
-  color: 'white',
   direction: 'horizontal',
 };
 

--- a/components/island/IslandGroup.js
+++ b/components/island/IslandGroup.js
@@ -16,7 +16,7 @@ class IslandGroup extends PureComponent {
     const classNames = cx(theme[`direction-${direction}`], theme['island-group'], className);
 
     return (
-      <Box {...boxProps} className={classNames} padding={0}>
+      <Box {...boxProps} className={classNames}>
         {React.Children.map(children, child => {
           return (
             <Island {...child.props} color={color} dark={isDark} size={size}>

--- a/components/island/IslandGroup.js
+++ b/components/island/IslandGroup.js
@@ -13,15 +13,7 @@ class IslandGroup extends PureComponent {
     const boxProps = pickBoxProps(otherProps);
     const isDark = elementIsDark(color, dark);
 
-    const classNames = cx(
-      theme[`direction-${direction}`],
-      theme['island-group'],
-      theme[color],
-      {
-        [theme['dark']]: isDark,
-      },
-      className,
-    );
+    const classNames = cx(theme[`direction-${direction}`], theme['island-group'], className);
 
     return (
       <Box {...boxProps} className={classNames} padding={0}>

--- a/components/island/IslandGroup.js
+++ b/components/island/IslandGroup.js
@@ -15,8 +15,7 @@ class IslandGroup extends PureComponent {
 
     const classNames = cx(
       theme[`direction-${direction}`],
-      theme['island'],
-      theme['segmented'],
+      theme['island-group'],
       theme[color],
       {
         [theme['dark']]: isDark,

--- a/components/island/theme.css
+++ b/components/island/theme.css
@@ -60,70 +60,57 @@
   color: var(--color-aqua-darkest);
 }
 
-.segmented {
-  align-items: stretch;
-  display: flex;
-  justify-content: center;
-  text-align: center;
-
+.island-group {
   .island {
-    align-items: center;
+    border-radius: 0;
+
+    &:only-child {
+      border-radius: var(--border-radius);
+    }
+  }
+
+  &.direction-horizontal {
     display: flex;
-    flex: 1;
-    flex-direction: column;
-    justify-content: flex-start;
 
-    &:not(:first-child),
-    &:not(:last-child) {
-      border-radius: 0;
+    .island {
+      align-items: center;
+      border-width: 1px 1px 1px 0;
+      display: flex;
+      flex: 1;
+      flex-direction: column;
+      text-align: center;
+
+      &:first-child {
+        border-width: 1px;
+      }
+
+      &:first-child:not(:only-child) {
+        border-radius: var(--border-radius) 0 0 var(--border-radius);
+      }
+
+      &:last-child:not(:only-child) {
+        border-radius: 0 var(--border-radius) var(--border-radius) 0;
+        border-width: 1px 1px 1px 0;
+      }
     }
   }
-}
 
-.direction-horizontal {
-  flex-direction: row;
+  &.direction-vertical {
+    .island {
+      border-width: 0 1px 1px 1px;
 
-  .island {
-    border-top: 0;
-    border-bottom: 0;
+      &:first-child {
+        border-width: 1px;
+      }
 
-    &:not(:first-child) {
-      border-right: 0;
-    }
+      &:first-child:not(:only-child) {
+        border-radius: var(--border-radius) var(--border-radius) 0 0;
+      }
 
-    &:not(:last-child) {
-      border-left: 0;
-    }
-
-    &:first-child {
-      border-radius: var(--border-radius) 0 0 var(--border-radius);
-    }
-    &:last-child {
-      border-radius: 0 var(--border-radius) var(--border-radius) 0;
-    }
-  }
-}
-
-.direction-vertical {
-  flex-direction: column;
-
-  .island {
-    border-left: 0;
-    border-right: 0;
-
-    &:not(:first-child) {
-      border-bottom: 0;
-    }
-
-    &:not(:last-child) {
-      border-top: 0;
-    }
-
-    &:first-child {
-      border-radius: var(--border-radius) var(--border-radius) 0 0;
-    }
-    &:last-child {
-      border-radius: 0 0 var(--border-radius) var(--border-radius);
+      &:last-child:not(:only-child) {
+        border-radius: 0 0 var(--border-radius) var(--border-radius);
+        border-width: 0 1px 1px 1px;
+      }
     }
   }
 }

--- a/stories/island.js
+++ b/stories/island.js
@@ -4,15 +4,16 @@ import { storiesOf } from '@storybook/react';
 import { checkA11y } from 'storybook-addon-a11y';
 import { withInfo } from '@storybook/addon-info';
 import { withKnobs, boolean, select } from '@storybook/addon-knobs/react';
-import { Island, IslandGroup, TextBody, Heading3 } from '../components';
+import { Island, IslandGroup, Link, TextBody, TextSmall, Heading3 } from '../components';
 import {
   IllustrationInvoices120X120Static,
   IllustrationMeetings120X120Static,
   IllustrationDeals120X120Static,
 } from '@teamleader/ui-illustrations';
 
+import { IconChevronRightSmallOutline } from '@teamleader/ui-icons';
+
 const colors = ['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'white'];
-const directions = ['horizontal', 'vertical'];
 const sizes = ['small', 'medium', 'large'];
 
 storiesOf('Island', module)
@@ -39,17 +40,16 @@ storiesOf('Island', module)
       <TextBody>I am an island.</TextBody>
     </Island>
   ))
-  .add('Segmented', () => (
+  .add('Segmented horizontal', () => (
     <IslandGroup
       dark={boolean('Dark', false)}
       color={select('Color', colors, 'white')}
-      direction={select('Direction', directions, 'horizontal')}
       size={select('Size', sizes, 'medium')}
     >
       <Island>
         <IllustrationInvoices120X120Static />
         <Heading3 marginBottom={3}>Invoices</Heading3>
-        <TextBody align="center">Send invoices to your clients straight from Teamleader.</TextBody>
+        <TextBody>Send invoices to your clients straight from Teamleader.</TextBody>
       </Island>
       <Island>
         <IllustrationMeetings120X120Static />
@@ -60,6 +60,27 @@ storiesOf('Island', module)
         <IllustrationDeals120X120Static />
         <Heading3 marginBottom={3}>Deals</Heading3>
         <TextBody>Keep track of all your deals with our fully integrated module.</TextBody>
+      </Island>
+    </IslandGroup>
+  ))
+  .add('Segmented vertical', () => (
+    <IslandGroup
+      dark={boolean('Dark', false)}
+      color={select('Color', colors, 'neutral')}
+      direction="vertical"
+      size={select('Size', sizes, 'medium')}
+    >
+      <Island>
+        <TextBody>kanye.west@goodmusic.com</TextBody>
+      </Island>
+      <Island display="flex" flexDirection="row" alignItems="center">
+        <IconChevronRightSmallOutline />
+        <TextBody marginHorizontal={2}>
+          <Link href="https://www.teamleader.be" target="_blank" inherit={false}>
+            Good music Ltd.
+          </Link>
+        </TextBody>
+        <TextSmall color="neutral">Company</TextSmall>
       </Island>
     </IslandGroup>
   ));

--- a/stories/island.js
+++ b/stories/island.js
@@ -73,7 +73,7 @@ storiesOf('Island', module)
       <Island>
         <TextBody>kanye.west@goodmusic.com</TextBody>
       </Island>
-      <Island display="flex" flexDirection="row" alignItems="center">
+      <Island display="flex" alignItems="center">
         <IconChevronRightSmallOutline />
         <TextBody marginHorizontal={2}>
           <Link href="https://www.teamleader.be" target="_blank" inherit={false}>

--- a/stories/island.js
+++ b/stories/island.js
@@ -22,7 +22,10 @@ storiesOf('Island', module)
       TableComponent: PropTable,
       propTablesExclude: [
         TextBody,
+        TextSmall,
         Heading3,
+        Link,
+        IconChevronRightSmallOutline,
         IllustrationInvoices120X120Static,
         IllustrationMeetings120X120Static,
         IllustrationDeals120X120Static,


### PR DESCRIPTION
### Description

This PR fixes:
* unwanted center alignment of children when `direction` is vertical
* weird `border-radius` & `border-width` behaviour when there's less or more then 3 Islands in an IslandGroup
* redundant `isDark` check (which is already done by `Island` component)
* background color overflow bug with rounded corners
* repetition of the Island component while mapping over children

#### Screenshot before this PR

![schermafdruk 2018-09-17 15 24 05](https://user-images.githubusercontent.com/5336831/45626153-08786e00-ba8f-11e8-927f-0662d5215754.png)

![schermafdruk 2018-09-17 15 36 39](https://user-images.githubusercontent.com/5336831/45626318-83418900-ba8f-11e8-8ee3-9a21733acbb6.png)

#### Screenshot after this PR

![schermafdruk 2018-09-17 15 23 09](https://user-images.githubusercontent.com/5336831/45626167-129a6c80-ba8f-11e8-9e9c-511501c33e21.png)

![schermafdruk 2018-09-17 15 22 30](https://user-images.githubusercontent.com/5336831/45626179-1cbc6b00-ba8f-11e8-89dd-f05a0a67a598.png)

### Breaking changes

None.
