### PR TITLE
Link: Add string as a possible prop type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `LoadingSpinner`: added all of the library's colors, accessible via the `color` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
 - `DataGrid`: added the `HeaderRowOverlay` which displays the amount of selected items and bulk actions ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#352](https://github.com/teamleadercrm/ui/pull/352))
 - `Button`: added the `LoadingSpinners` for the `Button`s whose `level` is set to `'link'` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#380](https://github.com/teamleadercrm/ui/pull/380))
+- `Link`: added `string` as a possible property type for the `element` property ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#388](https://github.com/teamleadercrm/ui/pull/388))
 
 ### Changed
 

--- a/components/link/Link.js
+++ b/components/link/Link.js
@@ -36,7 +36,7 @@ Link.propTypes = {
   /** The position of the icon inside the button. */
   iconPlacement: PropTypes.oneOf(['left', 'right']),
   inherit: PropTypes.bool,
-  element: PropTypes.element,
+  element: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
 };
 
 Link.defaultProps = {


### PR DESCRIPTION
### Description

This PR alters the prop type declaration of the `Link` element, so that `string` is a valid type for the `element` prop. 

Nothing has visually changed.

### Breaking changes
None
