### PR TITLE
Select: remove the max-width so it becomes fluid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Removed
 
+- `Select`: removed the `max-width` limitation, component will now take the full width of its parent ([@driesd](https://github.com/driesd) in [#397](https://github.com/teamleadercrm/ui/pull/397))
+
 ### Fixed
 
 ## [0.16.0] - 2018-10-08

--- a/components/select/theme.css
+++ b/components/select/theme.css
@@ -7,7 +7,6 @@
   font-family: var(--font-family-regular);
   font-size: calc(1.4 * var(--unit));
   border-color: var(--color-neutral-dark);
-  max-width: 360px;
 }
 
 .dropdown-indicator {


### PR DESCRIPTION
### Description

This PR removes the `max-width` limitation, component will now take the full width of its parent.

#### Screenshot before this PR

![schermafdruk 2018-10-09 14 13 03](https://user-images.githubusercontent.com/5336831/46668685-7a932d00-cbcd-11e8-9cc0-a84c683f1212.png)

#### Screenshot after this PR

![schermafdruk 2018-10-09 14 12 46](https://user-images.githubusercontent.com/5336831/46668692-8121a480-cbcd-11e8-9a8e-56080f4e87dc.png)

### Breaking changes

None.
