### PR TITLE
Input & Select: equal heights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- `Input` (small & large): decreased its height to meet the height of our `Button` & `Select` components ([@driesd](https://github.com/driesd) in [#408](https://github.com/teamleadercrm/ui/pull/408))
+- `Select` (multi value): decreased the margin around a selected item to meet the height of our `Button` & `Input` components ([@driesd](https://github.com/driesd) in [#408](https://github.com/teamleadercrm/ui/pull/408))
+
 ### Deprecated
 
 ### Removed

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -6,7 +6,7 @@
  * Variables
  */
 :root {
-  --input-height-large: calc(4.8 * var(--unit));
+  --input-height-large: calc(4.6 * var(--unit));
   --input-height-medium: calc(3.4 * var(--unit));
   --input-height-small: calc(3 * var(--unit));
   --input-horizontal-padding: calc(0.5 * var(--unit));

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -8,7 +8,7 @@
 :root {
   --input-height-large: calc(4.6 * var(--unit));
   --input-height-medium: calc(3.4 * var(--unit));
-  --input-height-small: calc(3 * var(--unit));
+  --input-height-small: calc(2.8 * var(--unit));
   --input-horizontal-padding: calc(0.5 * var(--unit));
   --input-text-size: calc(1.4 * var(--unit));
   --input-text-size-large: calc(1.6 * var(--unit));

--- a/components/select/Select.js
+++ b/components/select/Select.js
@@ -124,6 +124,7 @@ class Select extends PureComponent {
       borderStyle: 'solid',
       borderWidth: '1px',
       borderRadius: '4px',
+      margin: '1px',
     };
   };
 


### PR DESCRIPTION
### Description

This PR fixes the unequal heights between our Input, Select & Button components.

- `Input` (small & large): decreased its height to meet the height of our `Button` & `Select` components
- `Select` (multi value): decreased the margin around a selected item to meet the height of our `Button` & `Input` components

#### Screenshot before this PR

**Small**
![schermafdruk 2018-10-12 09 48 16](https://user-images.githubusercontent.com/5336831/46855531-4a819f00-ce04-11e8-912b-b5858c66bec9.png)

**Medium**
![schermafdruk 2018-10-12 09 48 32](https://user-images.githubusercontent.com/5336831/46855537-4e152600-ce04-11e8-8bb4-eb0a37097001.png)

**Large**
![schermafdruk 2018-10-12 09 48 49](https://user-images.githubusercontent.com/5336831/46855554-58372480-ce04-11e8-82ee-df1afc9baefb.png)

#### Screenshot after this PR

**Small**
![schermafdruk 2018-10-12 09 47 14](https://user-images.githubusercontent.com/5336831/46855514-3a69bf80-ce04-11e8-97cd-7f00c465ab2f.png)

**Medium**
![schermafdruk 2018-10-12 09 47 28](https://user-images.githubusercontent.com/5336831/46855518-3f2e7380-ce04-11e8-8d12-6344bbbc15e0.png)

**Large**
![schermafdruk 2018-10-12 09 47 44](https://user-images.githubusercontent.com/5336831/46855525-43f32780-ce04-11e8-9f40-4acddb473594.png)

### Breaking changes

None
