### PR TITLE
[TU-132] DataGrid add loading state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Added
 
+- `DataGrid`: added the boolean `processing` property ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#391](https://github.com/teamleadercrm/ui/pull/391))
+- `DataGrid`: added the `LoadingBar` component, which renders if the `processing` property is true ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#391](https://github.com/teamleadercrm/ui/pull/391))
+
 ### Changed
 
 ### Deprecated

--- a/components/datagrid/DataGrid.js
+++ b/components/datagrid/DataGrid.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import Box from '../box';
+import LoadingBar from '../loadingBar';
 import HeaderRowOverlay from './HeaderRowOverlay';
 import Cell from './Cell';
 import HeaderCell from './HeaderCell';
@@ -110,7 +111,7 @@ class DataGrid extends PureComponent {
   };
 
   render() {
-    const { checkboxSize, children, className, selectable, stickyFromLeft, stickyFromRight, ...others } = this.props;
+    const { checkboxSize, children, className, processing, selectable, stickyFromLeft, stickyFromRight, ...others } = this.props;
     const { selectedRows } = this.state;
 
     const classNames = cx(theme['data-grid'], className);
@@ -123,6 +124,7 @@ class DataGrid extends PureComponent {
 
     return (
       <Box data-teamleader-ui="data-grid" className={classNames} {...rest}>
+        {processing && <LoadingBar className={cx(theme['loading-bar'])} />}
         {selectedRows.length > 0 &&
           React.Children.map(children, child => {
             if (isComponentOfType(HeaderRowOverlay, child)) {

--- a/components/datagrid/DataGrid.js
+++ b/components/datagrid/DataGrid.js
@@ -196,10 +196,12 @@ DataGrid.propTypes = {
   stickyFromLeft: PropTypes.number,
   stickyFromRight: PropTypes.number,
   onSelectionChange: PropTypes.func,
+  processing: PropTypes.bool,
 };
 
 DataGrid.defaultProps = {
   checkboxSize: 'small',
+  processing: false,
 };
 
 DataGrid.HeaderRow = HeaderRow;

--- a/components/datagrid/theme.css
+++ b/components/datagrid/theme.css
@@ -93,6 +93,13 @@
   color: var(--color-teal-darkest);
 }
 
+.loading-bar {
+  position: absolute;
+  top: 48px;
+  left: 0;
+  z-index: 3;
+}
+
 /* Cell backgrounds */
 .has-background-neutral {
   background-color: var(--color-neutral-light) !important;

--- a/stories/datagrid.js
+++ b/stories/datagrid.js
@@ -34,6 +34,7 @@ storiesOf('DataGrids', module)
       comparableId={1}
       onSelectionChange={handleRowSelectionChange}
       checkboxSize={select('Checkbox size', ['small', 'medium', 'large'], 'small')}
+      processing={boolean('Processing', false)}
     >
       <DataGrid.HeaderRowOverlay
         numSelectedRowsLabel={numSelectedRows => (numSelectedRows === 1 ? 'sélectionné' : 'sélectionnés')}
@@ -94,7 +95,7 @@ storiesOf('DataGrids', module)
     </DataGrid>
   ))
   .add('with footer', () => (
-    <DataGrid selectable={boolean('Selectable', true)} comparableId={1} onSelectionChange={handleRowSelectionChange}>
+    <DataGrid selectable={boolean('Selectable', true)} comparableId={1} onSelectionChange={handleRowSelectionChange} processing={boolean('Processing', false)}>
       <DataGrid.HeaderRowOverlay>
         <Button size="small" level="primary" label="Marks as paid" />
         <ButtonGroup segmented marginHorizontal={3}>
@@ -161,6 +162,7 @@ storiesOf('DataGrids', module)
       stickyFromRight={number('Sticky from right', 1)}
       comparableId={1}
       onSelectionChange={handleRowSelectionChange}
+      processing={boolean('Processing', false)}
     >
       <DataGrid.HeaderRowOverlay>
         <Button size="small" level="primary" label="Marks as paid" />
@@ -225,6 +227,7 @@ storiesOf('DataGrids', module)
       stickyFromRight={number('Sticky from right', 1)}
       comparableId={1}
       onSelectionChange={handleRowSelectionChange}
+      processing={boolean('Processing', false)}
     >
       <DataGrid.HeaderRowOverlay>
         <Button size="small" level="primary" label="Marks as paid" />


### PR DESCRIPTION
### Description

Remember the [`LoadingBar` component](https://components.teamleader.design/?selectedKind=LoadingBar&selectedStory=Basic&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs&background=%23ffffff) I added [previously](https://github.com/teamleadercrm/ui/pull/385)?

Well this PR renders it inside the notorious [`DataGrid`](https://components.teamleader.design/?selectedKind=DataGrids&selectedStory=Basic&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs&background=%23ffffff).
If the new boolean prop `processing` is true, that is.

Note that this is an intermediate version of the loading state of a `DataGrid`, there will still be iterations coming up. But at least we can already indicate that the `DataGrid` is processing something 👍.

#### Screenshot before this PR

<img width="806" alt="screen shot 2018-10-08 at 14 39 44" src="https://user-images.githubusercontent.com/23736202/46609430-27a37200-cb08-11e8-8498-0d7f5b747e3a.png">

#### Screenshot after this PR

<img width="803" alt="screen shot 2018-10-08 at 14 39 31" src="https://user-images.githubusercontent.com/23736202/46609438-2f631680-cb08-11e8-9aba-d78a22f1aafd.png">

Due to the `LoadingBar`s transparent nature, the borders that are behind it are visible. This is not a desired effect. To fix this a few changes need to be done to the `LoadingBar`, which felt out of the scope of the PR, expect a follow-up pretty soon.

### Breaking changes

None.
