### PR TITLE
NumericInput: Fix spinner color for inverse input

### DIFF
--- a/components/input/NumericInput.js
+++ b/components/input/NumericInput.js
@@ -85,6 +85,7 @@ class NumericInput extends PureComponent {
   getSuffixWithSpinner = () => [
     ...this.props.suffix,
     <SpinnerControls
+      inverse={this.props.inverse}
       handleOnSpinnerUpClick={this.handleIncreaseValue}
       handleOnSpinnerDownClick={this.handleDecreaseValue}
     />,


### PR DESCRIPTION
### Description

This PR fixes the spinner color of the inverse `NumericInput`.
The visual issue was caused by not passing down the correct prop.

#### Screenshot before this PR
<img width="521" alt="screen shot 2018-10-25 at 19 09 19" src="https://user-images.githubusercontent.com/23736202/47549284-e4b10f00-d8fb-11e8-9d0d-834a0a4ab901.png">

#### Screenshot after this PR
<img width="522" alt="screen shot 2018-10-25 at 19 08 48" src="https://user-images.githubusercontent.com/23736202/47549281-dfec5b00-d8fb-11e8-84c3-f16f5d801c85.png">

### Breaking changes

None.
