### PR TITLE
Proposal: HOC InjectTheme

### DIFF
--- a/components/hoc/withTheme/index.js
+++ b/components/hoc/withTheme/index.js
@@ -1,0 +1,2 @@
+import withTheme from './withTheme';
+export default withTheme;

--- a/components/hoc/withTheme/withTheme.js
+++ b/components/hoc/withTheme/withTheme.js
@@ -1,0 +1,34 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+const withTheme = theme => WrappedComponent => {
+  class WithTheme extends PureComponent {
+    render() {
+      const { color, size, tint, className, ...others } = this.props;
+
+      const classNames = cx(theme[`is-${color}`], theme[`is-${size}`], theme[`is-${tint}`], className);
+
+      return <WrappedComponent className={classNames} {...others} />;
+    }
+  }
+
+  WithTheme.propTypes = {
+    /** The color of the component */
+    color: PropTypes.PropTypes.oneOf(['aqua', 'gold', 'mint', 'neutral', 'ruby', 'teal', 'violet']),
+    /** The size of the component */
+    size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'fullscreen']),
+    /** The tint of the component */
+    tint: PropTypes.oneOf(['lightest', 'light', 'normal', 'dark', 'darkest']),
+  };
+
+  WithTheme.defaultProps = {
+    color: 'neutral',
+    size: 'medium',
+    tint: 'normal',
+  };
+
+  return WithTheme;
+};
+
+export default withTheme;

--- a/components/hoc/withTheme/withTheme.js
+++ b/components/hoc/withTheme/withTheme.js
@@ -28,6 +28,8 @@ const withTheme = theme => WrappedComponent => {
     tint: 'normal',
   };
 
+  WithTheme.displayName = `WithTheme(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
+
   return WithTheme;
 };
 

--- a/components/loadingBar/LoadingBar.js
+++ b/components/loadingBar/LoadingBar.js
@@ -2,20 +2,16 @@ import React, { PureComponent } from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 
+import withTheme from '../hoc/withTheme';
+
 import Box from '../box';
 import theme from './theme.css';
 
 class LoadingBar extends PureComponent {
   render() {
-    const { className, color, size, tint, ...others } = this.props;
+    const { className, ...others } = this.props;
 
-    const classNames = cx(
-      theme['loading-bar'],
-      theme[`is-${color}`],
-      theme[`is-${size}`],
-      theme[`is-${tint}`],
-      className,
-    );
+    const classNames = cx(theme['loading-bar'], className);
 
     return (
       <Box data-teamleader-ui="loading-bar" className={classNames} {...others}>
@@ -28,18 +24,6 @@ class LoadingBar extends PureComponent {
 LoadingBar.propTypes = {
   /** A class name for the wrapper to add custom classes */
   className: PropTypes.string,
-  /** The color of the components */
-  color: PropTypes.oneOf(['aqua', 'gold', 'mint', 'neutral', 'ruby', 'teal', 'violet']),
-  /** Size of the component */
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
-  /** The tint of the components color */
-  tint: PropTypes.oneOf(['lightest', 'light', 'normal', 'dark', 'darkest']),
 };
 
-LoadingBar.defaultProps = {
-  color: 'mint',
-  size: 'small',
-  tint: 'neutral',
-};
-
-export default LoadingBar;
+export default withTheme(theme)(LoadingBar);

--- a/components/loadingBar/LoadingBar.js
+++ b/components/loadingBar/LoadingBar.js
@@ -2,16 +2,20 @@ import React, { PureComponent } from 'react';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 
-import withTheme from '../hoc/withTheme';
-
 import Box from '../box';
 import theme from './theme.css';
 
 class LoadingBar extends PureComponent {
   render() {
-    const { className, ...others } = this.props;
+    const { className, color, size, tint, ...others } = this.props;
 
-    const classNames = cx(theme['loading-bar'], className);
+    const classNames = cx(
+      theme['loading-bar'],
+      theme[`is-${color}`],
+      theme[`is-${size}`],
+      theme[`is-${tint}`],
+      className,
+    );
 
     return (
       <Box data-teamleader-ui="loading-bar" className={classNames} {...others}>
@@ -24,6 +28,18 @@ class LoadingBar extends PureComponent {
 LoadingBar.propTypes = {
   /** A class name for the wrapper to add custom classes */
   className: PropTypes.string,
+  /** The color of the components */
+  color: PropTypes.oneOf(['aqua', 'gold', 'mint', 'neutral', 'ruby', 'teal', 'violet']),
+  /** Size of the component */
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  /** The tint of the components color */
+  tint: PropTypes.oneOf(['lightest', 'light', 'normal', 'dark', 'darkest']),
 };
 
-export default withTheme(theme)(LoadingBar);
+LoadingBar.defaultProps = {
+  color: 'mint',
+  size: 'small',
+  tint: 'neutral',
+};
+
+export default LoadingBar;


### PR DESCRIPTION
### Description

Hi y'all,

This PR is a proposal for a HoC that'd remove quite some boilerplate.

`color`, `tint` and `size` are all props that are repeated throughout our library.

They are all used in the same way: their string values are used to construct another string, with the following signature: `'is-[PROP VALUE]'` (or at least they should've).

This string is then used as a class name to apply the appropriate styling.

The valid values for these props should also be the same over the whole library.

Wrapping the components in the HoC created in this PR, takes care of all of the above.

It would centralise all this logic and enhance consistency.

A concern of mine in this PR are the default props:
in the current implementation these'd be the same for all components.

We could say that from now on the default props of `withTheme` will be default for all components or remove the default props declaration out of `withTheme` and keep declaring them in the components themselves.

**What do you guys think?**

### Breaking changes

None, as this is HoC is something that we'll be using internally.