### PR TITLE
[TU-67] Input: prefix & suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- `Input`: added `prefix` & `suffix` props. ([@driesd](https://github.com/driesd) in [#383](https://github.com/teamleadercrm/ui/pull/383))
 - [BREAKING] `Popover`: added the `Popover`, it replaces `PopoverHorizontal` and `PopoverVertical` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#377](https://github.com/teamleadercrm/ui/pull/377))
 - `Link`: added `icon`& `iconPlacement` props ([@driesd](https://github.com/driesd) in [#381](https://github.com/teamleadercrm/ui/pull/381))
 - `LoadingSpinner`: added all of the library's tints, accessible via the new `tint` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
@@ -22,6 +23,7 @@
 
 ### Removed
 
+- [BREAKING] `Input`: removed `counter`, `icon` & `iconPlacement` props. They've been replaced by `prefix` & `suffix`. ([@driesd](https://github.com/driesd) in [#383](https://github.com/teamleadercrm/ui/pull/383))
 - `LoadingSpinner`: removed `'white'` as a possible value for `color` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
 
 ### Fixed

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -217,10 +217,8 @@ export default class Input extends PureComponent {
       inverse,
       prefix,
       size,
-      spinner,
       suffix,
       readOnly,
-      type,
       ...others
     } = this.props;
 
@@ -234,7 +232,6 @@ export default class Input extends PureComponent {
         [theme['has-focus']]: inputHasFocus,
         [theme['has-connected-left']]: connectedLeft,
         [theme['has-connected-right']]: connectedRight,
-        [theme['has-spinner']]: type === 'number' && spinner,
         [theme['is-inverse']]: inverse,
         [theme['is-disabled']]: disabled,
         [theme['is-read-only']]: readOnly,

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -207,6 +207,14 @@ export default class Input extends PureComponent {
     );
   }
 
+  renderOneOrMultipleElements(prop) {
+    if (Array.isArray(prop)) {
+      return prop.map((element, index) => React.cloneElement(element, { key: index }));
+    }
+
+    return prop;
+  }
+
   render() {
     const {
       className,
@@ -240,17 +248,15 @@ export default class Input extends PureComponent {
     );
 
     const rest = pickBoxProps(others);
-    const prefixes = prefix.map((prefix, index) => React.cloneElement(prefix, { key: `prefix-${index}` }));
-    const suffixes = suffix.map((suffix, index) => React.cloneElement(suffix, { key: `suffix-${index}` }));
 
     return (
       <Box className={classNames} {...rest}>
         <div className={theme['input-wrapper']}>
           {connectedLeft}
           <div className={theme['input-inner-wrapper']}>
-            {prefix && <div className={theme['prefix-wrapper']}>{prefixes}</div>}
+            {prefix && <div className={theme['prefix-wrapper']}>{this.renderOneOrMultipleElements(prefix)}</div>}
             {this.renderInput()}
-            {suffix && <div className={theme['suffix-wrapper']}>{suffixes}</div>}
+            {suffix && <div className={theme['suffix-wrapper']}>{this.renderOneOrMultipleElements(suffix)}</div>}
             {this.renderSpinnerControls()}
           </div>
           {connectedRight}

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -60,6 +60,8 @@ export default class Input extends PureComponent {
       this.updateValue(event, parsedValue);
     }
 
+    this.setState({ inputHasFocus: false });
+
     if (this.props.onBlur) {
       this.props.onBlur(event);
     }
@@ -70,6 +72,8 @@ export default class Input extends PureComponent {
   };
 
   handleFocus = event => {
+    this.setState({ inputHasFocus: true });
+
     if (this.props.onFocus) {
       this.props.onFocus(event);
     }

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -1,4 +1,4 @@
-import React, { PureComponent, createElement } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import omit from 'lodash.omit';
@@ -114,8 +114,6 @@ export default class Input extends PureComponent {
       'connectedLeft',
       'connectedRight',
       'helpText',
-      'icon',
-      'iconPlacement',
       'inverse',
       'onChange',
       'size',
@@ -202,8 +200,6 @@ export default class Input extends PureComponent {
       connectedRight,
       disabled,
       error,
-      icon,
-      iconPlacement,
       inverse,
       size,
       spinner,
@@ -216,7 +212,6 @@ export default class Input extends PureComponent {
       theme['wrapper'],
       theme[`is-${size}`],
       {
-        [theme[`has-icon-${iconPlacement}`]]: icon,
         [theme['has-error']]: error,
         [theme['has-connected-left']]: connectedLeft,
         [theme['has-connected-right']]: connectedRight,
@@ -239,10 +234,6 @@ export default class Input extends PureComponent {
         <div className={inputWrapperClassnames}>
           {connectedLeft}
           <div className={theme['input-inner-wrapper']}>
-            {icon &&
-              createElement(icon, {
-                className: theme['icon'],
-              })}
             {this.renderInput()}
             {this.renderSpinnerControls()}
           </div>
@@ -267,10 +258,6 @@ Input.propTypes = {
   error: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   /** The text string to use as help text below the input. */
   helpText: PropTypes.string,
-  /** The icon displayed inside the input. */
-  icon: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
-  /** The position of the icon inside the input. */
-  iconPlacement: PropTypes.oneOf(['left', 'right']),
   /** Boolean indicating whether the input should render as inverse. */
   inverse: PropTypes.bool,
   max: PropTypes.number,
@@ -294,7 +281,6 @@ Input.propTypes = {
 };
 
 Input.defaultProps = {
-  iconPlacement: 'left',
   inverse: false,
   disabled: false,
   min: Number.MIN_SAFE_INTEGER,

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -276,6 +276,8 @@ Input.propTypes = {
   spinner: PropTypes.bool,
   /** Callback function that is fired when blurring the input field. */
   onBlur: PropTypes.func,
+  /** Callback function that is fired when focusing the input field. */
+  onFocus: PropTypes.func,
   /** Callback function that is fired when the component's value changes. */
   onChange: PropTypes.func,
   /** The text string/element to use as a prefix inside the input field */

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -275,7 +275,7 @@ Input.propTypes = {
   /** Callback function that is fired when the component's value changes. */
   onChange: PropTypes.func,
   /** The text string/element to use as a prefix inside the input field */
-  prefix: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  prefix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
   /** Boolean indicating whether the input should render as read only. */
   readOnly: PropTypes.bool,
   /** Size of the input element. */
@@ -283,7 +283,7 @@ Input.propTypes = {
   /** Limit increment value for numeric inputs. */
   step: PropTypes.number,
   /** The text string/element to use as a suffix inside the input field */
-  suffix: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  suffix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
   /** Type of the input element. It can be a valid HTML5 input type. */
   type: PropTypes.string,
   /** Current value of the input element. */

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -276,6 +276,8 @@ Input.propTypes = {
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   /** Limit increment value for numeric inputs. */
   step: PropTypes.number,
+  /** The text string/element to use as a suffix inside the input field */
+  suffix: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   /** Type of the input element. It can be a valid HTML5 input type. */
   type: PropTypes.string,
   /** Current value of the input element. */

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -61,7 +61,7 @@ export default class Input extends PureComponent {
     }
 
     if (this.props.onBlur) {
-      this.props.onBlur();
+      this.props.onBlur(event);
     }
   };
 

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -238,9 +238,9 @@ export default class Input extends PureComponent {
         <div className={inputWrapperClassnames}>
           {connectedLeft}
           <div className={theme['input-inner-wrapper']}>
-            {prefix}
+            <div className={theme['prefix-wrapper']}>{prefix}</div>
             {this.renderInput()}
-            {suffix}
+            <div className={theme['suffix-wrapper']}>{suffix}</div>
             {this.renderSpinnerControls()}
           </div>
           {connectedRight}

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -48,6 +48,7 @@ export default class Input extends PureComponent {
   }
 
   state = {
+    inputHasFocus: false,
     value: '',
   };
 

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -240,15 +240,17 @@ export default class Input extends PureComponent {
     );
 
     const rest = pickBoxProps(others);
+    const prefixes = prefix.map((prefix, index) => React.cloneElement(prefix, { key: `prefix-${index}` }));
+    const suffixes = suffix.map((suffix, index) => React.cloneElement(suffix, { key: `suffix-${index}` }));
 
     return (
       <Box className={classNames} {...rest}>
         <div className={theme['input-wrapper']}>
           {connectedLeft}
           <div className={theme['input-inner-wrapper']}>
-            {prefix && <div className={theme['prefix-wrapper']}>{prefix}</div>}
+            {prefix && <div className={theme['prefix-wrapper']}>{prefixes}</div>}
             {this.renderInput()}
-            {suffix && <div className={theme['suffix-wrapper']}>{suffix}</div>}
+            {suffix && <div className={theme['suffix-wrapper']}>{suffixes}</div>}
             {this.renderSpinnerControls()}
           </div>
           {connectedRight}

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -201,8 +201,10 @@ export default class Input extends PureComponent {
       disabled,
       error,
       inverse,
+      prefix,
       size,
       spinner,
+      suffix,
       readOnly,
       type,
       ...others
@@ -234,7 +236,9 @@ export default class Input extends PureComponent {
         <div className={inputWrapperClassnames}>
           {connectedLeft}
           <div className={theme['input-inner-wrapper']}>
+            {prefix}
             {this.renderInput()}
+            {suffix}
             {this.renderSpinnerControls()}
           </div>
           {connectedRight}

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -69,6 +69,12 @@ export default class Input extends PureComponent {
     this.updateValue(event, event.target.value);
   };
 
+  handleFocus = event => {
+    if (this.props.onFocus) {
+      this.props.onFocus(event);
+    }
+  };
+
   handleIncreaseValue = event => {
     this.updateStep(event, 1);
   };
@@ -135,6 +141,7 @@ export default class Input extends PureComponent {
       className: classNames,
       onBlur: this.handleBlur,
       onChange: this.handleChange,
+      onFocus: this.handleFocus,
       type,
       value,
       ...restProps,

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -9,7 +9,6 @@ import {
 } from '@teamleader/ui-icons';
 import Box, { omitBoxProps, pickBoxProps } from '../box';
 import Button from '../button';
-import Counter from '../counter';
 import { TextSmall } from '../typography';
 import theme from './theme.css';
 
@@ -114,7 +113,6 @@ export default class Input extends PureComponent {
       'className',
       'connectedLeft',
       'connectedRight',
-      'counter',
       'helpText',
       'icon',
       'iconPlacement',
@@ -143,12 +141,6 @@ export default class Input extends PureComponent {
     };
 
     return <input {...props} />;
-  }
-
-  renderCounter() {
-    if (this.props.counter) {
-      return <Counter className={theme['counter']} count={this.props.counter} color="ruby" size="small" />;
-    }
   }
 
   renderHelpText() {
@@ -208,7 +200,6 @@ export default class Input extends PureComponent {
       className,
       connectedLeft,
       connectedRight,
-      counter,
       disabled,
       error,
       icon,
@@ -226,7 +217,6 @@ export default class Input extends PureComponent {
       theme[`is-${size}`],
       {
         [theme[`has-icon-${iconPlacement}`]]: icon,
-        [theme['has-counter']]: counter,
         [theme['has-error']]: error,
         [theme['has-connected-left']]: connectedLeft,
         [theme['has-connected-right']]: connectedRight,
@@ -254,7 +244,6 @@ export default class Input extends PureComponent {
                 className: theme['icon'],
               })}
             {this.renderInput()}
-            {this.renderCounter()}
             {this.renderSpinnerControls()}
           </div>
           {connectedRight}
@@ -272,8 +261,6 @@ Input.propTypes = {
   className: PropTypes.string,
   connectedLeft: PropTypes.element,
   connectedRight: PropTypes.element,
-  /** The number to render as a counter inside the input. */
-  counter: PropTypes.number,
   /** Boolean indicating whether the input should render as disabled. */
   disabled: PropTypes.bool,
   /** The text string/element to use as error message below the input. */

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -268,6 +268,8 @@ Input.propTypes = {
   onBlur: PropTypes.func,
   /** Callback function that is fired when the component's value changes. */
   onChange: PropTypes.func,
+  /** The text string/element to use as a prefix inside the input field */
+  prefix: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   /** Boolean indicating whether the input should render as read only. */
   readOnly: PropTypes.bool,
   /** Size of the input element. */

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -116,8 +116,10 @@ export default class Input extends PureComponent {
       'helpText',
       'inverse',
       'onChange',
+      'prefix',
       'size',
       'spinner',
+      'suffix',
       'value',
     ]);
 

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -249,9 +249,9 @@ export default class Input extends PureComponent {
         <div className={theme['input-wrapper']}>
           {connectedLeft}
           <div className={theme['input-inner-wrapper']}>
-            <div className={theme['prefix-wrapper']}>{prefix}</div>
+            {prefix && <div className={theme['prefix-wrapper']}>{prefix}</div>}
             {this.renderInput()}
-            <div className={theme['suffix-wrapper']}>{suffix}</div>
+            {suffix && <div className={theme['suffix-wrapper']}>{suffix}</div>}
             {this.renderSpinnerControls()}
           </div>
           {connectedRight}

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -242,15 +242,11 @@ export default class Input extends PureComponent {
       className,
     );
 
-    const inputWrapperClassnames = cx(theme['input-wrapper'], {
-      [theme['has-error']]: error,
-    });
-
     const rest = pickBoxProps(others);
 
     return (
       <Box className={classNames} {...rest}>
-        <div className={inputWrapperClassnames}>
+        <div className={theme['input-wrapper']}>
           {connectedLeft}
           <div className={theme['input-inner-wrapper']}>
             <div className={theme['prefix-wrapper']}>{prefix}</div>

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -213,11 +213,14 @@ export default class Input extends PureComponent {
       ...others
     } = this.props;
 
+    const { inputHasFocus } = this.state;
+
     const classNames = cx(
       theme['wrapper'],
       theme[`is-${size}`],
       {
         [theme['has-error']]: error,
+        [theme['has-focus']]: inputHasFocus,
         [theme['has-connected-left']]: connectedLeft,
         [theme['has-connected-right']]: connectedRight,
         [theme['has-spinner']]: type === 'number' && spinner,

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -34,9 +34,13 @@
       color: var(--color-neutral-darkest);
     }
 
+    .input-inner-wrapper {
+      border: 1px solid var(--color-neutral-dark);
+    }
+
     .input {
       background: var(--color-white);
-      border: 1px solid var(--color-neutral-dark);
+      border: 0;
       color: var(--color-teal-darkest);
 
       &::placeholder {

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -137,23 +137,17 @@
           border-color: var(--color-teal-light);
           box-shadow: 0 0 0 1px var(--color-teal-light);
         }
+
+        .spinner-up,
+        .spinner-down {
+          border-color: var(--color-teal-light);
+        }
       }
 
       &:active {
         .input-inner-wrapper {
           border-color: var(--color-teal-light);
           box-shadow: inset 0 1px 3px 0 color(var(--color-teal-darkest) a(0.48));
-        }
-      }
-
-      .input {
-        &:focus {
-          + .spinner {
-            .spinner-up,
-            .spinner-down {
-              border-color: var(--color-teal-light);
-            }
-          }
         }
       }
     }

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -122,6 +122,10 @@
 
     &:not(.is-disabled):not(.is-read-only) {
       &:hover {
+        .input-inner-wrapper {
+          border-color: var(--color-teal-light);
+        }
+
         .spinner-up,
         .spinner-down {
           border-color: var(--color-teal-light);
@@ -129,10 +133,6 @@
       }
 
       .input {
-        &:hover {
-          border-color: var(--color-teal-light);
-        }
-
         &:focus {
           border-color: var(--color-teal-light);
           box-shadow: 0 0 0 1px var(--color-teal-light);

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -35,11 +35,11 @@
     }
 
     .input-inner-wrapper {
+      background: var(--color-white);
       border: 1px solid var(--color-neutral-dark);
     }
 
     .input {
-      background: var(--color-white);
       border: 0;
       color: var(--color-teal-darkest);
 

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -50,6 +50,10 @@
 
     &:not(.is-disabled):not(.is-read-only) {
       &:hover {
+        .input-inner-wrapper {
+          border-color: var(--color-neutral-darkest);
+        }
+
         .spinner-up,
         .spinner-down {
           border-color: var(--color-neutral-darkest);
@@ -57,10 +61,6 @@
       }
 
       .input {
-        &:hover {
-          border-color: var(--color-neutral-darkest);
-        }
-
         &:focus {
           border-color: var(--color-neutral-darkest);
           box-shadow: 0 0 0 1px var(--color-neutral-darkest);

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -292,6 +292,10 @@
   color: var(--color-ruby-dark);
 }
 
+.validation-icon {
+  margin-top: -1px;
+}
+
 /**
  * Modifiers
  */
@@ -347,10 +351,6 @@
       border-color: var(--input-error-border) !important;
       box-shadow: 0 0 0 1px var(--input-error-border) !important;
       z-index: 2;
-    }
-
-    .validation-icon {
-      margin-top: -1px;
     }
 
     .validation-text {

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -44,8 +44,6 @@
     }
 
     .input {
-      background: transparent;
-      border: 0;
       color: var(--color-teal-darkest);
 
       &::placeholder {
@@ -219,6 +217,8 @@
   width: 100%;
   padding: 0 var(--input-horizontal-padding);
 
+  background: transparent;
+  border: 0;
   border-radius: var(--input-border-radius);
   box-shadow: 0;
 

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -29,6 +29,10 @@
 .wrapper {
   width: 100%;
 
+  &.has-focus .input-inner-wrapper {
+    z-index: 1;
+  }
+
   &:not(.is-inverse) {
     .icon {
       color: var(--color-neutral-darkest);
@@ -239,7 +243,6 @@
 
   &:focus {
     outline: none;
-    z-index: 1;
   }
 
   &.is-bold {

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -132,11 +132,15 @@
         }
       }
 
-      .input {
-        &:focus {
+      &.has-focus {
+        .input-inner-wrapper {
           border-color: var(--color-teal-light);
           box-shadow: 0 0 0 1px var(--color-teal-light);
+        }
+      }
 
+      .input {
+        &:focus {
           + .spinner {
             .spinner-up,
             .spinner-down {

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -95,7 +95,7 @@
     }
 
     &.is-read-only {
-      .input {
+      .input-inner-wrapper {
         background-color: var(--color-neutral);
         border-color: var(--color-neutral);
       }

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -9,15 +9,11 @@
   --input-height-medium: calc(3.4 * var(--unit));
   --input-height-small: calc(3 * var(--unit));
   --input-horizontal-padding: calc(0.5 * var(--unit));
-  --input-horizontal-padding-icon-large: calc(3.5 * var(--unit));
-  --input-horizontal-padding-icon: calc(2.2 * var(--unit));
   --input-text-size: calc(1.4 * var(--unit));
   --input-text-size-large: calc(1.6 * var(--unit));
   --input-border-radius: calc(0.4 * var(--unit));
   --input-error-border: var(--color-ruby-dark);
   --input-error-border-inverse: var(--color-ruby-light);
-
-  --icon-horizontal: calc(0.5 * var(--unit));
 
   --spinner-width: calc(3 * var(--unit));
   --spinner-width-large: calc(3.6 * var(--unit));
@@ -34,10 +30,6 @@
   }
 
   &:not(.is-inverse) {
-    .icon {
-      color: var(--color-neutral-darkest);
-    }
-
     .input-inner-wrapper {
       background: var(--color-white);
       border: 1px solid var(--color-neutral-dark);
@@ -103,10 +95,6 @@
   }
 
   &.is-inverse {
-    .icon {
-      color: var(--color-teal-light);
-    }
-
     .input-inner-wrapper {
       background: var(--color-teal);
       border: 1px solid var(--color-teal);
@@ -286,22 +274,6 @@
   border-radius: var(--input-border-radius) 0 0 var(--input-border-radius);
 }
 
-.icon,
-.counter {
-  position: absolute;
-  z-index: 1;
-  top: 50%;
-  transform: translateY(-50%);
-}
-
-.icon {
-  left: var(--icon-horizontal);
-}
-
-.counter {
-  right: var(--icon-horizontal);
-}
-
 .spinner {
   display: flex;
   flex-direction: column;
@@ -350,18 +322,6 @@
     height: var(--input-height-large);
     width: var(--spinner-width-large);
   }
-
-  &.has-icon-left {
-    .input {
-      padding-left: var(--input-horizontal-padding-icon-large);
-    }
-  }
-
-  &.has-icon-right {
-    .input {
-      padding-right: var(--input-horizontal-padding-icon-large);
-    }
-  }
 }
 
 .is-small {
@@ -387,24 +347,6 @@
   .spinner-up,
   .spinner-down {
     border-radius: 0;
-  }
-}
-
-.has-icon-left {
-  .input {
-    padding-left: var(--input-horizontal-padding-icon);
-  }
-}
-
-.has-icon-right,
-.has-counter {
-  .input {
-    padding-right: var(--input-horizontal-padding-icon);
-  }
-
-  .icon {
-    left: auto;
-    right: var(--icon-horizontal);
   }
 }
 

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -236,6 +236,36 @@
   }
 }
 
+.prefix-wrapper,
+.suffix-wrapper {
+  align-items: center;
+  display: flex;
+
+  > * {
+    white-space: nowrap;
+  }
+
+  svg {
+    transform: translate3D(0, -1px, 0);
+  }
+}
+
+.prefix-wrapper {
+  padding-left: var(--input-horizontal-padding);
+
+  > * {
+    margin-right: var(--input-horizontal-padding);
+  }
+}
+
+.suffix-wrapper {
+  padding-right: var(--input-horizontal-padding);
+
+  > * {
+    margin-left: var(--input-horizontal-padding);
+  }
+}
+
 .has-spinner .input {
   border-radius: var(--input-border-radius) 0 0 var(--input-border-radius);
 }

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -173,7 +173,8 @@
   }
 
   > *:first-child {
-    border-radius: var(--input-border-radius) 0 0 var(--input-border-radius);
+    border-top-left-radius: var(--input-border-radius);
+    border-bottom-left-radius: var(--input-border-radius);
   }
 
   > *:first-child:not(.input-inner-wrapper) {
@@ -181,7 +182,8 @@
   }
 
   > *:last-child {
-    border-radius: 0 var(--input-border-radius) var(--input-border-radius) 0;
+    border-top-right-radius: var(--input-border-radius);
+    border-bottom-right-radius: var(--input-border-radius);
   }
 
   > *:last-child:not(.input-inner-wrapper) {
@@ -194,6 +196,7 @@
   align-items: center;
   display: flex;
   flex: 1;
+  overflow: hidden;
   position: relative;
 }
 
@@ -215,7 +218,7 @@
 
   background: transparent;
   border: 0;
-  border-radius: var(--input-border-radius);
+  border-radius: 0;
   box-shadow: 0;
 
   font-size: var(--input-text-size);
@@ -270,10 +273,6 @@
   }
 }
 
-.has-spinner .input {
-  border-radius: var(--input-border-radius) 0 0 var(--input-border-radius);
-}
-
 .spinner {
   display: flex;
   flex-direction: column;
@@ -284,17 +283,16 @@
 
 .spinner-up,
 .spinner-down {
+  border-radius: 0;
   min-width: 0;
   padding: 0 !important;
 }
 
 .spinner-up {
-  border-radius: 0 var(--input-border-radius) 0 0;
   border-width: 0 0 1px 1px !important;
 }
 
 .spinner-down {
-  border-radius: 0 0 var(--input-border-radius) 0;
   border-width: 0 0 0 1px !important;
 }
 

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -139,6 +139,13 @@
         }
       }
 
+      &:active {
+        .input-inner-wrapper {
+          border-color: var(--color-teal-light);
+          box-shadow: inset 0 1px 3px 0 color(var(--color-teal-darkest) a(0.48));
+        }
+      }
+
       .input {
         &:focus {
           + .spinner {
@@ -147,11 +154,6 @@
               border-color: var(--color-teal-light);
             }
           }
-        }
-
-        &:active {
-          border-color: var(--color-neutral-darkest);
-          box-shadow: inset 0 1px 3px 0 color(var(--color-teal-darkest) a(0.48));
         }
       }
     }

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -70,23 +70,17 @@
           border-color: var(--color-neutral-darkest);
           box-shadow: 0 0 0 1px var(--color-neutral-darkest);
         }
+
+        .spinner-up,
+        .spinner-down {
+          border-color: var(--color-neutral-darkest);
+        }
       }
 
       &:active {
         .input-inner-wrapper {
           border-color: var(--color-neutral-darkest);
           box-shadow: inset 0 1px 3px 0 rgba(130, 130, 140, 0.48);
-        }
-      }
-
-      .input {
-        &:focus {
-          + .spinner {
-            .spinner-up,
-            .spinner-down {
-              border-color: var(--color-neutral-darkest);
-            }
-          }
         }
       }
     }

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -67,6 +67,13 @@
         }
       }
 
+      &:active {
+        .input-inner-wrapper {
+          border-color: var(--color-neutral-darkest);
+          box-shadow: inset 0 1px 3px 0 rgba(130, 130, 140, 0.48);
+        }
+      }
+
       .input {
         &:focus {
           + .spinner {
@@ -75,11 +82,6 @@
               border-color: var(--color-neutral-darkest);
             }
           }
-        }
-
-        &:active {
-          border-color: var(--color-neutral-darkest);
-          box-shadow: inset 0 1px 3px 0 rgba(130, 130, 140, 0.48);
         }
       }
     }

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -40,6 +40,7 @@
     }
 
     .input {
+      background: transparent;
       border: 0;
       color: var(--color-teal-darkest);
 

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -84,9 +84,12 @@
     }
 
     &.is-disabled {
-      .input {
+      .input-inner-wrapper {
         background-color: var(--color-neutral);
         border-color: var(--color-neutral);
+      }
+
+      .input {
         color: var(--color-neutral-darkest);
       }
     }

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -107,9 +107,12 @@
       color: var(--color-teal-light);
     }
 
-    .input {
+    .input-inner-wrapper {
       background: var(--color-teal);
       border: 1px solid var(--color-teal);
+    }
+
+    .input {
       color: var(--color-neutral-lightest);
 
       &::placeholder {

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -177,17 +177,9 @@
     border-bottom-left-radius: var(--input-border-radius);
   }
 
-  > *:first-child:not(.input-inner-wrapper) {
-    border-right: 0;
-  }
-
   > *:last-child {
     border-top-right-radius: var(--input-border-radius);
     border-bottom-right-radius: var(--input-border-radius);
-  }
-
-  > *:last-child:not(.input-inner-wrapper) {
-    border-left: 0;
   }
 }
 
@@ -330,44 +322,31 @@
 }
 
 .has-connected-left {
-  .input {
-    border-bottom-left-radius: 0;
-    border-top-left-radius: 0;
+  .input-wrapper *:first-child:focus {
+    z-index: 3;
+  }
+
+  .input-inner-wrapper {
+    margin-left: -1px;
   }
 }
 
 .has-connected-right {
-  .input {
-    border-bottom-right-radius: 0;
-    border-top-right-radius: 0;
+  .input-wrapper *:last-child:focus {
+    z-index: 2;
   }
 
-  .spinner-up,
-  .spinner-down {
-    border-radius: 0;
+  .input-inner-wrapper + * {
+    margin-left: -1px;
   }
 }
 
 .has-error {
   &:not(.is-inverse) {
-    &.has-connected-left .input-wrapper > *:first-child,
-    &.has-connected-right .input-wrapper > *:last-child,
-    .input {
+    &:not(.has-focus) .input-inner-wrapper {
       border-color: var(--input-error-border) !important;
-    }
-
-    .spinner-down {
-      border-bottom-color: var(--input-error-border);
-      border-right-color: var(--input-error-border);
-    }
-
-    .spinner-up {
-      border-top-color: var(--input-error-border);
-      border-right-color: var(--input-error-border);
-    }
-
-    .input-wrapper {
-      box-shadow: 0 0 0 1px var(--input-error-border);
+      box-shadow: 0 0 0 1px var(--input-error-border) !important;
+      z-index: 2;
     }
 
     .validation-icon {
@@ -380,24 +359,10 @@
   }
 
   &.is-inverse {
-    &.has-connected-left .input-wrapper > *:first-child,
-    &.has-connected-right .input-wrapper > *:last-child,
-    .input {
+    &:not(.has-focus) .input-inner-wrapper {
       border-color: var(--input-error-border-inverse) !important;
-    }
-
-    .spinner-down {
-      border-bottom-color: var(--input-error-border-inverse);
-      border-right-color: var(--input-error-border-inverse);
-    }
-
-    .spinner-up {
-      border-top-color: var(--input-error-border-inverse);
-      border-right-color: var(--input-error-border-inverse);
-    }
-
-    .input-wrapper {
-      box-shadow: 0 0 0 1px var(--input-error-border-inverse);
+      box-shadow: 0 0 0 1px var(--input-error-border-inverse) !important;
+      z-index: 2;
     }
 
     .validation-text {

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -316,11 +316,12 @@
 
 .spinner-up {
   border-radius: 0 var(--input-border-radius) 0 0;
+  border-width: 0 0 1px 1px !important;
 }
 
 .spinner-down {
   border-radius: 0 0 var(--input-border-radius) 0;
-  border-top: 0 !important;
+  border-width: 0 0 0 1px !important;
 }
 
 .error {

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -153,9 +153,12 @@
     }
 
     &.is-disabled {
-      .input {
+      .input-inner-wrapper {
         background-color: var(--color-teal-dark);
         border-color: var(--color-teal-dark);
+      }
+
+      .input {
         color: var(--color-teal);
 
         &::placeholder {

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -60,11 +60,15 @@
         }
       }
 
-      .input {
-        &:focus {
+      &.has-focus {
+        .input-inner-wrapper {
           border-color: var(--color-neutral-darkest);
           box-shadow: 0 0 0 1px var(--color-neutral-darkest);
+        }
+      }
 
+      .input {
+        &:focus {
           + .spinner {
             .spinner-up,
             .spinner-down {

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -168,7 +168,7 @@
     }
 
     &.is-read-only {
-      .input {
+      .input-inner-wrapper {
         background-color: var(--color-teal-dark);
         border-color: var(--color-teal-dark);
       }

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -6,7 +6,7 @@
  */
 :root {
   --input-height-large: calc(4.8 * var(--unit));
-  --input-height-medium: calc(3.6 * var(--unit));
+  --input-height-medium: calc(3.4 * var(--unit));
   --input-height-small: calc(3 * var(--unit));
   --input-horizontal-padding: calc(0.5 * var(--unit));
   --input-horizontal-padding-icon-large: calc(3.5 * var(--unit));

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -186,6 +186,7 @@
 }
 
 .input-inner-wrapper {
+  align-items: center;
   display: flex;
   flex: 1;
   position: relative;

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -202,6 +202,7 @@
 }
 
 .input-inner-wrapper {
+  transition: 0.3s ease-in-out border, 0.3s ease-in-out box-shadow;
   align-items: center;
   display: flex;
   flex: 1;
@@ -217,8 +218,6 @@
 }
 
 .input {
-  transition: 0.3s ease-in-out border, 0.3s ease-in-out box-shadow;
-
   position: relative;
   box-sizing: border-box;
 

--- a/stories/input.js
+++ b/stories/input.js
@@ -1,13 +1,32 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, number, select } from '@storybook/addon-knobs/react';
-import { Button, Checkbox, Icon, Input, Label, TextSmall, Tooltip } from '../components';
-import { IconCalendarMediumOutline, IconCalendarSmallOutline, IconInfoBadgedSmallFilled } from '@teamleader/ui-icons';
+import {
+  Button,
+  Checkbox,
+  Counter,
+  Icon,
+  Input,
+  Label,
+  LoadingSpinner,
+  TextBody,
+  TextSmall,
+  Tooltip,
+} from '../components';
+import { IconCalendarSmallOutline, IconInfoBadgedSmallFilled } from '@teamleader/ui-icons';
 
-const iconPlacement = ['left', 'right'];
 const colors = ['aqua', 'gold', 'mint', 'neutral', 'ruby', 'teal', 'violet'];
 const sizes = ['small', 'medium', 'large'];
 const tints = ['lightest', 'light', 'normal', 'dark', 'darkest'];
+
+const prefix = [
+  <Icon color="neutral" tint="darkest">
+    <IconCalendarSmallOutline />
+  </Icon>,
+  <TextBody color="neutral">€</TextBody>,
+];
+
+const suffix = [<TextSmall color="neutral">incl. BTW</TextSmall>, <Counter count={99} />, <LoadingSpinner />];
 
 const props = {
   helpText: 'This is the fields help text',
@@ -69,39 +88,11 @@ storiesOf('Inputs', module)
       />
     </Label>
   ))
-  .add('with icon', () => (
-    <Label htmlFor="input1" inverse={boolean('Inverse', false)} size={select('Size', sizes, 'medium')}>
-      Input label
-      <Input
-        icon={select('Size', sizes, 'medium') === 'large' ? IconCalendarMediumOutline : IconCalendarSmallOutline}
-        iconPlacement={select('Icon placement', iconPlacement, 'left')}
-        id="input1"
-        bold={boolean('Bold', false)}
-        disabled={boolean('Disabled', false)}
-        readOnly={boolean('Read only', false)}
-        {...props}
-      />
-    </Label>
-  ))
-  .add('with counter', () => (
-    <Label htmlFor="input1" inverse={boolean('Inverse', false)} size={select('Size', sizes, 'medium')}>
-      Input label
-      <Input
-        id="input1"
-        size="small"
-        counter={99}
-        bold={boolean('Bold', false)}
-        disabled={boolean('Disabled', false)}
-        readOnly={boolean('Read only', false)}
-        {...props}
-      />
-    </Label>
-  ))
   .add('with error', () => (
     <Label htmlFor="input1" inverse={boolean('Inverse', false)} size={select('Size', sizes, 'medium')}>
       Input label
       <Input
-        error={<span>This is an error message</span>}
+        error="This is an error message"
         id="input1"
         size="small"
         value="wrong value"
@@ -136,6 +127,20 @@ storiesOf('Inputs', module)
         bold={boolean('Bold', false)}
         disabled={boolean('Disabled', false)}
         readOnly={boolean('Read only', false)}
+        {...props}
+      />
+    </Label>
+  ))
+  .add('with prefix or suffix', () => (
+    <Label htmlFor="input1" inverse={boolean('Inverse', false)} size={select('Size', sizes, 'medium')}>
+      Input label
+      <Input
+        id="input1"
+        bold={boolean('Bold', false)}
+        disabled={boolean('Disabled', false)}
+        readOnly={boolean('Read only', false)}
+        prefix={prefix}
+        suffix={suffix}
         {...props}
       />
     </Label>


### PR DESCRIPTION
### Description

This PR adds `prefix` & `suffix` props, which can contain `one element` or an `array of elements`.
Also it removes `counter`, `icon` & `iconPlacement` because these props were too limited in use.

#### Screenshot before this PR

![schermafdruk 2018-10-04 14 26 56](https://user-images.githubusercontent.com/5336831/46473853-b26f2e80-c7e1-11e8-932a-9171e52a4ff2.png)

![schermafdruk 2018-10-04 14 27 43](https://user-images.githubusercontent.com/5336831/46473858-b56a1f00-c7e1-11e8-82e1-73b8dd2d5c0b.png)

![schermafdruk 2018-10-04 14 27 05](https://user-images.githubusercontent.com/5336831/46473864-b9963c80-c7e1-11e8-9b94-177d646a3661.png)

#### Screenshot after this PR

![schermafdruk 2018-10-04 14 25 22](https://user-images.githubusercontent.com/5336831/46473882-cadf4900-c7e1-11e8-984e-dcf1bff51fb6.png)

### Breaking changes

We removed `counter`, `icon` & `iconPlacement` props. They've been replaced by `prefix` & `suffix`.
