### PR TITLE
DataGrid.HeaderRowOverlay: Fix prop type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- `DataGrid`: fixed the property type of the `numSelectedRowsLabel` property in the `DataGrid.HeaderRowOverlay`, which threw a warning ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#403](https://github.com/teamleadercrm/ui/pull/403))
+
 ## [0.16.0] - 2018-10-08
 
 ### Added

--- a/components/datagrid/HeaderRowOverlay/HeaderRowOverlay.js
+++ b/components/datagrid/HeaderRowOverlay/HeaderRowOverlay.js
@@ -47,8 +47,8 @@ HeaderRowOverlay.propTypes = {
   className: PropTypes.string,
   /** If this value is greater than 0 then this component renders, it is also passed down to display the number of selected rows */
   numSelectedRows: PropTypes.number,
-  /** Passed down string, is used as the label accompanying the number of selected rows */
-  numSelectedRowsLabel: PropTypes.string,
+  /** Passed down function, is used to render the label accompanying the number of selected rows */
+  numSelectedRowsLabel: PropTypes.func,
 };
 
 HeaderRowOverlay.defaultProps = {


### PR DESCRIPTION
### Description

This PR fixes a wrongly declared prop type for the `numSelectedRowsLabel`, which was still set to be a `string` while it had become a render prop.

Nothing has visually changed.

### Breaking changes

None.
