### PR TITLE
[Proposal] Fix labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Changed
 
+- `Label` now checks if a child is of type `string` instead of the magic check for `Input` or `Select` ([@nickwaelkens](https://github.com/nickwaelkens) in [#395](https://github.com/teamleadercrm/ui/pull/395))
+
 ### Deprecated
 
 ### Removed

--- a/components/label/Label.js
+++ b/components/label/Label.js
@@ -41,7 +41,7 @@ export default class Label extends PureComponent {
     return (
       <Box element="label" marginBottom={3} className={classNames} {...others}>
         {React.Children.map(children, child => {
-          if (isComponentOfType(Input, child) || isComponentOfType(Select, child)) {
+          if (typeof child !== 'string') {
             return React.cloneElement(child, childProps);
           }
 

--- a/components/label/Label.js
+++ b/components/label/Label.js
@@ -1,11 +1,8 @@
 import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Input from '../input';
-import Select from '../select';
 import Box from '../box';
 import { TextBody, TextDisplay, TextSmall } from '../typography';
 import theme from './theme.css';
-import isComponentOfType from '../utils/is-component-of-type';
 import cx from 'classnames';
 
 export default class Label extends PureComponent {


### PR DESCRIPTION
### Description
The `<Label />` component would explicitly check if one of the children was either `<Input />` or `<Select />` to render certain things (the word "optional" if `required ==== false`). That worked, until we started wrapping these components; then the check wouldn't work as expected anymore and it would render the word "optional" multiple times.

Because we are using our component as follows:
```jsx
<Label>
	Some string
	<MyCustomWrappedInput />
</Label>
```

it made sense to check for a real `string` rather than a certain component type. Still doesn't feel 100% right, but I'm not sure how to fix it properly at this point in time.

### Breaking changes

- Nothing, I think? I'm not sure how people are actually using the `<Label />` component in their projects; feedback is welcome!
