### PR TITLE
Loading spinner colours update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Added
 
+- `LoadingSpinner`: added all of the library's tints, accessible via the new `tint` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
+- `LoadingSpinner`: added all of the library's colors, accessible via the `color` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
+
 ### Changed
 
 - `Button`: a link button can be created by setting the level property ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#376](https://github.com/teamleadercrm/ui/pull/376))
@@ -11,6 +14,8 @@
 - [BREAKING] `LinkButton`: The `LinkButton` is removed, since it is replaced by `Button` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#376](https://github.com/teamleadercrm/ui/pull/376))
 
 ### Removed
+
+- `LoadingSpinner`: removed `'white'` as a possible value for `color` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
 
 ### Fixed
 

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -8,7 +8,23 @@ class Button extends PureComponent {
   getSpinnerColor() {
     const { inverse, level } = this.props;
 
-    return level === 'secondary' || (level === 'outline' && !inverse) ? 'teal' : 'white';
+    switch (level) {
+      case 'secondary':
+        return 'teal';
+      case 'outline':
+        return inverse ? 'neutral' : 'teal';
+    }
+  }
+
+  getSpinnerTint() {
+    const { inverse, level } = this.props;
+
+    switch (level) {
+      case 'secondary':
+        return 'darkest';
+      case 'outline':
+        return inverse ? 'lightest' : 'darkest';
+    }
   }
 
   handleMouseUp = event => {
@@ -95,6 +111,7 @@ class Button extends PureComponent {
             className={theme['spinner']}
             color={this.getSpinnerColor()}
             size={size === 'small' ? 'small' : 'medium'}
+            tint={this.getSpinnerTint()}
           />
         ),
     );

--- a/components/loadingSpinner/LoadingSpinner.js
+++ b/components/loadingSpinner/LoadingSpinner.js
@@ -6,8 +6,15 @@ import theme from './theme.css';
 
 class LoadingSpinner extends PureComponent {
   render() {
-    const { className, color, size, ...others } = this.props;
-    const classNames = cx(theme['loading-spinner'], theme[`is-${color}`], theme[`is-${size}`], className);
+    const { className, color, size, tint, ...others } = this.props;
+
+    const classNames = cx(
+      theme['loading-spinner'],
+      theme[`is-${color}`],
+      theme[`is-${size}`],
+      theme[`is-${tint}`],
+      className,
+    );
 
     return <Box data-teamleader-ui="loading-spinner" className={classNames} {...others} />;
   }
@@ -15,13 +22,15 @@ class LoadingSpinner extends PureComponent {
 
 LoadingSpinner.propTypes = {
   className: PropTypes.string,
-  color: PropTypes.oneOf(['white', 'teal']),
+  color: PropTypes.oneOf(['aqua', 'gold', 'mint', 'neutral', 'ruby', 'teal', 'violet']),
   size: PropTypes.oneOf(['small', 'medium']),
+  tint: PropTypes.oneOf(['lightest', 'light', 'normal', 'dark', 'darkest']),
 };
 
 LoadingSpinner.defaultProps = {
   color: 'teal',
   size: 'medium',
+  tint: 'darkest',
 };
 
 export default LoadingSpinner;

--- a/components/loadingSpinner/theme.css
+++ b/components/loadingSpinner/theme.css
@@ -26,14 +26,193 @@
   }
 }
 
-.is-teal:before {
-  border: var(--spinner-border-width) solid color(var(--color-teal-darkest) a(18%));
-  border-top-color: var(--color-teal-darkest);
+.is-neutral {
+  &.is-lightest:before {
+    border: var(--spinner-border-width) solid color(var(--color-neutral-lightest) a(18%));
+    border-top-color: var(--color-neutral-lightest);
+  }
+
+  &.is-light:before {
+    border: var(--spinner-border-width) solid color(var(--color-neutral-light) a(18%));
+    border-top-color: var(--color-neutral-light);
+  }
+
+  &.is-normal:before {
+    border: var(--spinner-border-width) solid color(var(--color-neutral) a(18%));
+    border-top-color: var(--color-neutral);
+  }
+
+  &.is-dark:before {
+    border: var(--spinner-border-width) solid color(var(--color-neutral-dark) a(18%));
+    border-top-color: var(--color-neutral-dark);
+  }
+
+  &.is-darkest:before {
+    border: var(--spinner-border-width) solid color(var(--color-neutral-darkest) a(18%));
+    border-top-color: var(--color-neutral-darkest);
+  }
 }
 
-.is-white:before {
-  border: var(--spinner-border-width) solid color(var(--color-neutral-lightest) a(18%));
-  border-top-color: var(--color-neutral-lightest);
+.is-mint {
+  &.is-lightest:before {
+    border: var(--spinner-border-width) solid color(var(--color-mint-lightest) a(18%));
+    border-top-color: var(--color-mint-lightest);
+  }
+
+  &.is-light:before {
+    border: var(--spinner-border-width) solid color(var(--color-mint-light) a(18%));
+    border-top-color: var(--color-mint-light);
+  }
+
+  &.is-normal:before {
+    border: var(--spinner-border-width) solid color(var(--color-mint) a(18%));
+    border-top-color: var(--color-mint);
+  }
+
+  &.is-dark:before {
+    border: var(--spinner-border-width) solid color(var(--color-mint-dark) a(18%));
+    border-top-color: var(--color-mint-dark);
+  }
+
+  &.is-darkest:before {
+    border: var(--spinner-border-width) solid color(var(--color-mint-darkest) a(18%));
+    border-top-color: var(--color-mint-darkest);
+  }
+}
+
+.is-violet {
+  &.is-lightest:before {
+    border: var(--spinner-border-width) solid color(var(--color-violet-lightest) a(18%));
+    border-top-color: var(--color-violet-lightest);
+  }
+
+  &.is-light:before {
+    border: var(--spinner-border-width) solid color(var(--color-violet-light) a(18%));
+    border-top-color: var(--color-violet-light);
+  }
+
+  &.is-normal:before {
+    border: var(--spinner-border-width) solid color(var(--color-violet) a(18%));
+    border-top-color: var(--color-violet);
+  }
+
+  &.is-dark:before {
+    border: var(--spinner-border-width) solid color(var(--color-violet-dark) a(18%));
+    border-top-color: var(--color-violet-dark);
+  }
+
+  &.is-darkest:before {
+    border: var(--spinner-border-width) solid color(var(--color-violet-darkest) a(18%));
+    border-top-color: var(--color-violet-darkest);
+  }
+}
+
+.is-ruby {
+  &.is-lightest:before {
+    border: var(--spinner-border-width) solid color(var(--color-ruby-lightest) a(18%));
+    border-top-color: var(--color-ruby-lightest);
+  }
+
+  &.is-light:before {
+    border: var(--spinner-border-width) solid color(var(--color-ruby-light) a(18%));
+    border-top-color: var(--color-ruby-light);
+  }
+
+  &.is-normal:before {
+    border: var(--spinner-border-width) solid color(var(--color-ruby) a(18%));
+    border-top-color: var(--color-ruby);
+  }
+
+  &.is-dark:before {
+    border: var(--spinner-border-width) solid color(var(--color-ruby-dark) a(18%));
+    border-top-color: var(--color-ruby-dark);
+  }
+
+  &.is-darkest:before {
+    border: var(--spinner-border-width) solid color(var(--color-ruby-darkest) a(18%));
+    border-top-color: var(--color-ruby-darkest);
+  }
+}
+
+.is-gold {
+  &.is-lightest:before {
+    border: var(--spinner-border-width) solid color(var(--color-gold-lightest) a(18%));
+    border-top-color: var(--color-gold-lightest);
+  }
+
+  &.is-light:before {
+    border: var(--spinner-border-width) solid color(var(--color-gold-light) a(18%));
+    border-top-color: var(--color-gold-light);
+  }
+
+  &.is-normal:before {
+    border: var(--spinner-border-width) solid color(var(--color-gold) a(18%));
+    border-top-color: var(--color-gold);
+  }
+
+  &.is-dark:before {
+    border: var(--spinner-border-width) solid color(var(--color-gold-dark) a(18%));
+    border-top-color: var(--color-gold-dark);
+  }
+
+  &.is-darkest:before {
+    border: var(--spinner-border-width) solid color(var(--color-gold-darkest) a(18%));
+    border-top-color: var(--color-gold-darkest);
+  }
+}
+
+.is-aqua {
+  &.is-lightest:before {
+    border: var(--spinner-border-width) solid color(var(--color-aqua-lightest) a(18%));
+    border-top-color: var(--color-aqua-lightest);
+  }
+
+  &.is-light:before {
+    border: var(--spinner-border-width) solid color(var(--color-aqua-light) a(18%));
+    border-top-color: var(--color-aqua-light);
+  }
+
+  &.is-normal:before {
+    border: var(--spinner-border-width) solid color(var(--color-aqua) a(18%));
+    border-top-color: var(--color-aqua);
+  }
+
+  &.is-dark:before {
+    border: var(--spinner-border-width) solid color(var(--color-aqua-dark) a(18%));
+    border-top-color: var(--color-aqua-dark);
+  }
+
+  &.is-darkest:before {
+    border: var(--spinner-border-width) solid color(var(--color-aqua-darkest) a(18%));
+    border-top-color: var(--color-aqua-darkest);
+  }
+}
+
+.is-teal {
+  &.is-lightest:before {
+    border: var(--spinner-border-width) solid color(var(--color-teal-lightest) a(18%));
+    border-top-color: var(--color-teal-lightest);
+  }
+
+  &.is-light:before {
+    border: var(--spinner-border-width) solid color(var(--color-teal-light) a(18%));
+    border-top-color: var(--color-teal-light);
+  }
+
+  &.is-normal:before {
+    border: var(--spinner-border-width) solid color(var(--color-teal) a(18%));
+    border-top-color: var(--color-teal);
+  }
+
+  &.is-dark:before {
+    border: var(--spinner-border-width) solid color(var(--color-teal-dark) a(18%));
+    border-top-color: var(--color-teal-dark);
+  }
+
+  &.is-darkest:before {
+    border: var(--spinner-border-width) solid color(var(--color-teal-darkest) a(18%));
+    border-top-color: var(--color-teal-darkest);
+  }
 }
 
 .is-small {

--- a/components/toast/Toast.js
+++ b/components/toast/Toast.js
@@ -90,7 +90,7 @@ class Toast extends PureComponent {
     return (
       <div data-teamleader-ui="toast" onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
         <div className={classNames}>
-          {processing && <LoadingSpinner className={theme['spinner']} color="white" />}
+          {processing && <LoadingSpinner className={theme['spinner']} color="neutral" tint="lightest" />}
           <TextBody className={theme['label']} color="white">
             {label}
             {children}

--- a/stories/loadingSpinner.js
+++ b/stories/loadingSpinner.js
@@ -9,8 +9,8 @@ const tints = ['lightest', 'light', 'normal', 'dark', 'darkest'];
 
 storiesOf('Loading spinners', module).add('Basic', () => (
   <LoadingSpinner
-    color={select('Color', colors, 'neutral')}
+    color={select('Color', colors, 'teal')}
     size={select('Size', sizes, 'medium')}
-    tint={select('Tint', tints, 'lightest')}
+    tint={select('Tint', tints, 'darkest')}
   />
 ));

--- a/stories/loadingSpinner.js
+++ b/stories/loadingSpinner.js
@@ -3,9 +3,14 @@ import { storiesOf } from '@storybook/react';
 import { select } from '@storybook/addon-knobs/react';
 import { LoadingSpinner } from '../components';
 
-const colors = ['teal', 'white'];
+const colors = ['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'teal'];
 const sizes = ['small', 'medium'];
+const tints = ['lightest', 'light', 'normal', 'dark', 'darkest'];
 
 storiesOf('Loading spinners', module).add('Basic', () => (
-  <LoadingSpinner color={select('Color', colors, 'teal')} size={select('Size', sizes, 'medium')} />
+  <LoadingSpinner
+    color={select('Color', colors, 'neutral')}
+    size={select('Size', sizes, 'medium')}
+    tint={select('Tint', tints, 'lightest')}
+  />
 ));


### PR DESCRIPTION
### Description

This PR updates the `LoadingSpinner`, so it can be displayed in all our different colours and their tints.

Up until now there were only two colours `'white'` and `'teal'` possible.
By introducing the `tint` prop, we can use the more correct colour `'neutral'` instead, in combination with the `tint` prop set to `'lightest'`.

This gives us the opportunity to add the [correct spinner](https://github.com/teamleadercrm/ui/pull/376#discussion_r220245921), for the `Button` with the `level` `'link'`.

#### Screenshot before this PR

![screen shot 2018-09-27 at 11 55 14](https://user-images.githubusercontent.com/23736202/46138602-9b15cb80-c24c-11e8-9ef9-351fc7990fdd.png)
![screen shot 2018-09-27 at 11 55 33](https://user-images.githubusercontent.com/23736202/46138604-9cdf8f00-c24c-11e8-9732-cdad716700d2.png)

#### Screenshot after this PR
![screen shot 2018-09-27 at 11 57 38](https://user-images.githubusercontent.com/23736202/46138610-a1a44300-c24c-11e8-9edd-e634afdfc590.png)
![screen shot 2018-09-27 at 11 57 28](https://user-images.githubusercontent.com/23736202/46138613-a36e0680-c24c-11e8-9aec-1e349d589cda.png)
![screen shot 2018-09-27 at 11 56 06](https://user-images.githubusercontent.com/23736202/46138615-a537ca00-c24c-11e8-83c0-f9ae380a944d.png)
![screen shot 2018-09-27 at 11 56 24](https://user-images.githubusercontent.com/23736202/46138623-a79a2400-c24c-11e8-9dc3-41779cdbd282.png)
![screen shot 2018-09-27 at 11 56 37](https://user-images.githubusercontent.com/23736202/46138626-a8cb5100-c24c-11e8-8cea-fa393bfc7107.png)
![screen shot 2018-09-27 at 11 56 56](https://user-images.githubusercontent.com/23736202/46138627-a9fc7e00-c24c-11e8-98b8-67b81a149595.png)
![screen shot 2018-09-27 at 11 57 13](https://user-images.githubusercontent.com/23736202/46138631-abc64180-c24c-11e8-91eb-1be73c0c0b74.png)

### Breaking changes
None.