### PR TITLE
Select: replace the built-in clear indicator button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - `Label` now checks if a child is of type `string` instead of the magic check for `Input` or `Select` ([@nickwaelkens](https://github.com/nickwaelkens) in [#395](https://github.com/teamleadercrm/ui/pull/395))
 - `Select`: changed the dropdown arrow `Button` with a more subtile `Icon` ([@driesd](https://github.com/driesd) in [#396](https://github.com/teamleadercrm/ui/pull/396))
+- `Select`: replaced the built-in clear indicator button with an icon of our own library ([@driesd](https://github.com/driesd) in [#400](https://github.com/teamleadercrm/ui/pull/400))
 
 ### Deprecated
 

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -248,7 +248,6 @@ class Select extends PureComponent {
         color={inverse ? 'teal' : 'neutral'}
         display="flex"
         marginRight={3}
-        opacity={0.48}
         tint={inverse ? 'lightest' : 'darkest'}
         {...innerProps}
       >

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -244,13 +244,7 @@ class Select extends PureComponent {
     const { inverse } = this.props;
 
     return (
-      <Icon
-        color={inverse ? 'teal' : 'neutral'}
-        display="flex"
-        marginRight={3}
-        tint={inverse ? 'lightest' : 'darkest'}
-        {...innerProps}
-      >
+      <Icon color={inverse ? 'teal' : 'neutral'} display="flex" tint={inverse ? 'lightest' : 'darkest'} {...innerProps}>
         <IconCloseBadgedSmallFilled />
       </Icon>
     );

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -1,7 +1,11 @@
 import React, { PureComponent } from 'react';
 import ReactSelect from 'react-select';
 import PropTypes from 'prop-types';
-import { IconChevronDownSmallOutline, IconWarningBadgedSmallFilled } from '@teamleader/ui-icons';
+import {
+  IconCloseBadgedSmallFilled,
+  IconChevronDownSmallOutline,
+  IconWarningBadgedSmallFilled,
+} from '@teamleader/ui-icons';
 import Box, { omitBoxProps, pickBoxProps } from '../box';
 import Icon from '../icon';
 import { TextSmall } from '../typography';
@@ -236,6 +240,23 @@ class Select extends PureComponent {
     valueContainer: this.getValueContainerStyles,
   });
 
+  getClearIndicator = () => ({ innerProps }) => {
+    const { inverse } = this.props;
+
+    return (
+      <Icon
+        color={inverse ? 'teal' : 'neutral'}
+        display="flex"
+        marginRight={3}
+        opacity={0.48}
+        tint={inverse ? 'lightest' : 'darkest'}
+        {...innerProps}
+      >
+        <IconCloseBadgedSmallFilled />
+      </Icon>
+    );
+  };
+
   getDropDownIndicator = () => ({ isFocused }) => {
     const { inverse } = this.props;
 
@@ -292,6 +313,7 @@ class Select extends PureComponent {
         <ReactSelect
           className={theme['select']}
           components={{
+            ClearIndicator: this.getClearIndicator(),
             DropdownIndicator: this.getDropDownIndicator(),
             IndicatorSeparator: null,
             ...components,


### PR DESCRIPTION
### Description

This PR replaces the built-in `clear indicator button` with an icon of our own library.

#### Screenshot before this PR

![schermafdruk 2018-10-10 14 57 45](https://user-images.githubusercontent.com/5336831/46737865-eee8d180-cc9c-11e8-87f5-f547d64822fc.png)

![schermafdruk 2018-10-10 15 07 04](https://user-images.githubusercontent.com/5336831/46738324-31f77480-cc9e-11e8-9334-91327267c986.png)

#### Screenshot after this PR

![schermafdruk 2018-10-10 14 56 49](https://user-images.githubusercontent.com/5336831/46737874-f4461c00-cc9c-11e8-8ee7-30a61aede62a.png)

![schermafdruk 2018-10-10 15 06 13](https://user-images.githubusercontent.com/5336831/46738327-3459ce80-cc9e-11e8-89fa-713135ec6756.png)

### Breaking changes

None.
