### PR TITLE
Blur is not always available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- `Button`, `IconButton` & `LinkButton`: avoid error when `blur()` is not available on the passed node (e.g. when using a custom component such as a router link). ([@lowiebenoot](https://github.com/lowiebenoot) in [#322](https://github.com/teamleadercrm/ui/pull/322))
+
 ## [0.14.0] - 2018-09-13
 
 ### Added

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -12,18 +12,24 @@ class Button extends PureComponent {
   }
 
   handleMouseUp = event => {
-    this.buttonNode.blur();
+    this.blur();
     if (this.props.onMouseUp) {
       this.props.onMouseUp(event);
     }
   };
 
   handleMouseLeave = event => {
-    this.buttonNode.blur();
+    this.blur();
     if (this.props.onMouseLeave) {
       this.props.onMouseLeave(event);
     }
   };
+
+  blur() {
+    if (this.buttonNode.blur) {
+      this.buttonNode.blur();
+    }
+  }
 
   render() {
     const {

--- a/components/button/IconButton.js
+++ b/components/button/IconButton.js
@@ -5,18 +5,24 @@ import theme from './theme.css';
 
 class IconButton extends Component {
   handleMouseUp = event => {
-    this.buttonNode.blur();
+    this.blur();
     if (this.props.onMouseUp) {
       this.props.onMouseUp(event);
     }
   };
 
   handleMouseLeave = event => {
-    this.buttonNode.blur();
+    this.blur();
     if (this.props.onMouseLeave) {
       this.props.onMouseLeave(event);
     }
   };
+
+  blur() {
+    if (this.buttonNode.blur) {
+      this.buttonNode.blur();
+    }
+  }
 
   render() {
     const { children, className, disabled, element, icon, size, color, type, ...others } = this.props;

--- a/components/button/LinkButton.js
+++ b/components/button/LinkButton.js
@@ -5,18 +5,24 @@ import theme from './theme.css';
 
 class LinkButton extends PureComponent {
   handleMouseUp = event => {
-    this.buttonNode.blur();
+    this.blur();
     if (this.props.onMouseUp) {
       this.props.onMouseUp(event);
     }
   };
 
   handleMouseLeave = event => {
-    this.buttonNode.blur();
+    this.blur();
     if (this.props.onMouseLeave) {
       this.props.onMouseLeave(event);
     }
   };
+
+  blur() {
+    if (this.buttonNode.blur) {
+      this.buttonNode.blur();
+    }
+  }
 
   render() {
     const { children, className, disabled, element, icon, iconPlacement, inverse, label, size, ...others } = this.props;


### PR DESCRIPTION
### Fixed
* `blur()` is not always available on the button node (e.g. when using a custom component such as a router link), which results in an error.