### PR TITLE
DatePicker: fix collapsing when container is resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Fixed
 
+- `DatePicker`: fixed the DatePicker collapsing when the parent element resizes ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#410](https://github.com/teamleadercrm/ui/pull/410))
+
 ## [0.16.1] - 2018-10-11
 
 ### Added

--- a/components/datepicker/theme.css
+++ b/components/datepicker/theme.css
@@ -366,6 +366,7 @@
   border-radius: var(--border-radius);
   display: inline-block;
   transition: 0.3s ease-in-out border, 0.3s ease-in-out box-shadow;
+  white-space: nowrap;
 
   input {
     background: transparent;


### PR DESCRIPTION
### Description

The DatePicker was collapsing when the container was getting resized (or when the container width relied on the DatePicker's width)

#### Screenshot before this PR

![image](https://user-images.githubusercontent.com/10011712/47296858-da4cf780-d613-11e8-8d7e-abefb3f2dcf8.png)


#### Screenshot after this PR

![image](https://user-images.githubusercontent.com/10011712/47296838-c86b5480-d613-11e8-800d-aa9c59fdc449.png)

### Breaking changes

None
