### PR TITLE
Dialog: add flex behavior to the inner wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Fixed
 
+- `Dialog`: fixed the content cut off bug when content became to high ([@driesd](https://github.com/driesd) in [#399](https://github.com/teamleadercrm/ui/pull/399))
+
 ## [0.16.0] - 2018-10-08
 
 ### Added

--- a/components/dialog/theme.css
+++ b/components/dialog/theme.css
@@ -38,6 +38,8 @@
 .inner {
   background: var(--dialog-background-color);
   border-radius: var(--dialog-border-radius);
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
   position: relative;
 }


### PR DESCRIPTION
### Description

A `Dialog` gets a max-height according to your browser viewport. Before this PR, the content inside the Dialog is cut off when it gets too high. This PR adds some styling to the `inner` wrapper to fix this issue.

#### Screenshot before this PR

![schermafdruk 2018-10-10 10 44 38](https://user-images.githubusercontent.com/5336831/46724498-6fe2a180-cc7a-11e8-8b53-ff2758ee3380.png)

#### Screenshot after this PR

![schermafdruk 2018-10-10 10 43 55](https://user-images.githubusercontent.com/5336831/46724511-76711900-cc7a-11e8-8960-c5eef6ce830c.png)

### Breaking changes

None.
