### PR TITLE
Button level link add LoadingSpinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `LoadingSpinner`: added all of the library's tints, accessible via the new `tint` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
 - `LoadingSpinner`: added all of the library's colors, accessible via the `color` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
 - `DataGrid`: added the `HeaderRowOverlay` which displays the amount of selected items and bulk actions ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#352](https://github.com/teamleadercrm/ui/pull/352))
+- `Button`: added the `LoadingSpinners` for the `Button`s whose `level` is set to `'link'` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#376](https://github.com/teamleadercrm/ui/pull/376))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - `LoadingSpinner`: added all of the library's tints, accessible via the new `tint` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
 - `LoadingSpinner`: added all of the library's colors, accessible via the `color` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
 - `DataGrid`: added the `HeaderRowOverlay` which displays the amount of selected items and bulk actions ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#352](https://github.com/teamleadercrm/ui/pull/352))
-- `Button`: added the `LoadingSpinners` for the `Button`s whose `level` is set to `'link'` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#376](https://github.com/teamleadercrm/ui/pull/376))
+- `Button`: added the `LoadingSpinners` for the `Button`s whose `level` is set to `'link'` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#380](https://github.com/teamleadercrm/ui/pull/380))
 
 ### Changed
 

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -13,6 +13,10 @@ class Button extends PureComponent {
         return 'teal';
       case 'outline':
         return inverse ? 'neutral' : 'teal';
+      case 'link':
+        return inverse ? 'neutral' : 'aqua';
+      default:
+        return 'neutral';
     }
   }
 
@@ -24,6 +28,10 @@ class Button extends PureComponent {
         return 'darkest';
       case 'outline':
         return inverse ? 'lightest' : 'darkest';
+      case 'link':
+        return inverse ? 'lightest' : 'dark';
+      default:
+        return 'lightest';
     }
   }
 
@@ -105,15 +113,14 @@ class Button extends PureComponent {
         </span>
       ),
       icon && iconPlacement === 'right' && icon,
-      processing &&
-        level !== 'link' && (
-          <LoadingSpinner
-            className={theme['spinner']}
-            color={this.getSpinnerColor()}
-            size={size === 'small' ? 'small' : 'medium'}
-            tint={this.getSpinnerTint()}
-          />
-        ),
+      processing && (
+        <LoadingSpinner
+          className={theme['spinner']}
+          color={this.getSpinnerColor()}
+          size={size === 'small' ? 'small' : 'medium'}
+          tint={this.getSpinnerTint()}
+        />
+      ),
     );
   }
 }

--- a/components/button/theme.css
+++ b/components/button/theme.css
@@ -416,6 +416,10 @@
   &.has-icon-only:hover {
     background-color: color(var(--color-neutral-darkest) a(0.24));
   }
+
+  &.is-processing {
+    color: transparent;
+  }
 }
 
 /* Button sizes */


### PR DESCRIPTION
### Description

This PR displays the `LoadingSpinner` in the `Button` with `level` set to `'link'`, when it is processing.

#### Screenshot before this PR

![screen shot 2018-09-27 at 15 33 57](https://user-images.githubusercontent.com/23736202/46149621-05d5ff80-c26b-11e8-9972-2b89c51ed44d.png)
![screen shot 2018-09-27 at 15 35 04](https://user-images.githubusercontent.com/23736202/46149628-08d0f000-c26b-11e8-974c-293ff9a9d157.png)

#### Screenshot after this PR

![screen shot 2018-09-27 at 15 34 41](https://user-images.githubusercontent.com/23736202/46149644-0ec6d100-c26b-11e8-9213-309b921b7d40.png)
![screen shot 2018-09-27 at 15 35 25](https://user-images.githubusercontent.com/23736202/46149659-14241b80-c26b-11e8-8782-0f66a93c5eb7.png)

### Breaking changes
None.
