### PR TITLE
Input: refactor spinner positioning

### DIFF
--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -259,7 +259,7 @@
 .spinner {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  height: var(--input-height-medium);
 
   width: var(--spinner-width);
 }
@@ -300,6 +300,7 @@
   }
 
   .spinner {
+    height: var(--input-height-large);
     width: var(--spinner-width-large);
   }
 
@@ -323,7 +324,8 @@
 }
 
 .is-small {
-  .input {
+  .input,
+  .spinner {
     height: var(--input-height-small);
   }
 }

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -254,7 +254,7 @@
   display: flex;
   flex-direction: column;
   height: var(--input-height-medium);
-
+  margin-left: -1px;
   width: var(--spinner-width);
 }
 

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -235,6 +235,10 @@
   }
 }
 
+.has-spinner .input {
+  border-radius: var(--input-border-radius) 0 0 var(--input-border-radius);
+}
+
 .icon,
 .counter {
   position: absolute;

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -234,12 +234,6 @@
   }
 }
 
-.has-spinner {
-  .input {
-    padding-right: calc(var(--spinner-width) + var(--input-horizontal-padding));
-  }
-}
-
 .icon,
 .counter {
   position: absolute;
@@ -302,12 +296,6 @@
   .spinner {
     height: var(--input-height-large);
     width: var(--spinner-width-large);
-  }
-
-  &.has-spinner {
-    .input {
-      padding-right: calc(var(--spinner-width-large) + var(--input-horizontal-padding));
-    }
   }
 
   &.has-icon-left {

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -227,6 +227,7 @@
 
   &:focus {
     outline: none;
+    z-index: 1;
   }
 
   &.is-bold {

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -186,6 +186,7 @@
 }
 
 .input-inner-wrapper {
+  display: flex;
   flex: 1;
   position: relative;
 }
@@ -256,10 +257,6 @@
 }
 
 .spinner {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  right: 0;
   display: flex;
   flex-direction: column;
   height: 100%;


### PR DESCRIPTION
### Description

In this PR we refactored the way of positioning the input spinner.

Before this PR the spinner was positioned absolute above the input field. This way we had to adjust the input field's right padding according to its size, just to make the text wasn't dissappearing underneath the spinner controls.

After this PR the spinner is positioned right next to the input field by using flexbox. This way we can drop the padding adjustments. Also it's a good first step to refactor our complex Input component, in the following PRs. 

#### Screenshot before this PR

![schermafdruk 2018-08-08 16 48 19](https://user-images.githubusercontent.com/5336831/46290237-91ad9b80-c58b-11e8-9d41-e0e7ac0247ce.png)

#### Screenshot after this PR

![schermafdruk 2018-08-08 16 48 19](https://user-images.githubusercontent.com/5336831/46290237-91ad9b80-c58b-11e8-9d41-e0e7ac0247ce.png)

### Breaking changes

None.
