### PR TITLE
DatePickerInput: remove onDayClick handler and let DayPicker handle it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ### Changed
 
-- `DatePickerInput`: remove onDayClick handler and let DayPicker handle it ([@ArnaudWeyts](https://github.com/arnaudweyts) in [#414](https://github.com/teamleadercrm/ui/pull/414))
 - `Input` (small & large): decreased its height to meet the height of our `Button` & `Select` components ([@driesd](https://github.com/driesd) in [#408](https://github.com/teamleadercrm/ui/pull/408))
 - `Select` (multi value): decreased the margin around a selected item to meet the height of our `Button` & `Input` components ([@driesd](https://github.com/driesd) in [#408](https://github.com/teamleadercrm/ui/pull/408))
 
@@ -16,6 +15,7 @@
 
 ### Fixed
 
+- `DatePickerInput`: fixed the days still being selectable after passing `dayPickerProps` with `disabledDays` ([@ArnaudWeyts](https://github.com/arnaudweyts) in [#414](https://github.com/teamleadercrm/ui/pull/414))
 - `DataGrid`: fixed the ability to set its `selectable` property to `true` and/or set the value of `stickyLeft` greater than 0, without supplying the `HeaderRowOverlay` to it ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#412](https://github.com/teamleadercrm/ui/pull/412))
 - `DatePicker`: fixed the DatePicker collapsing when the parent element resizes ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#410](https://github.com/teamleadercrm/ui/pull/410))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 
+- `DatePickerInput`: remove onDayClick handler and let DayPicker handle it ([@ArnaudWeyts](https://github.com/arnaudweyts) in [#414](https://github.com/teamleadercrm/ui/pull/414))
 - `Input` (small & large): decreased its height to meet the height of our `Button` & `Select` components ([@driesd](https://github.com/driesd) in [#408](https://github.com/teamleadercrm/ui/pull/408))
 - `Select` (multi value): decreased the margin around a selected item to meet the height of our `Button` & `Input` components ([@driesd](https://github.com/driesd) in [#408](https://github.com/teamleadercrm/ui/pull/408))
 

--- a/components/datepicker/DatePickerInput.js
+++ b/components/datepicker/DatePickerInput.js
@@ -57,7 +57,6 @@ class DatePickerInput extends PureComponent {
           className: dayPickerClassNames,
           classNames: theme,
           modifiers: convertModifiersToClassnames(modifiers, theme),
-          onDayClick: this.handleInputDateChange,
           selectedDays: selectedDate,
           navbarElement: <NavigationBar size={size} />,
           weekdayElement: <WeekDay size={size} />,


### PR DESCRIPTION
### Description

Since the DayPicker already handles this function by itself, stop using a custom function to react to the date being clicked. In my case, I disabled all days before a certain date, and when a disabled date was being clicked, it would still run the function without keeping the disabled modifier into account. Letting the DayPicker handle it fixes this.

### Breaking changes

None.

It would probably be a good idea to do a manual check on all of the implemented DatePickers to see if no one actually uses this.