### PR TITLE
Input: spinner button opacity & position adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 
+- `Input`: adjusted the `opacity` & `position` of the `number type Input` field spinner buttons ([@driesd](https://github.com/driesd) in [#401](https://github.com/teamleadercrm/ui/pull/401))
 - `Label` now checks if a child is of type `string` instead of the magic check for `Input` or `Select` ([@nickwaelkens](https://github.com/nickwaelkens) in [#395](https://github.com/teamleadercrm/ui/pull/395))
 - `Select`: changed the dropdown arrow `Button` with a more subtile `Icon` ([@driesd](https://github.com/driesd) in [#396](https://github.com/teamleadercrm/ui/pull/396))
 

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -173,7 +173,6 @@ export default class Input extends PureComponent {
     const props = {
       color: inverse ? 'teal' : 'neutral',
       element: 'button',
-      opacity: 0.5,
       tint: inverse ? 'lightest' : 'darkest',
     };
 

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -16,8 +16,8 @@
   --input-error-border: var(--color-ruby-dark);
   --input-error-border-inverse: var(--color-ruby-light);
 
-  --spinner-width: calc(2 * var(--unit));
-  --spinner-width-large: calc(2.4 * var(--unit));
+  --spinner-width: calc(3 * var(--unit));
+  --spinner-width-large: calc(3.6 * var(--unit));
 }
 
 /**

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -261,20 +261,8 @@
   border: 0;
   border-radius: 0;
 
-  svg {
-    transition: var(--animation-duration) var(--animation-curve-fast-out-slow-in) opacity;
-  }
-
   &:focus {
     outline: none;
-
-    svg {
-      opacity: 1 !important;
-    }
-  }
-
-  &:hover svg {
-    opacity: 1 !important;
   }
 }
 


### PR DESCRIPTION
### Description

This PR adjusts the `opacity` & `position` of the `number type Input` field spinner buttons.

#### Screenshot before this PR

![schermafdruk 2018-10-10 15 25 12](https://user-images.githubusercontent.com/5336831/46739524-09bd4500-cca1-11e8-8973-bef64d0bdf50.png)

![schermafdruk 2018-10-10 15 25 39](https://user-images.githubusercontent.com/5336831/46739542-0fb32600-cca1-11e8-80f7-55f3515e2e9e.png)

#### Screenshot after this PR

![schermafdruk 2018-10-10 15 24 49](https://user-images.githubusercontent.com/5336831/46739557-15a90700-cca1-11e8-8647-ec27042d4acd.png)

![schermafdruk 2018-10-10 15 24 19](https://user-images.githubusercontent.com/5336831/46739561-19d52480-cca1-11e8-9494-e618de23d6b7.png)

### Breaking changes

None