### PR TITLE
Input: Refactor

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -14,7 +14,7 @@ import Dialog from './dialog';
 import HelpText from './helptext';
 import ErrorText from './errorText';
 import Icon from './icon';
-import Input, { InputBase } from './input';
+import Input, { InputBase, NumericInput } from './input';
 import Menu, { IconMenu, MenuItem, MenuDivider } from './menu';
 import Link from './link';
 import Message from './message';
@@ -82,6 +82,7 @@ export {
   MenuDivider,
   Message,
   Monospaced,
+  NumericInput,
   Overlay,
   Pagination,
   Popover,

--- a/components/index.js
+++ b/components/index.js
@@ -14,7 +14,7 @@ import Dialog from './dialog';
 import HelpText from './helptext';
 import ErrorText from './errorText';
 import Icon from './icon';
-import Input from './input';
+import Input, { InputBase } from './input';
 import Menu, { IconMenu, MenuItem, MenuDivider } from './menu';
 import Link from './link';
 import Message from './message';
@@ -45,6 +45,7 @@ export {
   AsyncSelect,
   Badge,
   Banner,
+  InputBase,
   Box,
   Bullet,
   Button,

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -2,9 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import omit from 'lodash.omit';
-import { IconChevronUpSmallOutline, IconChevronDownSmallOutline } from '@teamleader/ui-icons';
 import Box, { omitBoxProps, pickBoxProps } from '../box';
-import Icon from '../icon';
 import { ErrorText, HelpText } from '../../components';
 import theme from './theme.css';
 
@@ -23,39 +21,12 @@ export default class Input extends PureComponent {
     return null;
   }
 
-  parseValue(value) {
-    const { type } = this.props;
-    return type === 'number' ? this.bindToMinMax(this.toNumber(value)) : value;
-  }
-
-  toNumber(number) {
-    let float = parseFloat(number);
-
-    if (isNaN(float) || !isFinite(float)) {
-      float = 0;
-    }
-
-    return float;
-  }
-
-  bindToMinMax(value) {
-    const { min, max } = this.props;
-    return Math.min(Math.max(value, min), max);
-  }
-
   state = {
     inputHasFocus: false,
     value: '',
   };
 
   handleBlur = event => {
-    const { value } = this.state;
-    const parsedValue = this.parseValue(value);
-
-    if (parsedValue !== value) {
-      this.updateValue(event, parsedValue);
-    }
-
     this.setState({ inputHasFocus: false });
 
     if (this.props.onBlur) {
@@ -75,14 +46,6 @@ export default class Input extends PureComponent {
     }
   };
 
-  handleIncreaseValue = event => {
-    this.updateStep(event, 1);
-  };
-
-  handleDecreaseValue = event => {
-    this.updateStep(event, -1);
-  };
-
   updateValue(event, rawValue, triggerOnChange = true) {
     const { onChange } = this.props;
     const newValue = String(rawValue);
@@ -96,19 +59,8 @@ export default class Input extends PureComponent {
     }
   }
 
-  updateStep(event, n) {
-    const { step } = this.props;
-
-    const currentValue = this.toNumber(this.state.value || 0);
-    const newValue = this.parseValue(currentValue + step * n);
-
-    if (newValue !== currentValue) {
-      this.updateValue(event, newValue);
-    }
-  }
-
   renderInput() {
-    const { bold, max, min, step, type, ...otherProps } = this.props;
+    const { bold, type, ...otherProps } = this.props;
     const { value } = this.state;
 
     const classNames = cx(theme['input'], {
@@ -125,17 +77,9 @@ export default class Input extends PureComponent {
       'onChange',
       'prefix',
       'size',
-      'spinner',
       'suffix',
       'value',
     ]);
-
-    const numberTypeProps = {
-      max,
-      min,
-      step,
-      value,
-    };
 
     const props = {
       className: classNames,
@@ -145,33 +89,9 @@ export default class Input extends PureComponent {
       type,
       value,
       ...restProps,
-      ...(type === 'number' && numberTypeProps),
     };
 
     return <input {...props} />;
-  }
-
-  renderSpinnerControls() {
-    const { inverse, spinner, type } = this.props;
-
-    const props = {
-      color: inverse ? 'teal' : 'neutral',
-      element: 'button',
-      tint: inverse ? 'lightest' : 'darkest',
-    };
-
-    if (type === 'number' && spinner) {
-      return (
-        <div className={theme['spinner']}>
-          <Icon className={theme['spinner-up']} onClick={this.handleIncreaseValue} {...props}>
-            <IconChevronUpSmallOutline />
-          </Icon>
-          <Icon className={theme['spinner-down']} onClick={this.handleDecreaseValue} {...props}>
-            <IconChevronDownSmallOutline />
-          </Icon>
-        </div>
-      );
-    }
   }
 
   renderOneOrMultipleElements(prop) {
@@ -225,7 +145,6 @@ export default class Input extends PureComponent {
             {prefix && <div className={theme['prefix-wrapper']}>{this.renderOneOrMultipleElements(prefix)}</div>}
             {this.renderInput()}
             {suffix && <div className={theme['suffix-wrapper']}>{this.renderOneOrMultipleElements(suffix)}</div>}
-            {this.renderSpinnerControls()}
           </div>
           {connectedRight}
         </div>
@@ -254,10 +173,6 @@ Input.propTypes = {
   helpText: PropTypes.string,
   /** Boolean indicating whether the input should render as inverse. */
   inverse: PropTypes.bool,
-  max: PropTypes.number,
-  min: PropTypes.number,
-  /** Boolean indicating whether to number type input should render spinner controls */
-  spinner: PropTypes.bool,
   /** Callback function that is fired when blurring the input field. */
   onBlur: PropTypes.func,
   /** Callback function that is fired when focusing the input field. */
@@ -270,8 +185,6 @@ Input.propTypes = {
   readOnly: PropTypes.bool,
   /** Size of the input element. */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
-  /** Limit increment value for numeric inputs. */
-  step: PropTypes.number,
   /** The text string/element to use as a suffix inside the input field */
   suffix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
   /** Type of the input element. It can be a valid HTML5 input type. */
@@ -283,10 +196,6 @@ Input.propTypes = {
 Input.defaultProps = {
   inverse: false,
   disabled: false,
-  min: Number.MIN_SAFE_INTEGER,
-  max: Number.MAX_SAFE_INTEGER,
   readOnly: false,
   size: 'medium',
-  spinner: true,
-  step: 1,
 };

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -46,16 +46,13 @@ export default class Input extends PureComponent {
     }
   };
 
-  updateValue(event, rawValue) {
+  updateValue(event, value) {
     const { onChange } = this.props;
-    const newValue = String(rawValue);
 
-    this.setState({
-      value: newValue,
-    });
+    this.setState({ value });
 
     if (onChange) {
-      onChange(event, newValue);
+      onChange(event, value);
     }
   }
 

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -1,10 +1,5 @@
 import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import cx from 'classnames';
-import omit from 'lodash.omit';
-import Box, { omitBoxProps, pickBoxProps } from '../box';
-import { ErrorText, HelpText } from '../../components';
-import theme from './theme.css';
+import InputBase from './InputBase';
 
 export default class Input extends PureComponent {
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -22,177 +17,21 @@ export default class Input extends PureComponent {
   }
 
   state = {
-    inputHasFocus: false,
     value: '',
   };
 
-  handleBlur = event => {
-    this.setState({ inputHasFocus: false });
-
-    if (this.props.onBlur) {
-      this.props.onBlur(event);
-    }
-  };
-
-  handleChange = event => {
-    this.updateValue(event, event.target.value);
-  };
-
-  handleFocus = event => {
-    this.setState({ inputHasFocus: true });
-
-    if (this.props.onFocus) {
-      this.props.onFocus(event);
-    }
-  };
-
-  updateValue(event, value) {
-    const { onChange } = this.props;
-
-    this.setState({ value });
-
-    if (onChange) {
-      onChange(event, value);
-    }
-  }
-
-  renderInput() {
-    const { bold, type, ...otherProps } = this.props;
-    const { value } = this.state;
-
-    const classNames = cx(theme['input'], {
-      [theme['is-bold']]: bold,
-    });
-
-    const otherPropsWithoutBoxProps = omitBoxProps(otherProps);
-    const restProps = omit(otherPropsWithoutBoxProps, [
-      'className',
-      'connectedLeft',
-      'connectedRight',
-      'helpText',
-      'inverse',
-      'onChange',
-      'prefix',
-      'size',
-      'suffix',
-      'value',
-    ]);
-
-    const props = {
-      className: classNames,
-      onBlur: this.handleBlur,
-      onChange: this.handleChange,
-      onFocus: this.handleFocus,
-      type,
-      value,
-      ...restProps,
-    };
-
-    return <input {...props} />;
-  }
-
-  renderOneOrMultipleElements(prop) {
-    if (Array.isArray(prop)) {
-      return prop.map((element, index) => React.cloneElement(element, { key: index }));
-    }
-
-    return prop;
-  }
-
   render() {
-    const {
-      className,
-      connectedLeft,
-      connectedRight,
-      disabled,
-      error,
-      helpText,
-      inverse,
-      prefix,
-      size,
-      suffix,
-      readOnly,
-      ...others
-    } = this.props;
-
-    const { inputHasFocus } = this.state;
-
-    const classNames = cx(
-      theme['wrapper'],
-      theme[`is-${size}`],
-      {
-        [theme['has-error']]: error,
-        [theme['has-focus']]: inputHasFocus,
-        [theme['has-connected-left']]: connectedLeft,
-        [theme['has-connected-right']]: connectedRight,
-        [theme['is-inverse']]: inverse,
-        [theme['is-disabled']]: disabled,
-        [theme['is-read-only']]: readOnly,
-      },
-      className,
-    );
-
-    const rest = pickBoxProps(others);
+    const { onChange, ...others } = this.props;
 
     return (
-      <Box className={classNames} {...rest}>
-        <div className={theme['input-wrapper']}>
-          {connectedLeft}
-          <div className={theme['input-inner-wrapper']}>
-            {prefix && <div className={theme['prefix-wrapper']}>{this.renderOneOrMultipleElements(prefix)}</div>}
-            {this.renderInput()}
-            {suffix && <div className={theme['suffix-wrapper']}>{this.renderOneOrMultipleElements(suffix)}</div>}
-          </div>
-          {connectedRight}
-        </div>
-        {error ? (
-          <ErrorText inverse={inverse}>{error}</ErrorText>
-        ) : (
-          helpText && <HelpText inverse={inverse}>{helpText}</HelpText>
-        )}
-      </Box>
+      <InputBase
+        value={this.state.value}
+        onChange={event => {
+          this.setState({ value: event.currentTarget.value });
+          onChange(event, event.currentTarget.value);
+        }}
+        {...others}
+      />
     );
   }
 }
-
-Input.propTypes = {
-  /** Boolean indicating whether the input text should render in bold. */
-  bold: PropTypes.bool,
-  /** Sets a class name for the wrapper to give custom styles. */
-  className: PropTypes.string,
-  connectedLeft: PropTypes.element,
-  connectedRight: PropTypes.element,
-  /** Boolean indicating whether the input should render as disabled. */
-  disabled: PropTypes.bool,
-  /** The text string/element to use as error message below the input. */
-  error: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-  /** The text string to use as help text below the input. */
-  helpText: PropTypes.string,
-  /** Boolean indicating whether the input should render as inverse. */
-  inverse: PropTypes.bool,
-  /** Callback function that is fired when blurring the input field. */
-  onBlur: PropTypes.func,
-  /** Callback function that is fired when focusing the input field. */
-  onFocus: PropTypes.func,
-  /** Callback function that is fired when the component's value changes. */
-  onChange: PropTypes.func,
-  /** The text string/element to use as a prefix inside the input field */
-  prefix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
-  /** Boolean indicating whether the input should render as read only. */
-  readOnly: PropTypes.bool,
-  /** Size of the input element. */
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
-  /** The text string/element to use as a suffix inside the input field */
-  suffix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
-  /** Type of the input element. It can be a valid HTML5 input type. */
-  type: PropTypes.string,
-  /** Current value of the input element. */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-};
-
-Input.defaultProps = {
-  inverse: false,
-  disabled: false,
-  readOnly: false,
-  size: 'medium',
-};

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -46,7 +46,7 @@ export default class Input extends PureComponent {
     }
   };
 
-  updateValue(event, rawValue, triggerOnChange = true) {
+  updateValue(event, rawValue) {
     const { onChange } = this.props;
     const newValue = String(rawValue);
 
@@ -54,7 +54,7 @@ export default class Input extends PureComponent {
       value: newValue,
     });
 
-    if (triggerOnChange && onChange) {
+    if (onChange) {
       onChange(event, newValue);
     }
   }

--- a/components/input/InputBase.js
+++ b/components/input/InputBase.js
@@ -1,0 +1,171 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import omit from 'lodash.omit';
+import Box, { omitBoxProps, pickBoxProps } from '../box';
+import { ErrorText, HelpText } from '..';
+import theme from './theme.css';
+
+export default class InputBase extends PureComponent {
+  state = {
+    inputHasfocus: false,
+  };
+
+  handleBlur = event => {
+    this.setState({ inputHasFocus: false });
+    if (this.props.onBlur) {
+      this.props.onBlur(event);
+    }
+  };
+
+  handleChange = event => {
+    if (this.props.onChange) {
+      this.props.onChange(event);
+    }
+  };
+
+  handleFocus = event => {
+    this.setState({ inputHasFocus: true });
+    if (this.props.onFocus) {
+      this.props.onFocus(event);
+    }
+  };
+
+  renderOneOrMultipleElements(prop) {
+    if (Array.isArray(prop)) {
+      return prop.map((element, index) => React.cloneElement(element, { key: index }));
+    }
+
+    return prop;
+  }
+
+  renderInput = () => {
+    const { bold, ...otherProps } = this.props;
+
+    const classNames = cx(theme['input'], { [theme['is-bold']]: bold });
+
+    const restProps = omit(omitBoxProps(otherProps), [
+      'className',
+      'connectedLeft',
+      'connectedRight',
+      'helpText',
+      'inverse',
+      'onChange',
+      'prefix',
+      'size',
+      'suffix',
+      'value',
+    ]);
+
+    const props = {
+      className: classNames,
+      onBlur: this.handleBlur,
+      onChange: this.handleChange,
+      onFocus: this.handleFocus,
+      ...restProps,
+    };
+
+    return <input {...props} />;
+  };
+
+  render() {
+    const {
+      className,
+      connectedLeft,
+      connectedRight,
+      disabled,
+      error,
+      helpText,
+      inverse,
+      prefix,
+      size,
+      suffix,
+      readOnly,
+      ...others
+    } = this.props;
+
+    const { inputHasFocus } = this.state;
+
+    const classNames = cx(
+      theme['wrapper'],
+      theme[`is-${size}`],
+      {
+        [theme['has-error']]: error,
+        [theme['has-focus']]: inputHasFocus,
+        [theme['has-connected-left']]: connectedLeft,
+        [theme['has-connected-right']]: connectedRight,
+        [theme['is-inverse']]: inverse,
+        [theme['is-disabled']]: disabled,
+        [theme['is-read-only']]: readOnly,
+      },
+      className,
+    );
+
+    const rest = pickBoxProps(others);
+
+    return (
+      <Box className={classNames} {...rest}>
+        <div className={theme['input-wrapper']}>
+          {connectedLeft}
+          <div className={theme['input-inner-wrapper']}>
+            {prefix && <div className={theme['prefix-wrapper']}>{this.renderOneOrMultipleElements(prefix)}</div>}
+            {this.renderInput()}
+            {suffix && <div className={theme['suffix-wrapper']}>{this.renderOneOrMultipleElements(suffix)}</div>}
+          </div>
+          {connectedRight}
+        </div>
+        {error ? (
+          <ErrorText inverse={inverse}>{error}</ErrorText>
+        ) : (
+          helpText && <HelpText inverse={inverse}>{helpText}</HelpText>
+        )}
+      </Box>
+    );
+  }
+}
+
+InputBase.propTypes = {
+  /** Boolean indicating whether the input text should render in bold. */
+  bold: PropTypes.bool,
+  /** Sets a class name for the wrapper to give custom styles. */
+  className: PropTypes.string,
+  /** Element stuck to the left hand side of the component. */
+  connectedLeft: PropTypes.element,
+  /** Element stuck to the right hand side of the component. */
+  connectedRight: PropTypes.element,
+  /** Boolean indicating whether the input should render as disabled. */
+  disabled: PropTypes.bool,
+  /** The text string/element to use as error message below the input. */
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  /** The text string to use as help text below the input. */
+  helpText: PropTypes.string,
+  /** Boolean indicating whether the input should render as inverse. */
+  inverse: PropTypes.bool,
+  /** Callback function that is fired when blurring the input field. */
+  onBlur: PropTypes.func,
+  /** Callback function that is fired when focusing the input field. */
+  onFocus: PropTypes.func,
+  /** Callback function that is fired when the component's value changes. */
+  onChange: PropTypes.func,
+  /** The text string/element to use as a prefix inside the input field */
+  prefix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
+  /** Boolean indicating whether the input should render as read only. */
+  readOnly: PropTypes.bool,
+  /** Size of the input element. */
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  /** Limit increment value for numeric inputs. */
+  step: PropTypes.number,
+  /** The text string/element to use as a suffix inside the input field */
+  suffix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
+  /** Type of the input element. It can be a valid HTML5 input type. */
+  type: PropTypes.string,
+  /** Current value of the input element. */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};
+
+InputBase.defaultProps = {
+  inverse: false,
+  disabled: false,
+  readOnly: false,
+  size: 'medium',
+};

--- a/components/input/InputBase.js
+++ b/components/input/InputBase.js
@@ -152,8 +152,6 @@ InputBase.propTypes = {
   readOnly: PropTypes.bool,
   /** Size of the input element. */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
-  /** Limit increment value for numeric inputs. */
-  step: PropTypes.number,
   /** The text string/element to use as a suffix inside the input field */
   suffix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
   /** Type of the input element. It can be a valid HTML5 input type. */

--- a/components/input/InputBase.js
+++ b/components/input/InputBase.js
@@ -54,7 +54,6 @@ export default class InputBase extends PureComponent {
       'prefix',
       'size',
       'suffix',
-      'value',
     ]);
 
     const props = {

--- a/components/input/NumericInput.js
+++ b/components/input/NumericInput.js
@@ -82,24 +82,22 @@ class NumericInput extends PureComponent {
     this.updateStep(-1);
   };
 
+  getSuffixWithSpinner = () => [
+    ...this.props.suffix,
+    <SpinnerControls
+      handleOnSpinnerUpClick={this.handleIncreaseValue}
+      handleOnSpinnerdownClick={this.handleDecreaseValue}
+    />,
+  ];
+
   render() {
     const { spinner, suffix, onChange, ...others } = this.props;
-
-    const suffixWithSpinner = [
-      ...suffix,
-      spinner && (
-        <SpinnerControls
-          handleOnSpinnerUpClick={this.handleIncreaseValue}
-          handleOnSpinnerdownClick={this.handleDecreaseValue}
-        />
-      ),
-    ];
 
     return (
       <InputBase
         type="number"
         value={this.state.value}
-        suffix={suffixWithSpinner}
+        suffix={spinner ? this.getSuffixWithSpinner() : suffix}
         onChange={event => {
           this.handleOnChange(event);
           onChange && onChange(event, event.currentTarget.value);

--- a/components/input/NumericInput.js
+++ b/components/input/NumericInput.js
@@ -102,7 +102,7 @@ class NumericInput extends PureComponent {
         suffix={suffixWithSpinner}
         onChange={event => {
           this.handleOnChange(event);
-          onChange(event, event.currentTarget.value);
+          onChange && onChange(event, event.currentTarget.value);
         }}
         {...others}
       />

--- a/components/input/NumericInput.js
+++ b/components/input/NumericInput.js
@@ -1,0 +1,134 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { IconChevronUpSmallOutline, IconChevronDownSmallOutline } from '@teamleader/ui-icons';
+import Icon from '../icon';
+import InputBase from './InputBase';
+import theme from './theme.css';
+
+class SpinnerControls extends PureComponent {
+  render() {
+    const { inverse, handleOnSpinnerUpClick, handleOnSpinnerdownClick } = this.props;
+    const iconProps = {
+      color: inverse ? 'teal' : 'neutral',
+      element: 'button',
+      tint: inverse ? 'lightest' : 'darkest',
+    };
+
+    return (
+      <div className={theme['spinner']}>
+        <Icon className={theme['spinner-up']} onClick={() => handleOnSpinnerUpClick()} {...iconProps}>
+          <IconChevronUpSmallOutline />
+        </Icon>
+        <Icon className={theme['spinner-down']} onClick={() => handleOnSpinnerdownClick()} {...iconProps}>
+          <IconChevronDownSmallOutline />
+        </Icon>
+      </div>
+    );
+  }
+}
+
+class NumericInput extends PureComponent {
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.value !== undefined) {
+      const newValue = nextProps.value || '';
+      if (newValue !== prevState.value) {
+        return {
+          value: newValue,
+        };
+      }
+    }
+    return null;
+  }
+
+  state = {
+    value: '',
+  };
+
+  handleOnChange = event => {
+    this.setState({ value: this.parseValue(event.currentTarget.value) });
+  };
+
+  updateStep = n => {
+    const { step } = this.props;
+
+    const currentValue = this.toNumber(this.state.value || 0);
+    const newValue = this.parseValue(currentValue + step * n);
+
+    if (newValue !== currentValue) {
+      this.setState({ value: newValue });
+    }
+  };
+
+  parseValue = value => this.bindToMinMax(this.toNumber(value));
+
+  toNumber = number => {
+    let float = parseFloat(number);
+    if (isNaN(float) || !isFinite(float)) {
+      float = 0;
+    }
+    return float;
+  };
+
+  bindToMinMax = value => {
+    const { min, max } = this.props;
+    return Math.min(Math.max(value, min), max);
+  };
+
+  handleIncreaseValue = () => {
+    this.updateStep(1);
+  };
+
+  handleDecreaseValue = () => {
+    this.updateStep(-1);
+  };
+
+  render() {
+    const { spinner, suffix, onChange, ...others } = this.props;
+
+    const suffixWithSpinner = [
+      ...suffix,
+      spinner && (
+        <SpinnerControls
+          handleOnSpinnerUpClick={this.handleIncreaseValue}
+          handleOnSpinnerdownClick={this.handleDecreaseValue}
+        />
+      ),
+    ];
+
+    return (
+      <InputBase
+        type="number"
+        value={this.state.value}
+        suffix={suffixWithSpinner}
+        onChange={event => {
+          this.handleOnChange(event);
+          onChange(event, event.currentTarget.value);
+        }}
+        {...others}
+      />
+    );
+  }
+}
+
+NumericInput.propTypes = {
+  /** Sets a class name for the wrapper to give custom styles. */
+  className: PropTypes.string,
+  /** The maximum value that can be inputted */
+  max: PropTypes.number,
+  /** The minimum value that can be inputted */
+  min: PropTypes.number,
+  /** Boolean indicating whether to number type input should render spinner controls */
+  spinner: PropTypes.bool,
+  /** Limit increment value for numeric inputs. */
+  step: PropTypes.number,
+};
+
+NumericInput.defaultProps = {
+  min: Number.MIN_SAFE_INTEGER,
+  max: Number.MAX_SAFE_INTEGER,
+  step: 1,
+  suffix: [],
+  spinner: true,
+};
+
+export default NumericInput;

--- a/components/input/index.js
+++ b/components/input/index.js
@@ -1,5 +1,6 @@
 import Input from './Input';
 import InputBase from './InputBase';
+import NumericInput from './NumericInput';
 
-export { InputBase };
+export { InputBase, NumericInput };
 export default Input;

--- a/components/input/index.js
+++ b/components/input/index.js
@@ -1,2 +1,5 @@
 import Input from './Input';
+import InputBase from './InputBase';
+
+export { InputBase };
 export default Input;

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -16,7 +16,7 @@
   --input-error-border: var(--color-ruby-dark);
   --input-error-border-inverse: var(--color-ruby-light);
 
-  --spinner-width: calc(3 * var(--unit));
+  --spinner-width: calc(1.8 * var(--unit));
   --spinner-width-large: calc(3.6 * var(--unit));
 }
 

--- a/stories/input.js
+++ b/stories/input.js
@@ -79,7 +79,6 @@ storiesOf('Inputs', module)
       Input label
       <NumericInput
         id="input1"
-        type="number"
         bold={boolean('Bold', false)}
         disabled={boolean('Disabled', false)}
         readOnly={boolean('Read only', false)}

--- a/stories/input.js
+++ b/stories/input.js
@@ -74,7 +74,7 @@ storiesOf('Inputs', module)
       />
     </Label>
   ))
-  .add('number', () => (
+  .add('Numeric', () => (
     <Label htmlFor="input1" inverse={boolean('Inverse', false)} size={select('Size', sizes, 'medium')}>
       Input label
       <NumericInput

--- a/stories/input.js
+++ b/stories/input.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, number, select } from '@storybook/addon-knobs/react';
 import {
+  InputBase,
   Button,
   Checkbox,
   Counter,
@@ -37,6 +38,7 @@ const props = {
 const TooltippedIcon = Tooltip(Icon);
 
 storiesOf('Inputs', module)
+  .add('Input base', () => <InputBase />)
   .add('Input only', () => (
     <Input
       id="input1"

--- a/stories/input.js
+++ b/stories/input.js
@@ -10,6 +10,7 @@ import {
   Input,
   Label,
   LoadingSpinner,
+  NumericInput,
   TextBody,
   TextSmall,
   Tooltip,
@@ -76,7 +77,7 @@ storiesOf('Inputs', module)
   .add('number', () => (
     <Label htmlFor="input1" inverse={boolean('Inverse', false)} size={select('Size', sizes, 'medium')}>
       Input label
-      <Input
+      <NumericInput
         id="input1"
         type="number"
         bold={boolean('Bold', false)}


### PR DESCRIPTION
### Description

Hi folks!

This PR aims to make our dear beloved [`Input` component](https://components.teamleader.design/?selectedKind=Inputs&selectedStory=Input%20only&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs&background=%23ffffff) a little less complex.

I tried to achieve this by creating a dumb `InputBase` component - which is only concerned with its looks (what a narcissist) - and build on top of that the `Input` component which keeps track of its value.

The original `Input` component contained a lot of extra lines specifically used for when the input type was a number.
I extracted these lines and moved them to a new component: `NumericInput` 🎉,
which also is build upon the `InputBase`.

So from now on, if you want an input of the type number: use a `NumericInput`.
As a regular `Input` is unable to render a spinner (you know - the two arrows on the side to change the value).

With this PR I also aim to make the implementation of a textarea component easier.

Nothing should've changed visually.

#### Questions
This PR does not really contain a breaking change to me. As you're still able to generate an `input` that only accepts numbers, using the `Input` component (by setting the prop `type` to `"number"`). It just lost its ability to render a spinner, parse the values to an integer and keep min and max into account.

Am I wrong?

Should I make sure that for an `Input`, `type` can not be `number`(by using `PropTypes.oneOf`)?
