### PR TITLE
Input: bugfix when adjusting the value in a number type input field

### DIFF
--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -48,6 +48,14 @@ export default class Input extends PureComponent {
     value: '',
   };
 
+  handleBlur = event => {
+    const parsedValue = Input.parseValue(event.target.value, this.props);
+
+    if (parsedValue !== event.target.value) {
+      this.updateValue(event, parsedValue);
+    }
+  };
+
   handleChange = event => {
     this.updateValue(event);
   };
@@ -117,6 +125,7 @@ export default class Input extends PureComponent {
 
     const props = {
       className: classNames,
+      onBlur: this.handleBlur,
       onChange: this.handleChange,
       type,
       value,

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -73,11 +73,6 @@ export default class Input extends PureComponent {
     }
   }
 
-  formatNumber(number) {
-    const { min, max } = this.props;
-    return String(Input.toNumber(number, min, max));
-  }
-
   updateStep(event, n) {
     const { step } = this.props;
     const { value = 0 } = this.state;
@@ -117,7 +112,7 @@ export default class Input extends PureComponent {
       max,
       min,
       step,
-      value: value && this.formatNumber(value),
+      value,
     };
 
     const props = {

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -16,7 +16,7 @@ import theme from './theme.css';
 export default class Input extends PureComponent {
   static getDerivedStateFromProps(nextProps, prevState) {
     if (nextProps.value !== undefined) {
-      const newValue = Input.parseValue(nextProps.value || '', nextProps);
+      const newValue = nextProps.value || '';
 
       if (newValue !== prevState.value) {
         return {
@@ -62,7 +62,7 @@ export default class Input extends PureComponent {
 
   updateValue(event, rawValue, triggerOnChange = true) {
     const { onChange } = this.props;
-    const value = Input.parseValue(rawValue || event.target.value, this.props);
+    const value = rawValue || event.target.value;
 
     this.setState({
       value,
@@ -81,7 +81,12 @@ export default class Input extends PureComponent {
   updateStep(event, n) {
     const { step } = this.props;
     const { value = 0 } = this.state;
-    this.updateValue(event, value + step * n);
+
+    const parsedValue = Input.parseValue(value + step * n, this.props);
+
+    if (value !== parsedValue) {
+      this.updateValue(event, parsedValue);
+    }
   }
 
   renderInput() {

--- a/stories/input.js
+++ b/stories/input.js
@@ -14,6 +14,7 @@ const tints = ['lightest', 'light', 'normal', 'dark', 'darkest'];
 const props = {
   helpText: 'This is the fields help text',
   placeholder: 'Placeholder',
+  onChange: (event, value) => console.log('Changing to ', value),
 };
 
 const TooltippedIcon = Tooltip(Icon);


### PR DESCRIPTION
### Description

Before this PR, there was a bug that you could not adjust the current value in a number type input field combined with min & max attributes.
After this PR, we will only parse the value when using the spinner controls and when blurring the input field.

### Breaking changes

None.
