### PR TITLE
[TU-132] DataGrid add loading state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,35 +1,40 @@
-## [unreleased]
-
 ### Added
-
-- `Input`: added `prefix` & `suffix` props. ([@driesd](https://github.com/driesd) in [#383](https://github.com/teamleadercrm/ui/pull/383))
-- [BREAKING] `Popover`: added the `Popover`, it replaces `PopoverHorizontal` and `PopoverVertical` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#377](https://github.com/teamleadercrm/ui/pull/377))
-- `Link`: added `icon`& `iconPlacement` props ([@driesd](https://github.com/driesd) in [#381](https://github.com/teamleadercrm/ui/pull/381))
-- `LoadingSpinner`: added all of the library's tints, accessible via the new `tint` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
-- `LoadingSpinner`: added all of the library's colors, accessible via the `color` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
-- `DataGrid`: added the `HeaderRowOverlay` which displays the amount of selected items and bulk actions ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#352](https://github.com/teamleadercrm/ui/pull/352))
-- `Button`: added the `LoadingSpinners` for the `Button`s whose `level` is set to `'link'` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#380](https://github.com/teamleadercrm/ui/pull/380))
-- `Box`: added `baseline` and `stretch` as possible values for the `alignItems` property ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#387](https://github.com/teamleadercrm/ui/pull/387))
-- `LoadingBar`: added the new `LoadingBar` component ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#385](https://github.com/teamleadercrm/ui/pull/385))
-- `Link`: added `string` as a possible property type for the `element` property ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#388](https://github.com/teamleadercrm/ui/pull/388))
 
 ### Changed
 
-- `DataGrid`: changed the header checkbox, it does not render in an intermediate state anymore, when some rows are selected ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#352](https://github.com/teamleadercrm/ui/pull/352))
-- `Button`: a link button can be created by setting the level property ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#376](https://github.com/teamleadercrm/ui/pull/376))
-
 ### Deprecated
 
-- [BREAKING] `LinkButton`: The `LinkButton` is removed, since it is replaced by `Button` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#376](https://github.com/teamleadercrm/ui/pull/376))
-- [BREAKING] `PopoverHorizontal`: The `PopoverHorizontal` is removed, since it is replaced by `Popover` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#377](https://github.com/teamleadercrm/ui/pull/377))
-- [BREAKING] `PopoverVertical`: The `PopoverVertical` is removed, since it is replaced by `Popover` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#377](https://github.com/teamleadercrm/ui/pull/377))
+### Removed
+
+### Fixed
+
+## [0.16.0] - 2018-10-08
+
+### Added
+
+- `Box`: added `baseline` and `stretch` as possible values for the `alignItems` property ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#387](https://github.com/teamleadercrm/ui/pull/387))
+- `Button`: added the `LoadingSpinners` for the `Button`s whose `level` is set to `'link'` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#380](https://github.com/teamleadercrm/ui/pull/380))
+- `DataGrid`: added the `HeaderRowOverlay` which displays the amount of selected items and bulk actions ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#352](https://github.com/teamleadercrm/ui/pull/352))
+- `Input`: added `prefix` & `suffix` props. ([@driesd](https://github.com/driesd) in [#383](https://github.com/teamleadercrm/ui/pull/383))
+- `Popover`: added the `Popover`, it replaces `PopoverHorizontal` and `PopoverVertical` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#377](https://github.com/teamleadercrm/ui/pull/377))
+- `Link`: added `icon`& `iconPlacement` props ([@driesd](https://github.com/driesd) in [#381](https://github.com/teamleadercrm/ui/pull/381))
+- `Link`: added `string` as a possible property type for the `element` property ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#388](https://github.com/teamleadercrm/ui/pull/388))
+- `LoadingBar`: added the new `LoadingBar` component ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#385](https://github.com/teamleadercrm/ui/pull/385))
+- `LoadingSpinner`: added all of the library's tints, accessible via the new `tint` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
+- `LoadingSpinner`: added all of the library's colors, accessible via the `color` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
+
+### Changed
+
+- `Button`: a link button can be created by setting the level property ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#376](https://github.com/teamleadercrm/ui/pull/376))
+- `DataGrid`: changed the header checkbox, it does not render in an intermediate state anymore, when some rows are selected ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#352](https://github.com/teamleadercrm/ui/pull/352))
 
 ### Removed
 
 - [BREAKING] `Input`: removed `counter`, `icon` & `iconPlacement` props. They've been replaced by `prefix` & `suffix`. ([@driesd](https://github.com/driesd) in [#383](https://github.com/teamleadercrm/ui/pull/383))
+- [BREAKING] `LinkButton`: The `LinkButton` is removed, since it is replaced by `Button` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#376](https://github.com/teamleadercrm/ui/pull/376))
 - `LoadingSpinner`: removed `'white'` as a possible value for `color` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#378](https://github.com/teamleadercrm/ui/pull/378))
-
-### Fixed
+- [BREAKING] `PopoverHorizontal`: The `PopoverHorizontal` is removed, since it is replaced by `Popover` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#377](https://github.com/teamleadercrm/ui/pull/377))
+- [BREAKING] `PopoverVertical`: The `PopoverVertical` is removed, since it is replaced by `Popover` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#377](https://github.com/teamleadercrm/ui/pull/377))
 
 ## [0.15.2] - 2018-09-25
 

--- a/components/datagrid/DataGrid.js
+++ b/components/datagrid/DataGrid.js
@@ -196,10 +196,12 @@ DataGrid.propTypes = {
   stickyFromLeft: PropTypes.number,
   stickyFromRight: PropTypes.number,
   onSelectionChange: PropTypes.func,
+  processing: PropTypes.bool,
 };
 
 DataGrid.defaultProps = {
   checkboxSize: 'small',
+  processing: false,
 };
 
 DataGrid.HeaderRow = HeaderRow;

--- a/components/datagrid/DataGrid.js
+++ b/components/datagrid/DataGrid.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import Box from '../box';
+import LoadingBar from '../loadingBar';
 import HeaderRowOverlay from './HeaderRowOverlay';
 import Cell from './Cell';
 import HeaderCell from './HeaderCell';
@@ -110,7 +111,16 @@ class DataGrid extends PureComponent {
   };
 
   render() {
-    const { checkboxSize, children, className, selectable, stickyFromLeft, stickyFromRight, ...others } = this.props;
+    const {
+      checkboxSize,
+      children,
+      className,
+      processing,
+      selectable,
+      stickyFromLeft,
+      stickyFromRight,
+      ...others
+    } = this.props;
     const { selectedRows } = this.state;
 
     const classNames = cx(theme['data-grid'], className);
@@ -123,6 +133,7 @@ class DataGrid extends PureComponent {
 
     return (
       <Box data-teamleader-ui="data-grid" className={classNames} {...rest}>
+        {processing && <LoadingBar className={cx(theme['loading-bar'])} />}
         {selectedRows.length > 0 &&
           React.Children.map(children, child => {
             if (isComponentOfType(HeaderRowOverlay, child)) {

--- a/components/datagrid/theme.css
+++ b/components/datagrid/theme.css
@@ -93,6 +93,13 @@
   color: var(--color-teal-darkest);
 }
 
+.loading-bar {
+  position: absolute;
+  top: 48px;
+  left: 0;
+  z-index: 3;
+}
+
 /* Cell backgrounds */
 .has-background-neutral {
   background-color: var(--color-neutral-light) !important;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "author": "Teamleader <development@teamleader.eu>",
   "betterScripts": {
     "compile": {

--- a/stories/datagrid.js
+++ b/stories/datagrid.js
@@ -34,6 +34,7 @@ storiesOf('DataGrids', module)
       comparableId={1}
       onSelectionChange={handleRowSelectionChange}
       checkboxSize={select('Checkbox size', ['small', 'medium', 'large'], 'small')}
+      processing={boolean('Processing', false)}
     >
       <DataGrid.HeaderRowOverlay
         numSelectedRowsLabel={numSelectedRows => (numSelectedRows === 1 ? 'sélectionné' : 'sélectionnés')}
@@ -94,7 +95,12 @@ storiesOf('DataGrids', module)
     </DataGrid>
   ))
   .add('with footer', () => (
-    <DataGrid selectable={boolean('Selectable', true)} comparableId={1} onSelectionChange={handleRowSelectionChange}>
+    <DataGrid
+      selectable={boolean('Selectable', true)}
+      comparableId={1}
+      onSelectionChange={handleRowSelectionChange}
+      processing={boolean('Processing', false)}
+    >
       <DataGrid.HeaderRowOverlay>
         <Button size="small" level="primary" label="Marks as paid" />
         <ButtonGroup segmented marginHorizontal={3}>
@@ -161,6 +167,7 @@ storiesOf('DataGrids', module)
       stickyFromRight={number('Sticky from right', 1)}
       comparableId={1}
       onSelectionChange={handleRowSelectionChange}
+      processing={boolean('Processing', false)}
     >
       <DataGrid.HeaderRowOverlay>
         <Button size="small" level="primary" label="Marks as paid" />
@@ -225,6 +232,7 @@ storiesOf('DataGrids', module)
       stickyFromRight={number('Sticky from right', 1)}
       comparableId={1}
       onSelectionChange={handleRowSelectionChange}
+      processing={boolean('Processing', false)}
     >
       <DataGrid.HeaderRowOverlay>
         <Button size="small" level="primary" label="Marks as paid" />


### PR DESCRIPTION
### Description

Remember the [`LoadingBar` component](https://components.teamleader.design/?selectedKind=LoadingBar&selectedStory=Basic&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs&background=%23ffffff) I added [previously](https://github.com/teamleadercrm/ui/pull/385)?

Well this PR renders it inside the notorious [`DataGrid`](https://components.teamleader.design/?selectedKind=DataGrids&selectedStory=Basic&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs&background=%23ffffff).
If the new boolean prop `processing` is true, that is.

Note that this is an intermediate version of the loading state of a `DataGrid`, there will still be iterations coming up. But at least we can already indicate that the `DataGrid` is processing something 👍.

#### Screenshot before this PR

<img width="814" alt="screen shot 2018-10-08 at 13 08 59" src="https://user-images.githubusercontent.com/23736202/46605912-6979eb80-cafb-11e8-84f2-3f1e1a619c16.png">

#### Screenshot after this PR

<img width="816" alt="screen shot 2018-10-08 at 13 01 09" src="https://user-images.githubusercontent.com/23736202/46605904-64b53780-cafb-11e8-880b-b4c3aac3732d.png">

Due to the `LoadingBar`s transparent nature, the borders that are behind it are visible. This is not a desired effect. To fix this a few changes need to be done to the `LoadingBar`, which felt out of the scope of the PR, expect a follow-up pretty soon.

### Breaking changes

None.
