### PR TITLE
DataGrid maintenance

### DIFF
--- a/components/datagrid/BodyRow.js
+++ b/components/datagrid/BodyRow.js
@@ -38,13 +38,21 @@ class BodyRow extends PureComponent {
 }
 
 BodyRow.propTypes = {
+  /** The size of the checkbox rendered on the left side of the row. */
   checkboxSize: PropTypes.oneOf(['small', 'medium', 'large']),
+  /** A class name for the row to give custom styles. */
   className: PropTypes.string,
+  /** The cells to display inside the row. */
   children: PropTypes.any,
+  /** Callback function that is fired when the checkbox on the left side has changed. */
   onSelectionChange: PropTypes.func,
+  /** If true, checkboxes will be rendered on the left side of each row. */
   selectable: PropTypes.bool,
+  /** If true, the checkbox on the left side of the row will be checked. */
   selected: PropTypes.bool,
+  /** Amount of cells that will be sliced off, starting from left. */
   sliceFrom: PropTypes.number,
+  /** Amount of cells that will be sliced off, starting from right. */
   sliceTo: PropTypes.number,
 };
 

--- a/components/datagrid/Cell.js
+++ b/components/datagrid/Cell.js
@@ -41,15 +41,24 @@ class Cell extends PureComponent {
 }
 
 Cell.propTypes = {
+  /** The horizontal alignment of the text inside the cell. */
   align: PropTypes.oneOf(['left', 'center', 'right']),
+  /** The background color the cell should have. */
   backgroundColor: PropTypes.oneOf(['white', 'neutral']),
+  /** The border style the cell should have. */
   border: PropTypes.oneOf(['around', 'left', 'right']),
   bordered: PropTypes.bool,
+  /** The cells to display inside the cell. */
   children: PropTypes.any,
+  /** A class name for the cell to give custom styles. */
   className: PropTypes.string,
+  /** The width proportion of the cell against the others. */
   flex: PropTypes.oneOf(['min-width', '1', '2', '3', '4']),
+  /** If true, an ellipsis will be shown when the cell content is too long. */
   preventOverflow: PropTypes.bool,
+  /** If true, the text inside the cell will be bold */
   soft: PropTypes.bool,
+  /** If true, the color of the text inside the cell will be neutral darkest */
   strong: PropTypes.bool,
 };
 

--- a/components/datagrid/Cell.js
+++ b/components/datagrid/Cell.js
@@ -47,7 +47,6 @@ Cell.propTypes = {
   backgroundColor: PropTypes.oneOf(['white', 'neutral']),
   /** The border style the cell should have. */
   border: PropTypes.oneOf(['around', 'left', 'right']),
-  bordered: PropTypes.bool,
   /** The cells to display inside the cell. */
   children: PropTypes.any,
   /** A class name for the cell to give custom styles. */

--- a/components/datagrid/DataGrid.js
+++ b/components/datagrid/DataGrid.js
@@ -200,14 +200,23 @@ class DataGrid extends PureComponent {
 }
 
 DataGrid.propTypes = {
+  /** The size of the checkbox rendered on the left side of each row */
   checkboxSize: PropTypes.oneOf(['small', 'medium', 'large']),
+  /** The content to display inside the data grid. */
   children: PropTypes.node,
+  /** A class name for the wrapper to give custom styles. */
   className: PropTypes.string,
+  /** A unique id which will be compared on each render to reset the selected rows */
   comparableId: PropTypes.any,
+  /** If true, checkboxes will be rendered on the left side of each row */
   selectable: PropTypes.bool,
+  /** Amount of columns that will be sticky, starting from left */
   stickyFromLeft: PropTypes.number,
+  /** Amount of columns that will be sticky, starting from right */
   stickyFromRight: PropTypes.number,
+  /** Callback function that is fired when the selected rows have changed */
   onSelectionChange: PropTypes.func,
+  /** If true, a loading bar will be rendered below the header row */
   processing: PropTypes.bool,
 };
 

--- a/components/datagrid/HeaderCell.js
+++ b/components/datagrid/HeaderCell.js
@@ -28,9 +28,13 @@ class HeaderCell extends PureComponent {
 }
 
 HeaderCell.propTypes = {
+  /** The content to display inside the cell. */
   children: PropTypes.any,
+  /** A class name for the wrapper to give custom styles. */
   className: PropTypes.string,
+  /** Callback function that is fired when clicking on the cell. */
   onClick: PropTypes.func,
+  /** The order in which the grid rows will be sorted. */
   sorted: PropTypes.oneOf(['none', 'asc', 'desc']),
 };
 

--- a/components/datagrid/HeaderRow.js
+++ b/components/datagrid/HeaderRow.js
@@ -38,13 +38,21 @@ class HeaderRow extends PureComponent {
 }
 
 HeaderRow.propTypes = {
+  /** The size of the checkbox rendered on the left side of the row. */
   checkboxSize: PropTypes.oneOf(['small', 'medium', 'large']),
+  /** A class name for the row to give custom styles. */
   className: PropTypes.string,
+  /** The cells to display inside the row. */
   children: PropTypes.any,
+  /** Callback function that is fired when the checkbox on the left side has changed. */
   onSelectionChange: PropTypes.func,
+  /** If true, checkboxes will be rendered on the left side of each row. */
   selectable: PropTypes.bool,
+  /** If true, the checkbox on the left side of the row will be checked. */
   selected: PropTypes.bool,
+  /** Amount of cells that will be sliced off, starting from left. */
   sliceFrom: PropTypes.number,
+  /** Amount of cells that will be sliced off, starting from right. */
   sliceTo: PropTypes.number,
 };
 

--- a/stories/datagrid.js
+++ b/stories/datagrid.js
@@ -25,7 +25,7 @@ const handleRowSelectionChange = selectedRows => {
 storiesOf('DataGrids', module)
   .addParameters({
     info: {
-      propTablesExclude: [Link, TextSmall, Heading4, IconMenu, MenuItem],
+      propTablesExclude: [Button, ButtonGroup, Heading4, IconMenu, Link, MenuItem, TextSmall],
     },
   })
   .add('Basic', () => (


### PR DESCRIPTION
### Description

In this small PR, we did three things in order to complete the `DataGrid` documentation:
- Excluded some `prop tables` that were just clutter
- Added the missing `prop type descriptions`
- Removed the `bordered` prop, which was never used (must be a leftover from an earlier change)

### Breaking changes

None.
