### PR TITLE
Popover refactor: remove factory pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- [BREAKING] `Popover`: added the `Popover`, it replaces `PopoverHorizontal` and `PopoverVertical` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#377](https://github.com/teamleadercrm/ui/pull/377))
+
 ### Changed
 
 - `Button`: a link button can be created by setting the level property ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#376](https://github.com/teamleadercrm/ui/pull/376))
@@ -9,6 +11,8 @@
 ### Deprecated
 
 - [BREAKING] `LinkButton`: The `LinkButton` is removed, since it is replaced by `Button` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#376](https://github.com/teamleadercrm/ui/pull/376))
+- [BREAKING] `PopoverHorizontal`: The `PopoverHorizontal` is removed, since it is replaced by `Popover` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#377](https://github.com/teamleadercrm/ui/pull/377))
+- [BREAKING] `PopoverVertical`: The `PopoverVertical` is removed, since it is replaced by `Popover` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#377](https://github.com/teamleadercrm/ui/pull/377))
 
 ### Removed
 

--- a/components/index.js
+++ b/components/index.js
@@ -20,7 +20,7 @@ import Overlay from './overlay';
 import LoadingMolecule from './loadingMolecule';
 import LoadingSpinner from './loadingSpinner';
 import Pagination from './pagination';
-import { PopoverHorizontal, PopoverVertical } from './popover';
+import Popover from './popover';
 import { RadioButton, RadioGroup } from './radio';
 import Section from './section';
 import Select, { AsyncSelect } from './select';
