### PR TITLE
Primary & Secondary Button: fix border style when disabled 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Button`: fixed the faulty border style of our primary & secondary button when disabled ([@driesd](https://github.com/driesd) in [#424](https://github.com/teamleadercrm/ui/pull/424))
+
 ## [0.17.0] - 2018-10-26
 
 ### Added

--- a/components/button/theme.css
+++ b/components/button/theme.css
@@ -266,6 +266,7 @@
 .secondary {
   &.is-disabled {
     background-color: var(--color-neutral);
+    border: 1px solid var(--color-neutral-dark);
     color: var(--color-neutral-dark);
   }
 }


### PR DESCRIPTION
### Description

This PR fixes the faulty `border style` of our `disabled primary & secondary buttons`.

#### Screenshot before this PR
in `Chrome`

![schermafdruk 2018-10-29 11 36 29](https://user-images.githubusercontent.com/5336831/47644774-60ff5880-db6f-11e8-9fd4-60ee2b7db840.png)

in `IE11`

![schermafdruk 2018-10-29 11 41 08](https://user-images.githubusercontent.com/5336831/47644878-a4f25d80-db6f-11e8-807a-e529da32c515.png)

#### Screenshot after this PR

![schermafdruk 2018-10-29 11 31 19](https://user-images.githubusercontent.com/5336831/47644782-652b7600-db6f-11e8-9028-00b75a5c6c97.png)

### Breaking changes

None.
