### PR TITLE
Icon: add 'element' prop

### DIFF
--- a/components/icon/Icon.js
+++ b/components/icon/Icon.js
@@ -6,12 +6,12 @@ import theme from './theme.css';
 
 class Icon extends PureComponent {
   render() {
-    const { children, className, color, tint, opacity, ...others } = this.props;
+    const { children, className, color, element, tint, opacity, ...others } = this.props;
 
     const classNames = cx(theme[color], theme[tint], className);
 
     return (
-      <Box className={classNames} data-teamleader-ui="icon" element="span" {...others}>
+      <Box className={classNames} data-teamleader-ui="icon" element={element} {...others}>
         {React.Children.map(children, child => {
           // Check if child is an actual React component
           // if so, pass the needed props. If not, just render it.
@@ -32,12 +32,15 @@ Icon.propTypes = {
   children: PropTypes.any,
   className: PropTypes.string,
   color: PropTypes.oneOf(['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'teal']),
+  /** A custom element to be rendered */
+  element: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   opacity: PropTypes.number,
   tint: PropTypes.oneOf(['lightest', 'light', 'normal', 'dark', 'darkest']),
 };
 
 Icon.defaultProps = {
   color: 'teal',
+  element: 'span',
   tint: 'normal',
   opacity: 0.84,
 };


### PR DESCRIPTION
### Description

This PR implements an `element` prop for our `Icon` component. This way,  when needed, you can override the default `span` element to be rendered.

### Breaking changes

None
