### PR TITLE
[TU-111] DatePickerInput: Consistent text alignment 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 
+- `DatePickerInput`: left aligned the `DatePickerInput` text ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#415](https://github.com/teamleadercrm/ui/pull/415))
 - `Input` (small & large): decreased its height to meet the height of our `Button` & `Select` components ([@driesd](https://github.com/driesd) in [#408](https://github.com/teamleadercrm/ui/pull/408))
 - `Select` (multi value): decreased the margin around a selected item to meet the height of our `Button` & `Input` components ([@driesd](https://github.com/driesd) in [#408](https://github.com/teamleadercrm/ui/pull/408))
 

--- a/components/datepicker/theme.css
+++ b/components/datepicker/theme.css
@@ -377,7 +377,6 @@
     outline: 0;
     padding: 0;
     width: var(--input-width);
-    text-align: center;
   }
 }
 

--- a/components/datepicker/theme.css
+++ b/components/datepicker/theme.css
@@ -337,6 +337,10 @@
   }
 }
 
+.date-picker-input-range input {
+  text-align: center;
+}
+
 .overlay {
   composes: box-shadow-200;
   background: var(--color-white);


### PR DESCRIPTION
### Description

Up until now the text in al the of the inputs are left aligned, but only the `DatePickerInput` was aligned in the center.

Fo consistency reasons, we also align the text in the `DatePickerInput` to the left.

As you'll see we do still apply the center alignment for the `DatePickerInputRange` (which is a wrapper for two `DatePickerInput`s). This makes sure the dash in between the two inputs it contains stays centered, but the two inputs themselves stay on the left hand side of their wrapper (which was already the case before this PR).

#### Screenshot before this PR
![screen shot 2018-10-24 at 15 13 43](https://user-images.githubusercontent.com/23736202/47434582-1d89a080-d7a3-11e8-8caf-640e74d34be7.png)

#### Screenshot after this PR

![screen shot 2018-10-24 at 15 13 55](https://user-images.githubusercontent.com/23736202/47434575-1bbfdd00-d7a3-11e8-8a99-2de32564b317.png)

### Breaking changes

None.