### PR TITLE
Fix DataGrid: Error when not supplying HeaderRowOverlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- `DataGrid`: fixed the ability to set its `selectable` property to `true` and/or set the value of `stickyLeft` greater than 0, without supplying the `HeaderRowOverlay` to it ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#412](https://github.com/teamleadercrm/ui/pull/412))
 - `DatePicker`: fixed the DatePicker collapsing when the parent element resizes ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#410](https://github.com/teamleadercrm/ui/pull/410))
 
 ## [0.16.1] - 2018-10-11

--- a/components/datagrid/DataGrid.js
+++ b/components/datagrid/DataGrid.js
@@ -16,6 +16,7 @@ import omit from 'lodash.omit';
 import throttle from 'lodash.throttle';
 import theme from './theme.css';
 import { events } from '../utils';
+import { isArray } from 'util';
 
 class DataGrid extends PureComponent {
   state = {
@@ -111,8 +112,19 @@ class DataGrid extends PureComponent {
   };
 
   render() {
-    const { checkboxSize, children, className, processing, selectable, stickyFromLeft, stickyFromRight, ...others } = this.props;
+    const {
+      checkboxSize,
+      children,
+      className,
+      processing,
+      selectable,
+      stickyFromLeft,
+      stickyFromRight,
+      ...others
+    } = this.props;
     const { selectedRows } = this.state;
+
+    console.log(...children);
 
     const classNames = cx(theme['data-grid'], className);
     const rest = omit(others, ['comparableId', 'onSelectionChange']);
@@ -142,7 +154,7 @@ class DataGrid extends PureComponent {
                   return React.cloneElement(child, {
                     checkboxSize,
                     onSelectionChange: this.handleHeaderRowSelectionChange,
-                    selected: selectedRows.length === children[2].length,
+                    selected: selectedRows.length === children.find(child => isArray(child)).length,
                     selectable,
                     sliceTo: stickyFromLeft > 0 ? stickyFromLeft : 0,
                   });

--- a/components/datagrid/DataGrid.js
+++ b/components/datagrid/DataGrid.js
@@ -124,8 +124,6 @@ class DataGrid extends PureComponent {
     } = this.props;
     const { selectedRows } = this.state;
 
-    console.log(...children);
-
     const classNames = cx(theme['data-grid'], className);
     const rest = omit(others, ['comparableId', 'onSelectionChange']);
 


### PR DESCRIPTION
### Description

In this PR I try to fix an error I added myself a while ago (sorry 'bout that).
When a row was `selectable` or the value for `stickyFromLeft` was greater than 0, supplying a `DataGrid.HeaderRowOverlay` was mandatory.

My current fix is to find the supplied `child` that is an array and get that ones `length`. Instead of taking the `length` of the hardcoded `child` with `index` 2.

This works, as the `children` is always an array containing some objects (e.g. the `HeaderRow`, `FooterRow`, etc.) and one array: an array filled with all the `BodyRow`s. And it just happens to be we need the retrieve the amount of `BodyRow`s, so the `length` of `child` that is an array does the trick.

As you'll never create multiple `HeaderRow`s (read an array) and you'll never supply your `FooterRow`s (which could be an array) before your `BodyRow`s this fix stays solid. 

I thought of other fixes like:
- selecting the last `child`s length: `children[children.length - 1].length`, but this doesn't work when e.g. a `FooterRow` comes into play (cause that one'd be the last child)
- wrapping the `BodyRows` in a `Body` (much like a `tbody`) and retrieving that ones `children`s length: 
```children.find(child => isComponentOfType(Body)).children.length```, but that would require me to create and you guys to implement an extra component

**Any thoughts?**

Nothing should've changed visually.

### Breaking changes
