### PR TITLE
[TU 138] Box alignItems missing values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `LoadingSpinner`: added all of the library's colors, accessible via the `color` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
 - `DataGrid`: added the `HeaderRowOverlay` which displays the amount of selected items and bulk actions ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#352](https://github.com/teamleadercrm/ui/pull/352))
 - `Button`: added the `LoadingSpinners` for the `Button`s whose `level` is set to `'link'` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#380](https://github.com/teamleadercrm/ui/pull/380))
+- `Box`: added `baseline` and `stretch` as possible values for the `alignItems` property ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#387](https://github.com/teamleadercrm/ui/pull/387))
 
 ### Changed
 

--- a/components/box/Box.js
+++ b/components/box/Box.js
@@ -95,7 +95,7 @@ class Box extends PureComponent {
 
 Box.propTypes = {
   alignContent: PropTypes.oneOf(['center', 'flex-start', 'flex-end', 'space-around', 'space-between', 'space-evenly']),
-  alignItems: PropTypes.oneOf(['center', 'flex-start', 'flex-end']),
+  alignItems: PropTypes.oneOf(['center', 'flex-start', 'flex-end', 'baseline', 'stretch']),
   alignSelf: PropTypes.oneOf(['center', 'flex-start', 'flex-end', 'stretch']),
   boxSizing: PropTypes.oneOf(['border-box', 'content-box']),
   children: PropTypes.any,

--- a/components/box/theme.css
+++ b/components/box/theme.css
@@ -77,7 +77,7 @@
   }
 }
 
-@each $item-alignment in (center, flex-start, flex-end) {
+@each $item-alignment in (center, flex-start, flex-end, baseline, stretch) {
   .align-items-$(item-alignment) {
     align-items: $item-alignment;
   }


### PR DESCRIPTION
### Description

In this PR `baseline` and `stretch` are added as possible values for the `alignItems` prop.

Nothing should have visually changed.

### Breaking changes

None.
