### PR TITLE
Bugfix: avoid using Math.max()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- `Input`: fixed the failing Storybook build by avoiding the usage of Math.max() ([@driesd](https://github.com/driesd) in [#379](https://github.com/teamleadercrm/ui/pull/379))
+
 ## [0.15.2] - 2018-09-25
 
 ### Added

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -45,7 +45,13 @@ export default class Input extends PureComponent {
 
   bindToMinMax(value) {
     const { min, max } = this.props;
-    return Math.min(Math.max(value, min), max);
+
+    if (value > max) {
+      return max;
+    } else if (value < min) {
+      return min;
+    }
+    return value;
   }
 
   state = {


### PR DESCRIPTION
### Description

Before this PR we were using `Math.max()` in our `Input` component. Apparently this was breaking the production deploy of our design-components CI. This was caused by Storybooks dependency usage of `babel-preset-minify`.

This PR avoids the usage of `Math.max()` by refactoring the code with an `if/else if` notation.

### Breaking changes

None.
