### PR TITLE
Upgrade to webpack 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,20 @@
-## [Unreleased]
+## [unreleased]
 
 ### Added
 
 ### Changed
+
+- `webpack@4.1.1`
+- `extract-text-webpack-plugin@4.0.0-beta.0`
+- `html-webpack-plugin@4.0.0-alpha.2`
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- `Production build`: Fixed the failing production builds ([@driesd](https://github.com/driesd) in [#374](https://github.com/teamleadercrm/ui/pull/374))
 
 ## [0.15.1] - 2018-09-25
 

--- a/package.json
+++ b/package.json
@@ -112,12 +112,12 @@
     "eslint-plugin-promise": "^3.3.0",
     "eslint-plugin-react": "^7.4.0",
     "eslint-plugin-standard": "^3.0.1",
-    "extract-text-webpack-plugin": "^3.0.2",
+    "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "file-loader": "^1.1.5",
     "gulp": "^3.9.1",
     "gulp-babel": "8.0.0-beta.2",
     "gulp-postcss": "^7.0.0",
-    "html-webpack-plugin": "^2.22.0",
+    "html-webpack-plugin": "^4.0.0-alpha.2",
     "husky": "^0.14.3",
     "image-webpack-loader": "^4.1.0",
     "imports-loader": "^0.7.1",
@@ -140,7 +140,7 @@
     "rimraf": "^2.5.4",
     "style-loader": "^0.20.2",
     "url-loader": "^0.6.2",
-    "webpack": "^3.8.1"
+    "webpack": "^4.1.1"
   },
   "directories": {
     "doc": "docs"


### PR DESCRIPTION
### Description

This PR fixes the build failure on production. It contains upgrades for the following npm packages:
* `webpack@4.1.1`
* `extract-text-webpack-plugin@4.0.0-beta.0`
* `html-webpack-plugin@4.0.0-alpha.2`