### PR TITLE
Select: dropdown arrow opacity & position adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `Label` now checks if a child is of type `string` instead of the magic check for `Input` or `Select` ([@nickwaelkens](https://github.com/nickwaelkens) in [#395](https://github.com/teamleadercrm/ui/pull/395))
 - `Select`: changed the dropdown arrow `Button` with a more subtile `Icon` ([@driesd](https://github.com/driesd) in [#396](https://github.com/teamleadercrm/ui/pull/396))
 - `Select`: replaced the built-in clear indicator button with an icon of our own library ([@driesd](https://github.com/driesd) in [#400](https://github.com/teamleadercrm/ui/pull/400))
+- `Select`: adjusted the `opacity` & `position` of the `dropdown indicator arrow` ([@driesd](https://github.com/driesd) in [#402](https://github.com/teamleadercrm/ui/pull/402))
 
 ### Deprecated
 

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -255,8 +255,11 @@ class Select extends PureComponent {
 
     return (
       <Icon
+        alignItems="center"
         className={theme['dropdown-indicator']}
         color={inverse ? 'teal' : 'neutral'}
+        display="flex"
+        justifyContent="center"
         tint={inverse ? 'lightest' : 'darkest'}
       >
         <IconChevronDownSmallOutline />

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -250,14 +250,13 @@ class Select extends PureComponent {
     );
   };
 
-  getDropDownIndicator = () => ({ isFocused }) => {
+  getDropDownIndicator = () => () => {
     const { inverse } = this.props;
 
     return (
       <Icon
         className={theme['dropdown-indicator']}
         color={inverse ? 'teal' : 'neutral'}
-        opacity={isFocused ? 1 : 0.48}
         tint={inverse ? 'lightest' : 'darkest'}
       >
         <IconChevronDownSmallOutline />

--- a/components/select/theme.css
+++ b/components/select/theme.css
@@ -13,11 +13,11 @@
   align-items: center;
   display: flex;
   justify-content: center;
-  width: 20px;
+  width: 30px;
 }
 
 .is-large .dropdown-indicator {
-  width: 24px;
+  width: 36px;
 }
 
 .validation-icon {

--- a/components/select/theme.css
+++ b/components/select/theme.css
@@ -10,9 +10,6 @@
 }
 
 .dropdown-indicator {
-  align-items: center;
-  display: flex;
-  justify-content: center;
   width: 30px;
 }
 


### PR DESCRIPTION
### Description

This PR adjusts the `opacity` & `position` of the `dropdown indicator arrow`.

#### Screenshot before this PR

![schermafdruk 2018-10-10 15 46 34](https://user-images.githubusercontent.com/5336831/46740845-0f685a00-cca4-11e8-803e-d15da17d4559.png)

![schermafdruk 2018-10-10 15 46 20](https://user-images.githubusercontent.com/5336831/46740859-13947780-cca4-11e8-863a-26bbe5002fd6.png)

#### Screenshot after this PR

![schermafdruk 2018-10-10 15 45 15](https://user-images.githubusercontent.com/5336831/46740874-18f1c200-cca4-11e8-945f-1fbfd0662896.png)

![schermafdruk 2018-10-10 15 45 34](https://user-images.githubusercontent.com/5336831/46740884-1ee7a300-cca4-11e8-9f42-de47dffe143a.png)

### Breaking changes

None.
