### PR TITLE
[TU-160] Input: Set cursor to pointer on spinners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - `ErrorText`: added the `ErrorText` component ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#407](https://github.com/teamleadercrm/ui/pull/407))
+- `NumericInput`: added indication of the spinners click ablity, by changing the cursor to a pointer when hovering over it ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#417](https://github.com/teamleadercrm/ui/pull/417))
 
 ### Changed
 

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -260,6 +260,7 @@
   background: transparent;
   border: 0;
   border-radius: 0;
+  cursor: pointer;
 
   &:focus {
     outline: none;


### PR DESCRIPTION
### Description

The spinners lacked a visual cue for their click ability.
This PR sets the cursor to a pointer when hovering over a spinner to fix this.

**Q: should this be in the changelog? As this does not change anything about the implementation of the component**

#### Screenshot before this PR
![screen shot 2018-10-25 at 10 49 35](https://user-images.githubusercontent.com/23736202/47488114-00f17500-d844-11e8-9982-542579d5c4ec.png)

#### Screenshot after this PR
![screen shot 2018-10-25 at 10 50 05](https://user-images.githubusercontent.com/23736202/47488128-05b62900-d844-11e8-9dd0-aa5699a57b07.png)

### Breaking changes

None.