@@ -77,8 +77,7 @@ export {
   Monospaced,
   Overlay,
   Pagination,
-  PopoverHorizontal,
-  PopoverVertical,
+  Popover,
   ProgressTracker,
   RadioButton,
   RadioGroup,

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -165,7 +165,7 @@ Popover.propTypes = {
   /** The function executed, when the mouse is up on the Overlay. */
   onOverlayMouseUp: PropTypes.func,
   /** The position in which the Popover is rendered, is overridden with the another position if the Popover cannot be entirely displayed in the current position. */
-  position: PropTypes.oneOf(['top', 'middle', 'bottom', 'left', 'center', 'right']),
+  position: PropTypes.oneOf(['start', 'center', 'end']),
   /** The tint of the background colour of the Popover. */
   tint: PropTypes.oneOf(['lightest', 'light', 'normal', 'dark', 'darkest']),
 };

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -10,179 +10,173 @@ import { events } from '../utils';
 import { calculatePositions } from './positionCalculation';
 import theme from './theme.css';
 
-const factory = () => {
-  class Popover extends PureComponent {
-    popoverRoot = document.createElement('div');
+class Popover extends PureComponent {
+  popoverRoot = document.createElement('div');
 
-    state = { positioning: { left: 0, top: 0, arrowLeft: 0, arrowTop: 0, maxPopoverHeight: 'initial' } };
+  state = { positioning: { left: 0, top: 0, arrowLeft: 0, arrowTop: 0, maxPopoverHeight: 'initial' } };
 
-    componentDidMount() {
-      document.body.appendChild(this.popoverRoot);
+  componentDidMount() {
+    document.body.appendChild(this.popoverRoot);
 
-      events.addEventsToWindow({ resize: this.setPlacementThrottled, scroll: this.setPlacementThrottled });
-    }
+    events.addEventsToWindow({ resize: this.setPlacementThrottled, scroll: this.setPlacementThrottled });
+  }
 
-    componentWillUnmount() {
-      events.removeEventsFromWindow({ resize: this.setPlacementThrottled, scroll: this.setPlacementThrottled });
+  componentWillUnmount() {
+    events.removeEventsFromWindow({ resize: this.setPlacementThrottled, scroll: this.setPlacementThrottled });
 
-      document.body.removeChild(this.popoverRoot);
-    }
+    document.body.removeChild(this.popoverRoot);
+  }
 
-    componentDidUpdate(prevProps) {
-      if (this.props.active && prevProps !== this.props) {
-        this.setPlacement();
-      }
-    }
-
-    setPlacement = () => {
-      const { anchorEl, direction, position, offsetCorrection } = this.props;
-
-      if (this.popoverNode) {
-        this.setState({
-          positioning: calculatePositions(
-            anchorEl,
-            this.popoverNode,
-            this.popoverContentNode,
-            direction,
-            position,
-            offsetCorrection,
-          ),
-        });
-      }
-    };
-
-    setPlacementThrottled = throttle(this.setPlacement, 250);
-
-    getAxis() {
-      const { direction } = this.props;
-
-      if (direction === 'north' || direction === 'south') {
-        return 'vertical';
-      }
-
-      return 'horizontal';
-    }
-
-    render() {
-      const { left, top, arrowLeft, arrowTop, maxPopoverHeight } = this.state.positioning;
-
-      const {
-        active,
-        backdrop,
-        children,
-        className,
-        color,
-        lockScroll,
-        onOverlayClick,
-        onEscKeyDown,
-        onOverlayMouseDown,
-        onOverlayMouseMove,
-        onOverlayMouseUp,
-        tint,
-      } = this.props;
-
-      if (!active) {
-        return null;
-      }
-
-      const popover = (
-        <Transition timeout={0} in={active} appear>
-          {state => {
-            return (
-              <div
-                className={cx(theme['wrapper'], theme[color], theme[tint], {
-                  [theme['is-entering']]: state === 'entering',
-                  [theme['is-entered']]: state === 'entered',
-                })}
-              >
-                <InjectOverlay
-                  active={active}
-                  backdrop={backdrop}
-                  className={theme['overlay']}
-                  lockScroll={lockScroll}
-                  onClick={onOverlayClick}
-                  onEscKeyDown={onEscKeyDown}
-                  onMouseDown={onOverlayMouseDown}
-                  onMouseMove={onOverlayMouseMove}
-                  onMouseUp={onOverlayMouseUp}
-                />
-                <div
-                  data-teamleader-ui={`popover-${this.getAxis()}`}
-                  className={cx(theme['popover'], className)}
-                  style={{ left: `${left}px`, top: `${top}px` }}
-                  ref={node => {
-                    this.popoverNode = node;
-                  }}
-                >
-                  <div className={theme['arrow']} style={{ left: `${arrowLeft}px`, top: `${arrowTop}px` }} />
-                  <div className={theme['inner']} style={{ maxHeight: maxPopoverHeight }}>
-                    <div
-                      ref={node => {
-                        this.popoverContentNode = node;
-                      }}
-                    >
-                      {children}
-                    </div>
-                    <ReactResizeDetector handleHeight handleWidth onResize={this.setPlacementThrottled} />
-                  </div>
-                </div>
-              </div>
-            );
-          }}
-        </Transition>
-      );
-
-      return createPortal(popover, this.popoverRoot);
+  componentDidUpdate(prevProps) {
+    if (this.props.active && prevProps !== this.props) {
+      this.setPlacement();
     }
   }
 
-  Popover.propTypes = {
-    /** The state of the Popover, when true the Popover is rendered otherwise it is not. */
-    active: PropTypes.bool,
-    /** The Popovers anchor element. */
-    anchorEl: PropTypes.object,
-    /** The background colour of the Overlay. */
-    backdrop: PropTypes.string,
-    /** The component wrapped by the Popover. */
-    children: PropTypes.node,
-    /** The class names for the wrapper to apply custom styling. */
-    className: PropTypes.string,
-    /** The background colour of the Popover. */
-    color: PropTypes.oneOf(['aqua', 'gold', 'mint', 'neutral', 'ruby', 'teal', 'violet']),
-    /** The direction in which the Popover is rendered, is overridden with the opposite direction if the Popover cannot be entirely displayed in the current direction. */
-    direction: PropTypes.oneOf(['north', 'south', 'east', 'west']),
-    /** The scroll state of the body, if true it will not be scrollable. */
-    lockScroll: PropTypes.bool,
-    /** The amount of extra translation on the Popover (has no effect if position is "middle" or "center"). */
-    offsetCorrection: PropTypes.number,
-    /** The function executed, when the "ESC" key is down. */
-    onEscKeyDown: PropTypes.func,
-    /** The function executed, when the Overlay is clicked. */
-    onOverlayClick: PropTypes.func,
-    /** The function executed, when the mouse is down on the Overlay. */
-    onOverlayMouseDown: PropTypes.func,
-    /** The function executed, when the mouse is being moved over the Overlay. */
-    onOverlayMouseMove: PropTypes.func,
-    /** The function executed, when the mouse is up on the Overlay. */
-    onOverlayMouseUp: PropTypes.func,
-    /** The position in which the Popover is rendered, is overridden with the another position if the Popover cannot be entirely displayed in the current position. */
-    position: PropTypes.oneOf(['top', 'middle', 'bottom', 'left', 'center', 'right']),
-    /** The tint of the background colour of the Popover. */
-    tint: PropTypes.oneOf(['lightest', 'light', 'normal', 'dark', 'darkest']),
+  setPlacement = () => {
+    const { anchorEl, direction, position, offsetCorrection } = this.props;
+
+    if (this.popoverNode) {
+      this.setState({
+        positioning: calculatePositions(
+          anchorEl,
+          this.popoverNode,
+          this.popoverContentNode,
+          direction,
+          position,
+          offsetCorrection,
+        ),
+      });
+    }
   };
 
-  Popover.defaultProps = {
-    active: true,
-    backdrop: 'dark',
-    color: 'neutral',
-    lockScroll: true,
-    offsetCorrection: 0,
-    tint: 'lightest',
-  };
+  setPlacementThrottled = throttle(this.setPlacement, 250);
 
-  return Popover;
+  getAxis() {
+    const { direction } = this.props;
+
+    if (direction === 'north' || direction === 'south') {
+      return 'vertical';
+    }
+
+    return 'horizontal';
+  }
+
+  render() {
+    const { left, top, arrowLeft, arrowTop, maxPopoverHeight } = this.state.positioning;
+
+    const {
+      active,
+      backdrop,
+      children,
+      className,
+      color,
+      lockScroll,
+      onOverlayClick,
+      onEscKeyDown,
+      onOverlayMouseDown,
+      onOverlayMouseMove,
+      onOverlayMouseUp,
+      tint,
+    } = this.props;
+
+    if (!active) {
+      return null;
+    }
+
+    const popover = (
+      <Transition timeout={0} in={active} appear>
+        {state => {
+          return (
+            <div
+              className={cx(theme['wrapper'], theme[color], theme[tint], {
+                [theme['is-entering']]: state === 'entering',
+                [theme['is-entered']]: state === 'entered',
+              })}
+            >
+              <InjectOverlay
+                active={active}
+                backdrop={backdrop}
+                className={theme['overlay']}
+                lockScroll={lockScroll}
+                onClick={onOverlayClick}
+                onEscKeyDown={onEscKeyDown}
+                onMouseDown={onOverlayMouseDown}
+                onMouseMove={onOverlayMouseMove}
+                onMouseUp={onOverlayMouseUp}
+              />
+              <div
+                data-teamleader-ui={`popover-${this.getAxis()}`}
+                className={cx(theme['popover'], className)}
+                style={{ left: `${left}px`, top: `${top}px` }}
+                ref={node => {
+                  this.popoverNode = node;
+                }}
+              >
+                <div className={theme['arrow']} style={{ left: `${arrowLeft}px`, top: `${arrowTop}px` }} />
+                <div className={theme['inner']} style={{ maxHeight: maxPopoverHeight }}>
+                  <div
+                    ref={node => {
+                      this.popoverContentNode = node;
+                    }}
+                  >
+                    {children}
+                  </div>
+                  <ReactResizeDetector handleHeight handleWidth onResize={this.setPlacementThrottled} />
+                </div>
+              </div>
+            </div>
+          );
+        }}
+      </Transition>
+    );
+
+    return createPortal(popover, this.popoverRoot);
+  }
+}
+
+Popover.propTypes = {
+  /** The state of the Popover, when true the Popover is rendered otherwise it is not. */
+  active: PropTypes.bool,
+  /** The Popovers anchor element. */
+  anchorEl: PropTypes.object,
+  /** The background colour of the Overlay. */
+  backdrop: PropTypes.string,
+  /** The component wrapped by the Popover. */
+  children: PropTypes.node,
+  /** The class names for the wrapper to apply custom styling. */
+  className: PropTypes.string,
+  /** The background colour of the Popover. */
+  color: PropTypes.oneOf(['aqua', 'gold', 'mint', 'neutral', 'ruby', 'teal', 'violet']),
+  /** The direction in which the Popover is rendered, is overridden with the opposite direction if the Popover cannot be entirely displayed in the current direction. */
+  direction: PropTypes.oneOf(['north', 'south', 'east', 'west']),
+  /** The scroll state of the body, if true it will not be scrollable. */
+  lockScroll: PropTypes.bool,
+  /** The amount of extra translation on the Popover (has no effect if position is "middle" or "center"). */
+  offsetCorrection: PropTypes.number,
+  /** The function executed, when the "ESC" key is down. */
+  onEscKeyDown: PropTypes.func,
+  /** The function executed, when the Overlay is clicked. */
+  onOverlayClick: PropTypes.func,
+  /** The function executed, when the mouse is down on the Overlay. */
+  onOverlayMouseDown: PropTypes.func,
+  /** The function executed, when the mouse is being moved over the Overlay. */
+  onOverlayMouseMove: PropTypes.func,
+  /** The function executed, when the mouse is up on the Overlay. */
+  onOverlayMouseUp: PropTypes.func,
+  /** The position in which the Popover is rendered, is overridden with the another position if the Popover cannot be entirely displayed in the current position. */
+  position: PropTypes.oneOf(['top', 'middle', 'bottom', 'left', 'center', 'right']),
+  /** The tint of the background colour of the Popover. */
+  tint: PropTypes.oneOf(['lightest', 'light', 'normal', 'dark', 'darkest']),
 };
 
-export const PopoverHorizontal = factory();
+Popover.defaultProps = {
+  active: true,
+  backdrop: 'dark',
+  color: 'neutral',
+  lockScroll: true,
+  offsetCorrection: 0,
+  tint: 'lightest',
+};
 
-export const PopoverVertical = factory();
+export default Popover;

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -10,7 +10,7 @@ import { events } from '../utils';
 import { calculatePositions } from './positionCalculation';
 import theme from './theme.css';
 
-const factory = (axis, calculatePositions, Overlay) => {
+const factory = (axis, calculatePositions) => {
   class Popover extends PureComponent {
     popoverRoot = document.createElement('div');
 
@@ -85,7 +85,7 @@ const factory = (axis, calculatePositions, Overlay) => {
                   [theme['is-entered']]: state === 'entered',
                 })}
               >
-                <Overlay
+                <InjectOverlay
                   active={active}
                   backdrop={backdrop}
                   className={theme['overlay']}
@@ -173,6 +173,6 @@ const factory = (axis, calculatePositions, Overlay) => {
   return Popover;
 };
 
-export const PopoverHorizontal = factory('horizontal', calculatePositions, InjectOverlay);
+export const PopoverHorizontal = factory('horizontal', calculatePositions);
 
-export const PopoverVertical = factory('vertical', calculatePositions, InjectOverlay);
+export const PopoverVertical = factory('vertical', calculatePositions);

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -52,16 +52,6 @@ class Popover extends PureComponent {
 
   setPlacementThrottled = throttle(this.setPlacement, 250);
 
-  getAxis() {
-    const { direction } = this.props;
-
-    if (direction === 'north' || direction === 'south') {
-      return 'vertical';
-    }
-
-    return 'horizontal';
-  }
-
   render() {
     const { left, top, arrowLeft, arrowTop, maxPopoverHeight } = this.state.positioning;
 
@@ -106,7 +96,7 @@ class Popover extends PureComponent {
                 onMouseUp={onOverlayMouseUp}
               />
               <div
-                data-teamleader-ui={`popover-${this.getAxis()}`}
+                data-teamleader-ui={'popover'}
                 className={cx(theme['popover'], className)}
                 style={{ left: `${left}px`, top: `${top}px` }}
                 ref={node => {

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -10,7 +10,7 @@ import { events } from '../utils';
 import { calculatePositions } from './positionCalculation';
 import theme from './theme.css';
 
-const factory = (axis, calculatePositions) => {
+const factory = axis => {
   class Popover extends PureComponent {
     popoverRoot = document.createElement('div');
 
@@ -173,6 +173,6 @@ const factory = (axis, calculatePositions) => {
   return Popover;
 };
 
-export const PopoverHorizontal = factory('horizontal', calculatePositions);
+export const PopoverHorizontal = factory('horizontal');
 
-export const PopoverVertical = factory('vertical', calculatePositions);
+export const PopoverVertical = factory('vertical');

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -10,7 +10,7 @@ import { events } from '../utils';
 import { calculatePositions } from './positionCalculation';
 import theme from './theme.css';
 
-const factory = axis => {
+const factory = () => {
   class Popover extends PureComponent {
     popoverRoot = document.createElement('div');
 
@@ -52,6 +52,16 @@ const factory = axis => {
     };
 
     setPlacementThrottled = throttle(this.setPlacement, 250);
+
+    getAxis() {
+      const { direction } = this.props;
+
+      if (direction === 'north' || direction === 'south') {
+        return 'vertical';
+      }
+
+      return 'horizontal';
+    }
 
     render() {
       const { left, top, arrowLeft, arrowTop, maxPopoverHeight } = this.state.positioning;
@@ -97,7 +107,7 @@ const factory = axis => {
                   onMouseUp={onOverlayMouseUp}
                 />
                 <div
-                  data-teamleader-ui={`popover-${axis}`}
+                  data-teamleader-ui={`popover-${this.getAxis()}`}
                   className={cx(theme['popover'], className)}
                   style={{ left: `${left}px`, top: `${top}px` }}
                   ref={node => {
@@ -173,6 +183,6 @@ const factory = axis => {
   return Popover;
 };
 
-export const PopoverHorizontal = factory('horizontal');
+export const PopoverHorizontal = factory();
 
-export const PopoverVertical = factory('vertical');
+export const PopoverVertical = factory();

--- a/components/popover/Popover.js
+++ b/components/popover/Popover.js
@@ -173,9 +173,11 @@ Popover.propTypes = {
 Popover.defaultProps = {
   active: true,
   backdrop: 'dark',
+  direction: 'south',
   color: 'neutral',
   lockScroll: true,
   offsetCorrection: 0,
+  position: 'center',
   tint: 'lightest',
 };
 

--- a/components/popover/index.js
+++ b/components/popover/index.js
@@ -1,3 +1,3 @@
-import { PopoverHorizontal, PopoverVertical } from './Popover';
+import Popover from './Popover';
 
-export { PopoverVertical, PopoverHorizontal };
+export default Popover;

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -9,8 +9,8 @@ const getElementPositionValues = element => {
     left,
     right,
     bottom,
-    middle: top + (bottom - top) / 2,
-    center: left + (right - left) / 2,
+    centerY: top + (bottom - top) / 2,
+    centerX: left + (right - left) / 2,
   };
 };
 
@@ -89,7 +89,7 @@ const getHorizontalDirectionPositionTopValue = ({
 }) => {
   switch (position) {
     case 'center':
-      return anchorPosition.middle - popoverDimensions.height / 2;
+      return anchorPosition.centerY - popoverDimensions.height / 2;
     case 'start':
       return anchorPosition.top - POPUP_OFFSET * 0.75 - inputOffsetCorrection;
     case 'end':
@@ -130,7 +130,7 @@ const getVerticalDirectionPositionLeftValue = ({
 }) => {
   switch (position) {
     case 'center':
-      return anchorPosition.center - popoverDimensions.width / 2;
+      return anchorPosition.centerX - popoverDimensions.width / 2;
     case 'start':
       return anchorPosition.left - inputOffsetCorrection;
     case 'end':
@@ -200,8 +200,8 @@ const isVerticalDirectionPositionPossible = (position, anchorPosition, popoverDi
   switch (position) {
     case 'center':
       return (
-        anchorPosition.middle + popoverDimensions.height / 2 < window.innerHeight &&
-        anchorPosition.middle - popoverDimensions.height / 2 > 0
+        anchorPosition.centerY + popoverDimensions.height / 2 < window.innerHeight &&
+        anchorPosition.centerY - popoverDimensions.height / 2 > 0
       );
     case 'start':
       return anchorPosition.top + popoverDimensions.height < window.innerHeight;
@@ -214,8 +214,8 @@ const isHorizontalDirectionPositionPossible = (position, anchorPosition, popover
   switch (position) {
     case 'center':
       return (
-        anchorPosition.center + popoverDimensions.width / 2 < window.innerWidth &&
-        anchorPosition.center - popoverDimensions.width / 2 > 0
+        anchorPosition.centerX + popoverDimensions.width / 2 < window.innerWidth &&
+        anchorPosition.centerX - popoverDimensions.width / 2 > 0
       );
     case 'start':
       return anchorPosition.left + popoverDimensions.width < window.innerWidth;

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -1,6 +1,15 @@
 const ARROW_OFFSET = 7;
 const POPUP_OFFSET = 12;
 
+const POSITION_START = 'start';
+const POSITION_CENTER = 'center';
+const POSITION_END = 'end';
+
+const DIRECTION_NORTH = 'north';
+const DIRECTION_EAST = 'east';
+const DIRECTION_SOUTH = 'south';
+const DIRECTION_WEST = 'west';
+
 const getElementPositionValues = element => {
   const { top, left, right, bottom } = element.getBoundingClientRect();
 
@@ -64,7 +73,7 @@ const getHorizontalDirectionPositionValues = ({
 });
 
 const getPositionValues = ({ direction, position, anchorPosition, popoverDimensions, inputOffsetCorrection }) =>
-  direction === 'north' || direction === 'south'
+  direction === DIRECTION_NORTH || direction === DIRECTION_SOUTH
     ? getVerticalDirectionPositionValues({
         direction,
         position,
@@ -88,37 +97,37 @@ const getHorizontalDirectionPositionTopValue = ({
   inputOffsetCorrection,
 }) => {
   switch (position) {
-    case 'center':
+    case POSITION_CENTER:
       return anchorPosition.centerY - popoverDimensions.height / 2;
-    case 'start':
+    case POSITION_START:
       return anchorPosition.top - POPUP_OFFSET * 0.75 - inputOffsetCorrection;
-    case 'end':
+    case POSITION_END:
       return anchorPosition.bottom - popoverDimensions.height + POPUP_OFFSET * 0.75 + inputOffsetCorrection;
   }
 };
 
 const getHorizontalDirectionPositionLeftValue = ({ direction, anchorPosition, popoverDimensions }) =>
-  direction === 'west'
+  direction === DIRECTION_WEST
     ? anchorPosition.left - popoverDimensions.width - POPUP_OFFSET
     : anchorPosition.right + POPUP_OFFSET;
 
 const getHorizontalDirectionArrowPositionTopValue = ({ position, popoverDimensions }) => {
   switch (position) {
-    case 'center':
+    case POSITION_CENTER:
       return popoverDimensions.height / 2 - ARROW_OFFSET;
-    case 'start':
+    case POSITION_START:
       return ARROW_OFFSET * 2.35;
-    case 'end':
+    case POSITION_END:
       return popoverDimensions.height - ARROW_OFFSET * 4.5;
   }
 };
 
 const getHorizontalDirectionArrowPositionLeftValue = ({ direction, popoverDimensions }) =>
-  direction === 'west' ? popoverDimensions.width - ARROW_OFFSET : -ARROW_OFFSET;
+  direction === DIRECTION_WEST ? popoverDimensions.width - ARROW_OFFSET : -ARROW_OFFSET;
 
 // VERTICAL
 const getVerticalDirectionPositionTopValue = ({ direction, anchorPosition, popoverDimensions }) =>
-  direction === 'north'
+  direction === DIRECTION_NORTH
     ? anchorPosition.top - popoverDimensions.height - POPUP_OFFSET
     : anchorPosition.bottom + POPUP_OFFSET;
 
@@ -129,52 +138,52 @@ const getVerticalDirectionPositionLeftValue = ({
   inputOffsetCorrection,
 }) => {
   switch (position) {
-    case 'center':
+    case POSITION_CENTER:
       return anchorPosition.centerX - popoverDimensions.width / 2;
-    case 'start':
+    case POSITION_START:
       return anchorPosition.left - inputOffsetCorrection;
-    case 'end':
+    case POSITION_END:
       return anchorPosition.right - popoverDimensions.width + inputOffsetCorrection;
   }
 };
 
 const getVerticalDirectionArrowPositionTopValue = ({ direction, popoverDimensions }) =>
-  direction === 'north' ? popoverDimensions.height - ARROW_OFFSET : -ARROW_OFFSET;
+  direction === DIRECTION_NORTH ? popoverDimensions.height - ARROW_OFFSET : -ARROW_OFFSET;
 
 const getVerticalDirectionArrowPositionLeftValue = ({ position, popoverDimensions }) => {
   switch (position) {
-    case 'center':
+    case POSITION_CENTER:
       return popoverDimensions.width / 2 - ARROW_OFFSET;
-    case 'start':
+    case POSITION_START:
       return 2 * POPUP_OFFSET;
-    case 'end':
+    case POSITION_END:
       return popoverDimensions.width - POPUP_OFFSET * 3;
   }
 };
 
 const isInViewport = ({ direction, anchorPosition, popoverDimensions }) => {
   switch (direction) {
-    case 'north':
+    case DIRECTION_NORTH:
       return anchorPosition.top - popoverDimensions.height - POPUP_OFFSET > 0;
-    case 'south':
+    case DIRECTION_SOUTH:
       return anchorPosition.bottom + popoverDimensions.height + POPUP_OFFSET < window.innerHeight;
-    case 'east':
+    case DIRECTION_EAST:
       return anchorPosition.right + popoverDimensions.width + POPUP_OFFSET < window.innerWidth;
-    case 'west':
+    case DIRECTION_WEST:
       return anchorPosition.left - popoverDimensions.width - POPUP_OFFSET > 0;
   }
 };
 
 const getOppositeDirection = direction => {
   switch (direction) {
-    case 'north':
-      return 'south';
-    case 'south':
-      return 'north';
-    case 'east':
-      return 'west';
-    case 'west':
-      return 'east';
+    case DIRECTION_NORTH:
+      return DIRECTION_SOUTH;
+    case DIRECTION_SOUTH:
+      return DIRECTION_NORTH;
+    case DIRECTION_EAST:
+      return DIRECTION_WEST;
+    case DIRECTION_WEST:
+      return DIRECTION_EAST;
   }
 };
 
@@ -192,44 +201,44 @@ const getDirection = ({ direction, anchorPosition, popoverDimensions }) => {
 };
 
 const isPositionPossible = (direction, position, anchorPosition, popoverDimensions) =>
-  direction === 'north' || direction === 'south'
+  direction === DIRECTION_NORTH || direction === DIRECTION_SOUTH
     ? isVerticalDirectionPositionPossible(position, anchorPosition, popoverDimensions)
     : isHorizontalDirectionPositionPossible(position, anchorPosition, popoverDimensions);
 
 const isVerticalDirectionPositionPossible = (position, anchorPosition, popoverDimensions) => {
   switch (position) {
-    case 'center':
+    case POSITION_CENTER:
       return (
         anchorPosition.centerY + popoverDimensions.height / 2 < window.innerHeight &&
         anchorPosition.centerY - popoverDimensions.height / 2 > 0
       );
-    case 'start':
+    case POSITION_START:
       return anchorPosition.top + popoverDimensions.height < window.innerHeight;
-    case 'end':
+    case POSITION_END:
       return anchorPosition.bottom - popoverDimensions.height > 0;
   }
 };
 
 const isHorizontalDirectionPositionPossible = (position, anchorPosition, popoverDimensions) => {
   switch (position) {
-    case 'center':
+    case POSITION_CENTER:
       return (
         anchorPosition.centerX + popoverDimensions.width / 2 < window.innerWidth &&
         anchorPosition.centerX - popoverDimensions.width / 2 > 0
       );
-    case 'start':
+    case POSITION_START:
       return anchorPosition.left + popoverDimensions.width < window.innerWidth;
-    case 'end':
+    case POSITION_END:
       return anchorPosition.right - popoverDimensions.width > 0;
   }
 };
 
 const getOppositePosition = direction => {
   switch (direction) {
-    case 'start':
-      return 'end';
-    case 'end':
-      return 'start';
+    case POSITION_START:
+      return POSITION_END;
+    case POSITION_END:
+      return POSITION_START;
   }
 };
 
@@ -239,14 +248,16 @@ const getPosition = ({ direction, position, anchorPosition, popoverDimensions })
   }
 
   switch (position) {
-    case 'center':
-      return isPositionPossible('start', anchorPosition, popoverDimensions)
-        ? 'start'
-        : isPositionPossible('end', anchorPosition, popoverDimensions)
-          ? 'end'
+    case POSITION_CENTER:
+      return isPositionPossible(POSITION_START, anchorPosition, popoverDimensions)
+        ? POSITION_START
+        : isPositionPossible(POSITION_END, anchorPosition, popoverDimensions)
+          ? POSITION_END
           : position;
     default:
-      return isPositionPossible('center', anchorPosition, popoverDimensions) ? 'center' : getOppositePosition(position);
+      return isPositionPossible(POSITION_CENTER, anchorPosition, popoverDimensions)
+        ? POSITION_CENTER
+        : getOppositePosition(position);
   }
 };
 
@@ -274,9 +285,9 @@ const getMaxPopoverHeight = ({ direction, anchorPosition, popoverContentEl }) =>
 
 const getMaxPopoverHeightValue = ({ direction, anchorPosition }) => {
   switch (direction) {
-    case 'north':
+    case DIRECTION_NORTH:
       return anchorPosition.top - POPUP_OFFSET * 2;
-    case 'south':
+    case DIRECTION_SOUTH:
       return window.innerHeight - anchorPosition.bottom - POPUP_OFFSET * 2;
   }
 };

--- a/components/popover/positionCalculation.js
+++ b/components/popover/positionCalculation.js
@@ -88,11 +88,11 @@ const getHorizontalDirectionPositionTopValue = ({
   inputOffsetCorrection,
 }) => {
   switch (position) {
-    case 'middle':
+    case 'center':
       return anchorPosition.middle - popoverDimensions.height / 2;
-    case 'top':
+    case 'start':
       return anchorPosition.top - POPUP_OFFSET * 0.75 - inputOffsetCorrection;
-    case 'bottom':
+    case 'end':
       return anchorPosition.bottom - popoverDimensions.height + POPUP_OFFSET * 0.75 + inputOffsetCorrection;
   }
 };
@@ -104,11 +104,11 @@ const getHorizontalDirectionPositionLeftValue = ({ direction, anchorPosition, po
 
 const getHorizontalDirectionArrowPositionTopValue = ({ position, popoverDimensions }) => {
   switch (position) {
-    case 'middle':
+    case 'center':
       return popoverDimensions.height / 2 - ARROW_OFFSET;
-    case 'top':
+    case 'start':
       return ARROW_OFFSET * 2.35;
-    case 'bottom':
+    case 'end':
       return popoverDimensions.height - ARROW_OFFSET * 4.5;
   }
 };
@@ -131,9 +131,9 @@ const getVerticalDirectionPositionLeftValue = ({
   switch (position) {
     case 'center':
       return anchorPosition.center - popoverDimensions.width / 2;
-    case 'left':
+    case 'start':
       return anchorPosition.left - inputOffsetCorrection;
-    case 'right':
+    case 'end':
       return anchorPosition.right - popoverDimensions.width + inputOffsetCorrection;
   }
 };
@@ -145,9 +145,9 @@ const getVerticalDirectionArrowPositionLeftValue = ({ position, popoverDimension
   switch (position) {
     case 'center':
       return popoverDimensions.width / 2 - ARROW_OFFSET;
-    case 'left':
+    case 'start':
       return 2 * POPUP_OFFSET;
-    case 'right':
+    case 'end':
       return popoverDimensions.width - POPUP_OFFSET * 3;
   }
 };
@@ -191,65 +191,61 @@ const getDirection = ({ direction, anchorPosition, popoverDimensions }) => {
     : direction;
 };
 
-const isPositionPossible = (position, anchorPosition, popoverDimensions) => {
+const isPositionPossible = (direction, position, anchorPosition, popoverDimensions) =>
+  direction === 'north' || direction === 'south'
+    ? isVerticalDirectionPositionPossible(position, anchorPosition, popoverDimensions)
+    : isHorizontalDirectionPositionPossible(position, anchorPosition, popoverDimensions);
+
+const isVerticalDirectionPositionPossible = (position, anchorPosition, popoverDimensions) => {
   switch (position) {
-    case 'middle':
+    case 'center':
       return (
         anchorPosition.middle + popoverDimensions.height / 2 < window.innerHeight &&
         anchorPosition.middle - popoverDimensions.height / 2 > 0
       );
-    case 'top':
+    case 'start':
       return anchorPosition.top + popoverDimensions.height < window.innerHeight;
-    case 'bottom':
+    case 'end':
       return anchorPosition.bottom - popoverDimensions.height > 0;
+  }
+};
+
+const isHorizontalDirectionPositionPossible = (position, anchorPosition, popoverDimensions) => {
+  switch (position) {
     case 'center':
       return (
         anchorPosition.center + popoverDimensions.width / 2 < window.innerWidth &&
         anchorPosition.center - popoverDimensions.width / 2 > 0
       );
-    case 'left':
+    case 'start':
       return anchorPosition.left + popoverDimensions.width < window.innerWidth;
-    case 'right':
+    case 'end':
       return anchorPosition.right - popoverDimensions.width > 0;
   }
 };
 
 const getOppositePosition = direction => {
   switch (direction) {
-    case 'top':
-      return 'bottom';
-    case 'bottom':
-      return 'top';
-    case 'left':
-      return 'right';
-    case 'right':
-      return 'left';
+    case 'start':
+      return 'end';
+    case 'end':
+      return 'start';
   }
 };
 
-const getPosition = ({ position, anchorPosition, popoverDimensions }) => {
+const getPosition = ({ direction, position, anchorPosition, popoverDimensions }) => {
   if (isPositionPossible(position, anchorPosition, popoverDimensions)) {
     return position;
   }
 
   switch (position) {
-    case 'middle':
-      return isPositionPossible('top', anchorPosition, popoverDimensions)
-        ? 'top'
-        : isPositionPossible('bottom', anchorPosition, popoverDimensions)
-          ? 'bottom'
-          : position;
     case 'center':
-      return isPositionPossible('left', anchorPosition, popoverDimensions)
-        ? 'left'
-        : isPositionPossible('right', anchorPosition, popoverDimensions)
-          ? 'right'
+      return isPositionPossible('start', anchorPosition, popoverDimensions)
+        ? 'start'
+        : isPositionPossible('end', anchorPosition, popoverDimensions)
+          ? 'end'
           : position;
-    case 'top':
-    case 'bottom':
-      return isPositionPossible('middle', anchorPosition, popoverDimensions) ? 'middle' : getOppositePosition(position);
-    case 'left':
-    case 'right':
+    default:
       return isPositionPossible('center', anchorPosition, popoverDimensions) ? 'center' : getOppositePosition(position);
   }
 };
@@ -297,7 +293,7 @@ export const calculatePositions = (
   const popoverDimensions = getElementDimensionValues(popoverEl);
 
   const direction = getDirection({ direction: inputDirection, anchorPosition, popoverDimensions });
-  const position = getPosition({ position: inputPosition, anchorPosition, popoverDimensions });
+  const position = getPosition({ direction, position: inputPosition, anchorPosition, popoverDimensions });
 
   return {
     maxPopoverHeight: getMaxPopoverHeight({

--- a/stories/popover.js
+++ b/stories/popover.js
@@ -31,48 +31,6 @@ const contentBoxWithSingleTextLine = (
       </Link>{' '}
       inside
     </TextBody>
-    <TextBody>
-      This is the popover content with a{' '}
-      <Link href="#" inherit={false}>
-        link
-      </Link>{' '}
-      inside
-    </TextBody>
-    <TextBody>
-      This is the popover content with a{' '}
-      <Link href="#" inherit={false}>
-        link
-      </Link>{' '}
-      inside
-    </TextBody>
-    <TextBody>
-      This is the popover content with a{' '}
-      <Link href="#" inherit={false}>
-        link
-      </Link>{' '}
-      inside
-    </TextBody>
-    <TextBody>
-      This is the popover content with a{' '}
-      <Link href="#" inherit={false}>
-        link
-      </Link>{' '}
-      inside
-    </TextBody>
-    <TextBody>
-      This is the popover content with a{' '}
-      <Link href="#" inherit={false}>
-        link
-      </Link>{' '}
-      inside
-    </TextBody>
-    <TextBody>
-      This is the popover content with a{' '}
-      <Link href="#" inherit={false}>
-        link
-      </Link>{' '}
-      inside
-    </TextBody>
   </Box>
 );
 
@@ -83,7 +41,7 @@ storiesOf('Popover', module)
     },
   })
   .add('Basic', () => (
-    <Box>
+    <Box display="flex" justifyContent="center">
       <Button onClick={handleButtonClick} label="Open a basic Popover" />
       <State store={store}>
         <Popover
@@ -104,7 +62,7 @@ storiesOf('Popover', module)
     </Box>
   ))
   .add('with title', () => (
-    <Box>
+    <Box display="flex" justifyContent="center">
       <Button onClick={handleButtonClick} label="Open titled Popover" />
       <State store={store}>
         <Popover
@@ -128,7 +86,7 @@ storiesOf('Popover', module)
     </Box>
   ))
   .add('with title & subtitle', () => (
-    <Box>
+    <Box display="flex" justifyContent="center">
       <Button onClick={handleButtonClick} label="Open titled & subtitled Popover" />
       <State store={store}>
         <Popover
@@ -153,7 +111,7 @@ storiesOf('Popover', module)
     </Box>
   ))
   .add('with close button', () => (
-    <Box>
+    <Box display="flex" justifyContent="center">
       <Button onClick={handleButtonClick} label="Open Popover with close button" />
       <State store={store}>
         <Popover
@@ -177,7 +135,7 @@ storiesOf('Popover', module)
     </Box>
   ))
   .add('with actions', () => (
-    <Box>
+    <Box display="flex" justifyContent="center">
       <Button onClick={handleButtonClick} label="Open Popover with actions" />
       <State store={store}>
         <Popover
@@ -202,7 +160,7 @@ storiesOf('Popover', module)
     </Box>
   ))
   .add('experiment 1', () => (
-    <Box>
+    <Box display="flex" justifyContent="center">
       <Button onClick={handleButtonClick} label="Open a experimental Popover" />
       <State store={store}>
         <Popover
@@ -229,7 +187,7 @@ storiesOf('Popover', module)
     </Box>
   ))
   .add('experiment 2', () => (
-    <Box>
+    <Box display="flex" justifyContent="center">
       <Button onClick={handleButtonClick} label="Open a experimental Popover" />
       <State store={store}>
         <Popover

--- a/stories/popover.js
+++ b/stories/popover.js
@@ -1,18 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { Store, State } from '@sambego/storybook-state';
-import {
-  Banner,
-  Box,
-  Button,
-  ButtonGroup,
-  Heading3,
-  Link,
-  PopoverHorizontal,
-  PopoverVertical,
-  TextBody,
-  TextSmall,
-} from '../components';
+import { Banner, Box, Button, ButtonGroup, Heading3, Link, Popover, TextBody, TextSmall } from '../components';
 import { select, boolean, number } from '@storybook/addon-knobs/react';
 
 const store = new Store({
@@ -99,7 +88,7 @@ storiesOf('Popover', module)
     <Box>
       <Button onClick={handleButtonClick} label="Open a horizontalPopover" />
       <State store={store}>
-        <PopoverHorizontal
+        <Popover
           active={false}
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
@@ -112,7 +101,7 @@ storiesOf('Popover', module)
           offsetCorrection={number('Offset correction', 0)}
         >
           {contentBoxWithSingleTextLine}
-        </PopoverHorizontal>
+        </Popover>
       </State>
     </Box>
   ))
@@ -120,7 +109,7 @@ storiesOf('Popover', module)
     <Box>
       <Button onClick={handleButtonClick} label="Open a vertical Popover" />
       <State store={store}>
-        <PopoverVertical
+        <Popover
           active={false}
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
@@ -133,7 +122,7 @@ storiesOf('Popover', module)
           offsetCorrection={number('Offset correction', 0)}
         >
           {contentBoxWithSingleTextLine}
-        </PopoverVertical>
+        </Popover>
       </State>
     </Box>
   ))
@@ -141,7 +130,7 @@ storiesOf('Popover', module)
     <Box>
       <Button onClick={handleButtonClick} label="Open titled Popover" />
       <State store={store}>
-        <PopoverVertical
+        <Popover
           active={false}
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
@@ -157,7 +146,7 @@ storiesOf('Popover', module)
             <Heading3>Popover Title</Heading3>
           </Banner>
           {contentBoxWithSingleTextLine}
-        </PopoverVertical>
+        </Popover>
       </State>
     </Box>
   ))
@@ -165,7 +154,7 @@ storiesOf('Popover', module)
     <Box>
       <Button onClick={handleButtonClick} label="Open titled & subtitled Popover" />
       <State store={store}>
-        <PopoverVertical
+        <Popover
           active={false}
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
@@ -182,7 +171,7 @@ storiesOf('Popover', module)
             <TextSmall marginTop={1}>This is the popover content</TextSmall>
           </Banner>
           {contentBoxWithSingleTextLine}
-        </PopoverVertical>
+        </Popover>
       </State>
     </Box>
   ))
@@ -190,7 +179,7 @@ storiesOf('Popover', module)
     <Box>
       <Button onClick={handleButtonClick} label="Open Popover with close button" />
       <State store={store}>
-        <PopoverVertical
+        <Popover
           active={false}
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
@@ -206,7 +195,7 @@ storiesOf('Popover', module)
             <Heading3>I am a heading 3</Heading3>
           </Banner>
           {contentBoxWithSingleTextLine}
-        </PopoverVertical>
+        </Popover>
       </State>
     </Box>
   ))
@@ -214,7 +203,7 @@ storiesOf('Popover', module)
     <Box>
       <Button onClick={handleButtonClick} label="Open Popover with actions" />
       <State store={store}>
-        <PopoverVertical
+        <Popover
           active={false}
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
@@ -231,7 +220,7 @@ storiesOf('Popover', module)
             <Button label="Cancel" />
             <Button level="primary" label="Confirm" />
           </ButtonGroup>
-        </PopoverVertical>
+        </Popover>
       </State>
     </Box>
   ))
@@ -239,7 +228,7 @@ storiesOf('Popover', module)
     <Box>
       <Button onClick={handleButtonClick} label="Open a experimental Popover" />
       <State store={store}>
-        <PopoverVertical
+        <Popover
           active={false}
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
@@ -258,7 +247,7 @@ storiesOf('Popover', module)
               et dolore magna aliquyam erat, sed diam voluptua.
             </TextBody>
           </Box>
-        </PopoverVertical>
+        </Popover>
       </State>
     </Box>
   ))
@@ -266,7 +255,7 @@ storiesOf('Popover', module)
     <Box>
       <Button onClick={handleButtonClick} label="Open a experimental Popover" />
       <State store={store}>
-        <PopoverVertical
+        <Popover
           active={false}
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
@@ -284,7 +273,7 @@ storiesOf('Popover', module)
               <li>dolor sit amet</li>
             </ul>
           </Box>
-        </PopoverVertical>
+        </Popover>
       </State>
     </Box>
   ));

--- a/stories/popover.js
+++ b/stories/popover.js
@@ -11,8 +11,7 @@ const store = new Store({
 const colors = ['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'teal'];
 const tints = ['lightest', 'light', 'normal', 'dark', 'darkest'];
 const backdrops = ['transparent', 'dark'];
-const horizontalDirections = ['east', 'west'];
-const verticalDirections = ['north', 'south'];
+const directions = ['north', 'south', 'east', 'west'];
 const positions = ['start', 'center', 'end'];
 
 const handleButtonClick = event => {
@@ -83,36 +82,15 @@ storiesOf('Popover', module)
       propTablesExclude: [Link, TextBody, TextSmall, Button, State, Banner, Heading3, ButtonGroup, Box],
     },
   })
-  .add('horizontal', () => (
+  .add('Basic', () => (
     <Box>
-      <Button onClick={handleButtonClick} label="Open a horizontalPopover" />
+      <Button onClick={handleButtonClick} label="Open a basic Popover" />
       <State store={store}>
         <Popover
           active={false}
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
-          direction={select('Direction', horizontalDirections, 'west')}
-          position={select('Position', positions, 'center')}
-          onEscKeyDown={handleCloseClick}
-          onOverlayClick={handleCloseClick}
-          tint={select('Tint', tints, 'lightest')}
-          lockScroll={boolean('Lock scroll', true)}
-          offsetCorrection={number('Offset correction', 0)}
-        >
-          {contentBoxWithSingleTextLine}
-        </Popover>
-      </State>
-    </Box>
-  ))
-  .add('vertical', () => (
-    <Box>
-      <Button onClick={handleButtonClick} label="Open a vertical Popover" />
-      <State store={store}>
-        <Popover
-          active={false}
-          backdrop={select('Backdrop', backdrops, 'transparent')}
-          color={select('Color', colors, 'neutral')}
-          direction={select('Direction', verticalDirections, 'south')}
+          direction={select('Direction', directions, 'south')}
           position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
@@ -133,7 +111,7 @@ storiesOf('Popover', module)
           active={false}
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
-          direction={select('Direction', verticalDirections, 'south')}
+          direction={select('Direction', directions, 'south')}
           position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
@@ -157,7 +135,7 @@ storiesOf('Popover', module)
           active={false}
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
-          direction={select('Direction', verticalDirections, 'south')}
+          direction={select('Direction', directions, 'south')}
           position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
@@ -206,7 +184,7 @@ storiesOf('Popover', module)
           active={false}
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
-          direction={select('Direction', verticalDirections, 'south')}
+          direction={select('Direction', directions, 'south')}
           position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
@@ -231,7 +209,7 @@ storiesOf('Popover', module)
           active={false}
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
-          direction={select('Direction', verticalDirections, 'south')}
+          direction={select('Direction', directions, 'south')}
           position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
@@ -258,7 +236,7 @@ storiesOf('Popover', module)
           active={false}
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
-          direction={select('Direction', verticalDirections, 'south')}
+          direction={select('Direction', directions, 'south')}
           position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}

--- a/stories/popover.js
+++ b/stories/popover.js
@@ -13,8 +13,7 @@ const tints = ['lightest', 'light', 'normal', 'dark', 'darkest'];
 const backdrops = ['transparent', 'dark'];
 const horizontalDirections = ['east', 'west'];
 const verticalDirections = ['north', 'south'];
-const horizontalPositions = ['top', 'middle', 'bottom'];
-const verticalPositions = ['left', 'center', 'right'];
+const positions = ['start', 'center', 'end'];
 
 const handleButtonClick = event => {
   store.set({ anchorEl: event.currentTarget, active: true });
@@ -93,7 +92,7 @@ storiesOf('Popover', module)
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
           direction={select('Direction', horizontalDirections, 'west')}
-          position={select('Position', horizontalPositions, 'middle')}
+          position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
@@ -114,7 +113,7 @@ storiesOf('Popover', module)
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
           direction={select('Direction', verticalDirections, 'south')}
-          position={select('Position', verticalPositions, 'center')}
+          position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
@@ -135,7 +134,7 @@ storiesOf('Popover', module)
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
           direction={select('Direction', verticalDirections, 'south')}
-          position={select('Position', verticalPositions, 'center')}
+          position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
@@ -159,7 +158,7 @@ storiesOf('Popover', module)
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
           direction={select('Direction', verticalDirections, 'south')}
-          position={select('Position', verticalPositions, 'center')}
+          position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
@@ -184,7 +183,7 @@ storiesOf('Popover', module)
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
           direction="south"
-          position={select('Position', verticalPositions, 'center')}
+          position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
@@ -208,7 +207,7 @@ storiesOf('Popover', module)
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
           direction={select('Direction', verticalDirections, 'south')}
-          position={select('Position', verticalPositions, 'center')}
+          position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
@@ -233,7 +232,7 @@ storiesOf('Popover', module)
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
           direction={select('Direction', verticalDirections, 'south')}
-          position={select('Position', verticalPositions, 'center')}
+          position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
@@ -260,7 +259,7 @@ storiesOf('Popover', module)
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
           direction={select('Direction', verticalDirections, 'south')}
-          position={select('Position', verticalPositions, 'center')}
+          position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}


### PR DESCRIPTION
### Description

This PR refactors the [Popover component](https://components.teamleader.design/?knob-Position=middle&knob-Direction=west&knob-Lock%20scroll=true&knob-Color=neutral&knob-Backdrop=transparent&knob-Locale=nl&knob-Tint=lightest&knob-Offset%20correction=0&knob-Size=medium&selectedKind=Popover&selectedStory=horizontal&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs).

As [requested](https://github.com/teamleadercrm/ui/pull/343#issuecomment-419834046) in a [previous refactor](https://github.com/teamleadercrm/ui/pull/343): I removed the factory pattern, as it did not have much use anymore.

Nothing should have visually changed.

### Breaking changes

`PopoverHorizontal` and `PopoverVertical` are removed. Use the new `Popover` instead. The `direction` prop (its possible values are: `"north`, `"south"`, `"east"`, "`west`") determines on which axis the component will be rendered.
