### PR TITLE
Release 0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Changed
 
+### Deprecated
+
+### Removed
+
+### Fixed
+
+## [0.15.1] - 2018-09-25
+
+### Added
+
+### Changed
+
 - `webpack@4.1.1`
 - `extract-text-webpack-plugin@4.0.0-beta.0`
 - `html-webpack-plugin@4.0.0-alpha.2`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "author": "Teamleader <development@teamleader.eu>",
   "betterScripts": {
     "compile": {


### PR DESCRIPTION
### Changed

- `webpack@4.1.1`
- `extract-text-webpack-plugin@4.0.0-beta.0`
- `html-webpack-plugin@4.0.0-alpha.2`

### Fixed

- `Production build`: Fixed the failing production builds ([@driesd](https://github.com/driesd) in [#374](https://github.com/teamleadercrm/ui/pull/374))
