### PR TITLE
Link: extend with an icon & iconPlacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - [BREAKING] `Popover`: added the `Popover`, it replaces `PopoverHorizontal` and `PopoverVertical` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#377](https://github.com/teamleadercrm/ui/pull/377))
+- `Link`: added `icon`& `iconPlacement` props ([@driesd](https://github.com/driesd) in [#381](https://github.com/teamleadercrm/ui/pull/381))
 - `LoadingSpinner`: added all of the library's tints, accessible via the new `tint` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
 - `LoadingSpinner`: added all of the library's colors, accessible via the `color` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
 - `DataGrid`: added the `HeaderRowOverlay` which displays the amount of selected items and bulk actions ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#352](https://github.com/teamleadercrm/ui/pull/352))

--- a/components/link/Link.js
+++ b/components/link/Link.js
@@ -1,11 +1,11 @@
-import React, { PureComponent } from 'react';
+import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import theme from './theme.css';
 
 class Link extends PureComponent {
   render() {
-    const { children, className, element, inherit, ...others } = this.props;
+    const { children, className, icon, iconPlacement, element, inherit, ...others } = this.props;
 
     const classNames = cx(
       theme['link'],
@@ -15,11 +15,14 @@ class Link extends PureComponent {
       className,
     );
 
+    const ChildrenWrapper = icon ? 'span' : Fragment;
     const Element = element || 'a';
 
     return (
       <Element className={classNames} data-teamleader-ui="link" {...others}>
-        {children}
+        {icon && iconPlacement === 'left' && icon}
+        <ChildrenWrapper>{children}</ChildrenWrapper>
+        {icon && iconPlacement === 'right' && icon}
       </Element>
     );
   }

--- a/components/link/Link.js
+++ b/components/link/Link.js
@@ -30,6 +30,8 @@ Link.propTypes = {
   className: PropTypes.string,
   /** The icon displayed inside the button. */
   icon: PropTypes.element,
+  /** The position of the icon inside the button. */
+  iconPlacement: PropTypes.oneOf(['left', 'right']),
   inherit: PropTypes.bool,
   element: PropTypes.element,
 };

--- a/components/link/Link.js
+++ b/components/link/Link.js
@@ -16,7 +16,7 @@ class Link extends PureComponent {
     );
 
     const ChildrenWrapper = icon ? 'span' : Fragment;
-    const Element = element || 'a';
+    const Element = element;
 
     return (
       <Element className={classNames} data-teamleader-ui="link" {...others}>
@@ -41,6 +41,7 @@ Link.propTypes = {
 
 Link.defaultProps = {
   className: '',
+  element: 'a',
   inherit: true,
 };
 

--- a/components/link/Link.js
+++ b/components/link/Link.js
@@ -28,6 +28,8 @@ class Link extends PureComponent {
 Link.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
+  /** The icon displayed inside the button. */
+  icon: PropTypes.element,
   inherit: PropTypes.bool,
   element: PropTypes.element,
 };

--- a/components/link/theme.css
+++ b/components/link/theme.css
@@ -11,7 +11,7 @@
   padding: 0;
 
   svg {
-    transform: translateY(-2px);
+    transform: translate3d(0, -2px, 0);
   }
 
   * + svg,

--- a/components/link/theme.css
+++ b/components/link/theme.css
@@ -10,6 +10,15 @@
   font-size: 100%;
   padding: 0;
 
+  svg {
+    transform: translateY(-1px);
+  }
+
+  * + svg,
+  svg + * {
+    margin-left: var(--spacer-smallest);
+  }
+
   &:not(.inherit) {
     color: var(--color-aqua-dark);
     font-family: var(--font-family-regular);

--- a/components/link/theme.css
+++ b/components/link/theme.css
@@ -5,6 +5,10 @@
 .link {
   composes: reset-font-smoothing;
   cursor: pointer;
+  background: transparent;
+  border: 0;
+  font-size: 100%;
+  padding: 0;
 
   &:not(.inherit) {
     color: var(--color-aqua-dark);

--- a/components/link/theme.css
+++ b/components/link/theme.css
@@ -11,7 +11,7 @@
   padding: 0;
 
   svg {
-    transform: translateY(-1px);
+    transform: translateY(-2px);
   }
 
   * + svg,

--- a/stories/link.js
+++ b/stories/link.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, select } from '@storybook/addon-knobs/react';
+import { IconAddSmallOutline } from '@teamleader/ui-icons';
 import { Link, TextDisplay } from '../components';
 
+const elements = ['a', 'button'];
 const colors = ['white', 'neutral', 'mint', 'teal', 'violet', 'ruby', 'gold', 'aqua'];
+const iconPositions = ['left', 'right'];
 
 storiesOf('Links', module)
   .addParameters({
@@ -11,12 +14,37 @@ storiesOf('Links', module)
       propTablesExclude: [TextDisplay],
     },
   })
-  .add('Basic', () => (
+  .add('With text', () => (
     <TextDisplay color={select('Color', colors, 'teal')}>
       Display text with a{' '}
       <Link href="https://www.teamleader.be" target="_blank" inherit={boolean('Inherit', false)}>
         link
       </Link>{' '}
       inside
+    </TextDisplay>
+  ))
+  .add('With text and icon', () => (
+    <TextDisplay color={select('Color', colors, 'teal')}>
+      <Link
+        href="https://www.teamleader.be"
+        icon={<IconAddSmallOutline />}
+        iconPlacement={select('Icon placement', iconPositions, 'left')}
+        target="_blank"
+        inherit={boolean('Inherit', false)}
+      >
+        link
+      </Link>
+    </TextDisplay>
+  ))
+  .add('With custom element', () => (
+    <TextDisplay color={select('Color', colors, 'teal')}>
+      <Link
+        element={select('Element', elements, 'button')}
+        icon={<IconAddSmallOutline />}
+        iconPlacement={select('Icon placement', iconPositions, 'left')}
+        inherit={boolean('Inherit', false)}
+      >
+        link
+      </Link>
     </TextDisplay>
   ));


### PR DESCRIPTION
### Description

This PR implements the `icon` && `iconPlacement` props in our `Link` component.

#### Screenshot before this PR

![schermafdruk 2018-09-28 16 00 57](https://user-images.githubusercontent.com/5336831/46213180-35067280-c338-11e8-9bb2-121aced96d42.png)

#### Screenshot after this PR

![schermafdruk 2018-09-28 16 01 07](https://user-images.githubusercontent.com/5336831/46213194-3d5ead80-c338-11e8-8c41-9b19d37f3417.png)

![schermafdruk 2018-09-28 16 01 58](https://user-images.githubusercontent.com/5336831/46213204-43548e80-c338-11e8-9613-d756ebc390e7.png)

### Breaking changes

None.
