### PR TITLE
InputBase: Extract SingleLineInputBase

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -12,7 +12,7 @@ import DataGrid from './datagrid';
 import { DatePicker, DatePickerRange, DatePickerInput, DatePickerInputRange } from './datepicker';
 import Dialog from './dialog';
 import Icon from './icon';
-import Input, { InputBase, NumericInput, SingleLineInputBase } from './input';
+import Input, { InputBase, NumericInput } from './input';
 import Menu, { IconMenu, MenuItem, MenuDivider } from './menu';
 import Link from './link';
 import Message from './message';
@@ -90,7 +90,6 @@ export {
   RadioGroup,
   Section,
   Select,
-  SingleLineInputBase,
   StatusBullet,
   StatusLabel,
   TextBody,

--- a/components/index.js
+++ b/components/index.js
@@ -12,7 +12,7 @@ import DataGrid from './datagrid';
 import { DatePicker, DatePickerRange, DatePickerInput, DatePickerInputRange } from './datepicker';
 import Dialog from './dialog';
 import Icon from './icon';
-import Input, { InputBase, NumericInput } from './input';
+import Input, { InputBase, NumericInput, SingleLineInputBase } from './input';
 import Menu, { IconMenu, MenuItem, MenuDivider } from './menu';
 import Link from './link';
 import Message from './message';
@@ -90,6 +90,7 @@ export {
   RadioGroup,
   Section,
   Select,
+  SingleLineInputBase,
   StatusBullet,
   StatusLabel,
   TextBody,

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-import InputBase from './InputBase';
+import SingleLineInputBase from './SingleLineInputBase';
 
 class Input extends PureComponent {
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -26,7 +26,7 @@ class Input extends PureComponent {
     const { onChange, ...others } = this.props;
 
     return (
-      <InputBase
+      <SingleLineInputBase
         value={this.state.value}
         onChange={event => {
           this.setState({ value: event.currentTarget.value });

--- a/components/input/InputBase.js
+++ b/components/input/InputBase.js
@@ -2,17 +2,11 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import omit from 'lodash.omit';
-import Box, { omitBoxProps, pickBoxProps } from '../box';
-import ValidationText from '../validationText';
+import { omitBoxProps } from '../box';
 import theme from './theme.css';
 
 class InputBase extends PureComponent {
-  state = {
-    inputHasfocus: false,
-  };
-
   handleBlur = event => {
-    this.setState({ inputHasFocus: false });
     if (this.props.onBlur) {
       this.props.onBlur(event);
     }
@@ -25,36 +19,26 @@ class InputBase extends PureComponent {
   };
 
   handleFocus = event => {
-    this.setState({ inputHasFocus: true });
     if (this.props.onFocus) {
       this.props.onFocus(event);
     }
   };
 
-  renderOneOrMultipleElements(prop) {
-    if (Array.isArray(prop)) {
-      return prop.map((element, index) => React.cloneElement(element, { key: index }));
-    }
+  render() {
+    const { bold, className, error, inverse, size, ...otherProps } = this.props;
 
-    return prop;
-  }
+    const classNames = cx(
+      theme['input'],
+      theme[`is-${size}`],
+      {
+        [theme['has-error']]: error,
+        [theme['is-inverse']]: inverse,
+        [theme['is-bold']]: bold,
+      },
+      className,
+    );
 
-  renderInput = () => {
-    const { bold, ...otherProps } = this.props;
-
-    const classNames = cx(theme['input'], { [theme['is-bold']]: bold });
-
-    const restProps = omit(omitBoxProps(otherProps), [
-      'className',
-      'connectedLeft',
-      'connectedRight',
-      'helpText',
-      'inverse',
-      'onChange',
-      'prefix',
-      'size',
-      'suffix',
-    ]);
+    const restProps = omit(omitBoxProps(otherProps), ['className', 'helpText', 'inverse', 'size']);
 
     const props = {
       className: classNames,
@@ -65,57 +49,6 @@ class InputBase extends PureComponent {
     };
 
     return <input {...props} />;
-  };
-
-  render() {
-    const {
-      className,
-      connectedLeft,
-      connectedRight,
-      disabled,
-      error,
-      helpText,
-      inverse,
-      prefix,
-      size,
-      suffix,
-      readOnly,
-      ...others
-    } = this.props;
-
-    const { inputHasFocus } = this.state;
-
-    const classNames = cx(
-      theme['wrapper'],
-      theme[`is-${size}`],
-      {
-        [theme['has-error']]: error,
-        [theme['has-focus']]: inputHasFocus,
-        [theme['has-connected-left']]: connectedLeft,
-        [theme['has-connected-right']]: connectedRight,
-        [theme['is-inverse']]: inverse,
-        [theme['is-disabled']]: disabled,
-        [theme['is-read-only']]: readOnly,
-      },
-      className,
-    );
-
-    const rest = pickBoxProps(others);
-
-    return (
-      <Box className={classNames} {...rest}>
-        <div className={theme['input-wrapper']}>
-          {connectedLeft}
-          <div className={theme['input-inner-wrapper']}>
-            {prefix && <div className={theme['prefix-wrapper']}>{this.renderOneOrMultipleElements(prefix)}</div>}
-            {this.renderInput()}
-            {suffix && <div className={theme['suffix-wrapper']}>{this.renderOneOrMultipleElements(suffix)}</div>}
-          </div>
-          {connectedRight}
-        </div>
-        <ValidationText error={error} help={helpText} inverse={inverse} />
-      </Box>
-    );
   }
 }
 
@@ -124,10 +57,6 @@ InputBase.propTypes = {
   bold: PropTypes.bool,
   /** Sets a class name for the wrapper to give custom styles. */
   className: PropTypes.string,
-  /** Element stuck to the left hand side of the component. */
-  connectedLeft: PropTypes.element,
-  /** Element stuck to the right hand side of the component. */
-  connectedRight: PropTypes.element,
   /** Boolean indicating whether the input should render as disabled. */
   disabled: PropTypes.bool,
   /** The text string/element to use as error message below the input. */
@@ -142,14 +71,10 @@ InputBase.propTypes = {
   onFocus: PropTypes.func,
   /** Callback function that is fired when the component's value changes. */
   onChange: PropTypes.func,
-  /** The text string/element to use as a prefix inside the input field */
-  prefix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
   /** Boolean indicating whether the input should render as read only. */
   readOnly: PropTypes.bool,
   /** Size of the input element. */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
-  /** The text string/element to use as a suffix inside the input field */
-  suffix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
   /** Type of the input element. It can be a valid HTML5 input type. */
   type: PropTypes.oneOf([
     'button',

--- a/components/input/InputBase.js
+++ b/components/input/InputBase.js
@@ -6,24 +6,6 @@ import { omitBoxProps } from '../box';
 import theme from './theme.css';
 
 class InputBase extends PureComponent {
-  handleBlur = event => {
-    if (this.props.onBlur) {
-      this.props.onBlur(event);
-    }
-  };
-
-  handleChange = event => {
-    if (this.props.onChange) {
-      this.props.onChange(event);
-    }
-  };
-
-  handleFocus = event => {
-    if (this.props.onFocus) {
-      this.props.onFocus(event);
-    }
-  };
-
   render() {
     const { bold, className, element, error, inverse, size, ...otherProps } = this.props;
 
@@ -42,9 +24,6 @@ class InputBase extends PureComponent {
 
     const props = {
       className: classNames,
-      onBlur: this.handleBlur,
-      onChange: this.handleChange,
-      onFocus: this.handleFocus,
       ...restProps,
     };
 

--- a/components/input/InputBase.js
+++ b/components/input/InputBase.js
@@ -25,7 +25,7 @@ class InputBase extends PureComponent {
   };
 
   render() {
-    const { bold, className, error, inverse, size, ...otherProps } = this.props;
+    const { bold, className, element, error, inverse, size, ...otherProps } = this.props;
 
     const classNames = cx(
       theme['input'],
@@ -48,7 +48,7 @@ class InputBase extends PureComponent {
       ...restProps,
     };
 
-    return <input {...props} />;
+    return React.createElement(element, props);
   }
 }
 
@@ -59,6 +59,8 @@ InputBase.propTypes = {
   className: PropTypes.string,
   /** Boolean indicating whether the input should render as disabled. */
   disabled: PropTypes.bool,
+  /** The element to render. */
+  element: PropTypes.oneOf(['input', 'textarea']),
   /** The text string/element to use as error message below the input. */
   error: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   /** The text string to use as help text below the input. */
@@ -107,6 +109,7 @@ InputBase.propTypes = {
 InputBase.defaultProps = {
   inverse: false,
   disabled: false,
+  element: 'input',
   readOnly: false,
   size: 'medium',
 };

--- a/components/input/NumericInput.js
+++ b/components/input/NumericInput.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { IconChevronUpSmallOutline, IconChevronDownSmallOutline } from '@teamleader/ui-icons';
 import Icon from '../icon';
-import InputBase from './InputBase';
+import SingleLineInputBase from './SingleLineInputBase';
 import theme from './theme.css';
 
 class SpinnerControls extends PureComponent {
@@ -95,7 +95,7 @@ class NumericInput extends PureComponent {
     const { spinner, suffix, onChange, ...others } = this.props;
 
     return (
-      <InputBase
+      <SingleLineInputBase
         type="number"
         value={this.state.value}
         suffix={spinner ? this.getSuffixWithSpinner() : suffix}

--- a/components/input/SingleLineInputBase.js
+++ b/components/input/SingleLineInputBase.js
@@ -13,6 +13,20 @@ class SingleLineInputBase extends PureComponent {
     inputHasfocus: false,
   };
 
+  handleBlur = event => {
+    this.setState({ inputHasfocus: false });
+    if (this.props.onBlur) {
+      this.props.onBlur(event);
+    }
+  };
+
+  handleFocus = event => {
+    this.setState({ inputHasfocus: true });
+    if (this.props.onFocus) {
+      this.props.onFocus(event);
+    }
+  };
+
   renderOneOrMultipleElements(prop) {
     if (Array.isArray(prop)) {
       return prop.map((element, index) => React.cloneElement(element, { key: index }));
@@ -57,6 +71,8 @@ class SingleLineInputBase extends PureComponent {
       disabled,
       error,
       inverse,
+      onBlur: this.handleBlur,
+      onFocus: this.handleFocus,
       readOnly,
       ...omitBoxProps(others),
     };
@@ -67,17 +83,7 @@ class SingleLineInputBase extends PureComponent {
           {connectedLeft}
           <div className={theme['input-inner-wrapper']}>
             {prefix && <div className={theme['prefix-wrapper']}>{this.renderOneOrMultipleElements(prefix)}</div>}
-            <InputBase
-              onFocus={() => {
-                this.setState({ inputHasfocus: true });
-                onFocus && onFocus();
-              }}
-              onBlur={() => {
-                this.setState({ inputHasfocus: false });
-                onBlur && onBlur();
-              }}
-              {...inputProps}
-            />
+            <InputBase {...inputProps} />
             {suffix && <div className={theme['suffix-wrapper']}>{this.renderOneOrMultipleElements(suffix)}</div>}
           </div>
           {connectedRight}

--- a/components/input/SingleLineInputBase.js
+++ b/components/input/SingleLineInputBase.js
@@ -1,0 +1,14 @@
+import React, { PureComponent } from 'react';
+import InputBase from './InputBase';
+
+class SingleLineInputBase extends PureComponent {
+  render() {
+    return <InputBase {...this.props} />;
+  }
+}
+
+SingleLineInputBase.propTypes = {};
+
+SingleLineInputBase.defaultProps = {};
+
+export default SingleLineInputBase;

--- a/components/input/SingleLineInputBase.js
+++ b/components/input/SingleLineInputBase.js
@@ -74,7 +74,7 @@ class SingleLineInputBase extends PureComponent {
               }}
               onBlur={() => {
                 this.setState({ inputHasfocus: false });
-                onBlur && onFocus();
+                onBlur && onBlur();
               }}
               {...inputProps}
             />

--- a/components/input/SingleLineInputBase.js
+++ b/components/input/SingleLineInputBase.js
@@ -1,14 +1,102 @@
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
 import InputBase from './InputBase';
+import Box, { omitBoxProps, pickBoxProps } from '../box';
+import ValidationText from '../validationText';
+
+import theme from './theme.css';
 
 class SingleLineInputBase extends PureComponent {
+  state = {
+    inputHasfocus: false,
+  };
+
+  renderOneOrMultipleElements(prop) {
+    if (Array.isArray(prop)) {
+      return prop.map((element, index) => React.cloneElement(element, { key: index }));
+    }
+
+    return prop;
+  }
+
   render() {
-    return <InputBase {...this.props} />;
+    const {
+      className,
+      connectedLeft,
+      connectedRight,
+      disabled,
+      error,
+      helpText,
+      onFocus,
+      onBlur,
+      prefix,
+      inverse,
+      readOnly,
+      suffix,
+      ...others
+    } = this.props;
+
+    const classNames = cx(
+      theme['wrapper'],
+      {
+        [theme['has-focus']]: this.state.inputHasfocus,
+        [theme['has-error']]: error,
+        [theme['has-connected-left']]: connectedLeft,
+        [theme['has-connected-right']]: connectedRight,
+        [theme['is-disabled']]: disabled,
+        [theme['is-inverse']]: inverse,
+        [theme['is-read-only']]: readOnly,
+      },
+      className,
+    );
+
+    const boxProps = pickBoxProps(others);
+    const inputProps = {
+      disabled,
+      error,
+      inverse,
+      readOnly,
+      ...omitBoxProps(others),
+    };
+
+    return (
+      <Box className={classNames} {...boxProps}>
+        <div className={theme['input-wrapper']}>
+          {connectedLeft}
+          <div className={theme['input-inner-wrapper']}>
+            {prefix && <div className={theme['prefix-wrapper']}>{this.renderOneOrMultipleElements(prefix)}</div>}
+            <InputBase
+              onFocus={() => {
+                this.setState({ inputHasfocus: true });
+                onFocus && onFocus();
+              }}
+              onBlur={() => {
+                this.setState({ inputHasfocus: false });
+                onBlur && onFocus();
+              }}
+              {...inputProps}
+            />
+            {suffix && <div className={theme['suffix-wrapper']}>{this.renderOneOrMultipleElements(suffix)}</div>}
+          </div>
+          {connectedRight}
+        </div>
+        <ValidationText error={error} help={helpText} inverse={inverse} />
+      </Box>
+    );
   }
 }
 
-SingleLineInputBase.propTypes = {};
-
-SingleLineInputBase.defaultProps = {};
+SingleLineInputBase.propTypes = {
+  /** Element stuck to the left hand side of the component. */
+  connectedLeft: PropTypes.element,
+  /** Element stuck to the right hand side of the component. */
+  connectedRight: PropTypes.element,
+  /** The text string/element to use as a prefix inside the input field */
+  prefix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
+  /** The text string/element to use as a suffix inside the input field */
+  suffix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
+};
 
 export default SingleLineInputBase;

--- a/components/input/index.js
+++ b/components/input/index.js
@@ -1,6 +1,7 @@
 import Input from './Input';
 import InputBase from './InputBase';
+import SingleLineInputBase from './SingleLineInputBase';
 import NumericInput from './NumericInput';
 
-export { InputBase, NumericInput };
+export { InputBase, NumericInput, SingleLineInputBase };
 export default Input;

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -23,166 +23,92 @@
 /**
  * Components
  */
-.wrapper {
-  width: 100%;
 
-  .input-inner-wrapper {
-    background: var(--color-white);
-    border: 1px solid var(--color-neutral-dark);
-  }
-
-  &:hover .input-inner-wrapper {
-    border-color: var(--color-neutral-darkest);
-  }
-
-  &.has-focus .input-inner-wrapper {
-    border-color: var(--color-neutral-darkest);
-    box-shadow: 0 0 0 1px var(--color-neutral-darkest);
-  }
-
-  &:active .input-inner-wrapper {
-    border-color: var(--color-neutral-darkest);
-    box-shadow: inset 0 1px 3px 0 rgba(130, 130, 140, 0.48);
-    z-index: 1;
-  }
-
-  &.is-disabled input {
-    color: var(--color-neutral-darkest);
-  }
-
-  &.is-read-only,
-  &.is-disabled {
-    .input-inner-wrapper {
-      background-color: var(--color-neutral);
-      border-color: var(--color-neutral);
-      box-shadow: none;
-    }
-  }
-
-  &.is-inverse {
-    .input-inner-wrapper {
-      background: var(--color-teal);
-      border-color: var(--color-teal);
-    }
-
-    .input {
-      color: var(--color-neutral-lightest);
-
-      &::placeholder {
-        color: var(--color-teal-light);
-      }
-    }
-
-    &:hover .input-inner-wrapper {
-      border-color: var(--color-teal-light);
-    }
-
-    &.has-focus .input-inner-wrapper {
-      border-color: var(--color-teal-light);
-      box-shadow: 0 0 0 1px var(--color-teal-light);
-    }
-
-    &:active .input-inner-wrapper {
-      border-color: var(--color-teal-light);
-      box-shadow: inset 0 1px 3px 0 color(var(--color-teal-darkest) a(0.48));
-    }
-
-    &.is-disabled .input {
-      color: var(--color-teal);
-
-      &::placeholder {
-        color: var(--color-teal);
-      }
-    }
-
-    &.is-read-only,
-    &.is-disabled {
-      .input-inner-wrapper {
-        background-color: var(--color-teal-dark);
-        border-color: var(--color-teal-dark);
-      }
-    }
-  }
-}
-
+.wrapper,
 .input {
   width: 100%;
+  border-radius: var(--input-border-radius);
+}
+
+/*
+  Default styling
+*/
+
+.wrapper .input-inner-wrapper,
+.input {
   border: 1px solid var(--color-neutral-dark);
   background-color: var(--color-white);
-  color: var(--color-teal-darkest);
-
-  &::placeholder {
-    color: var(--color-neutral-darkest);
-  }
-
-  &:hover {
-    border-color: var(--color-neutral-darkest);
-  }
-
-  &:focus {
-    border-color: var(--color-neutral-darkest);
-    box-shadow: 0 0 0 1px var(--color-neutral-darkest);
-  }
-
-  &:active {
-    border-color: var(--color-neutral-darkest);
-    box-shadow: inset 0 1px 3px 0 rgba(130, 130, 140, 0.48);
-  }
-
-  &:disabled {
-    color: var(--color-neutral-darkest);
-  }
-
-  &:disabled,
-  &:read-only {
-    background-color: var(--color-neutral);
-    border-color: var(--color-neutral);
-    box-shadow: none;
-  }
-
-  &.is-inverse {
-    background-color: var(--color-teal);
-    border-color: var(--color-teal);
-
-    color: var(--color-neutral-lightest);
-
-    &::placeholder {
-      color: var(--color-teal-light);
-    }
-
-    &:hover {
-      border-color: var(--color-teal-light);
-    }
-
-    &:focus {
-      border-color: var(--color-teal-light);
-      box-shadow: 0 0 0 1px var(--color-teal-light);
-    }
-
-    &:active {
-      border-color: var(--color-teal-light);
-      box-shadow: inset 0 1px 3px 0 color(var(--color-teal-darkest) a(0.48));
-    }
-
-    &:disabled {
-      color: var(--color-teal);
-
-      &::placeholder {
-        color: var(--color-teal);
-      }
-    }
-
-    &:disabled,
-    &:read-only {
-      background-color: var(--color-teal-dark);
-      border-color: var(--color-teal-dark);
-    }
-  }
 }
 
-.input-wrapper,
-.input {
-  border-radius: var(--input-border-radius);
+/* Hover state */
+.wrapper:hover .input-inner-wrapper,
+.input:hover {
+  border-color: var(--color-neutral-darkest);
+}
+
+/* Focus state */
+.wrapper.has-focus .input-inner-wrapper,
+.input:focus {
+  border-color: var(--color-neutral-darkest);
+  box-shadow: 0 0 0 1px var(--color-neutral-darkest);
+}
+
+/* Active state */
+.wrapper:active .input-inner-wrapper,
+.input:active {
+  border-color: var(--color-neutral-darkest);
+  box-shadow: inset 0 1px 3px 0 rgba(130, 130, 140, 0.48);
+  z-index: 1;
+}
+
+/* Disabled and Read-only state */
+.wrapper.is-disabled .input-inner-wrapper,
+.wrapper.is-read-only .input-inner-wrapper,
+.input:disabled,
+.input:read-only {
+  background-color: var(--color-neutral);
+  border-color: var(--color-neutral);
+  box-shadow: none;
+}
+
+/*
+  Inverse styling
+*/
+
+.wrapper.is-inverse .input-inner-wrapper,
+.input.is-inverse {
+  background: var(--color-teal);
+  border-color: var(--color-teal);
+}
+
+/* Hover state */
+.wrapper.is-inverse:hover .input-inner-wrapper,
+.input.is-inverse:hover {
+  border-color: var(--color-teal-light);
+}
+
+/* Focus state */
+.wrapper.is-inverse.has-focus .input-inner-wrapper,
+.input.is-inverse:focus {
+  border-color: var(--color-teal-light);
+  box-shadow: 0 0 0 1px var(--color-teal-light);
+}
+
+/* Active state */
+.wrapper.is-inverse:active .input-inner-wrapper,
+.input.is-inverse:active {
+  border-color: var(--color-teal-light);
+  box-shadow: inset 0 1px 3px 0 color(var(--color-teal-darkest) a(0.48));
+}
+
+/* Disabled and Read-only state */
+.wrapper.is-inverse.is-disabled .input-inner-wrapper,
+.wrapper.is-inverse.is-read-only .input-inner-wrapper,
+.input.is-inverse:disabled,
+.input.is-inverse:read-only {
+  background-color: var(--color-teal-dark);
+  border-color: var(--color-teal-dark);
+  box-shadow: none;
 }
 
 .input-wrapper {
@@ -234,6 +160,12 @@
 .input {
   box-sizing: border-box;
 
+  color: var(--color-teal-darkest);
+
+  &::placeholder {
+    color: var(--color-neutral-darkest);
+  }
+
   height: var(--input-height-medium);
   width: 100%;
   padding: 0 var(--input-horizontal-padding);
@@ -249,6 +181,22 @@
   &[type='number']::-webkit-inner-spin-button {
     -webkit-appearance: none;
     margin: 0;
+  }
+
+  &.is-inverse {
+    color: var(--color-neutral-lightest);
+
+    &::placeholder {
+      color: var(--color-teal-light);
+    }
+  }
+
+  &:disabled {
+    color: var(--color-teal);
+
+    &::placeholder {
+      color: var(--color-teal);
+    }
   }
 
   &:focus {

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -139,7 +139,6 @@
 
 .input {
   width: 100%;
-  z-index: 1;
   border: 1px solid var(--color-neutral-dark);
   background-color: var(--color-white);
   color: var(--color-teal-darkest);

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -201,6 +201,7 @@
   }
 }
 
+/* Remove all default input styling, when wrapped with prefix and/or suffix */
 .wrapper .input-wrapper .input-inner-wrapper .input {
   border: 0;
   border-radius: 0;

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -386,7 +386,7 @@
 }
 
 .is-large {
-  .input {
+  &.input {
     height: var(--input-height-large);
     font-size: var(--input-text-size-large);
   }
@@ -398,7 +398,7 @@
 }
 
 .is-small {
-  .input,
+  &.input,
   .spinner {
     height: var(--input-height-small);
   }

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -216,7 +216,6 @@
 .input-wrapper,
 .input {
   border-radius: var(--input-border-radius);
-  background: transparent;
 }
 
 .input-wrapper {
@@ -254,6 +253,7 @@
   border: 0;
   border-radius: 0;
   box-shadow: none;
+  background: transparent;
 }
 
 .input,

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -140,49 +140,42 @@
 .input {
   width: 100%;
   z-index: 1;
+  border: 1px solid var(--color-neutral-dark);
+  background-color: var(--color-white);
+  color: var(--color-teal-darkest);
 
-  &:not(.is-inverse) {
-    background: var(--color-white);
-    border: 1px solid var(--color-neutral-dark);
+  &::placeholder {
+    color: var(--color-neutral-darkest);
+  }
 
-    color: var(--color-teal-darkest);
+  &:hover {
+    border-color: var(--color-neutral-darkest);
+  }
 
-    &::placeholder {
-      color: var(--color-neutral-darkest);
-    }
+  &:focus {
+    border-color: var(--color-neutral-darkest);
+    box-shadow: 0 0 0 1px var(--color-neutral-darkest);
+  }
 
-    &:not(:disabled):not(:read-only) {
-      &:hover {
-        border-color: var(--color-neutral-darkest);
-      }
+  &:active {
+    border-color: var(--color-neutral-darkest);
+    box-shadow: inset 0 1px 3px 0 rgba(130, 130, 140, 0.48);
+  }
 
-      &:focus {
-        border-color: var(--color-neutral-darkest);
-        box-shadow: 0 0 0 1px var(--color-neutral-darkest);
-      }
+  &:disabled {
+    color: var(--color-neutral-darkest);
+  }
 
-      &:active {
-        border-color: var(--color-neutral-darkest);
-        box-shadow: inset 0 1px 3px 0 rgba(130, 130, 140, 0.48);
-      }
-    }
-
-    &:disabled {
-      background-color: var(--color-neutral);
-      border-color: var(--color-neutral);
-
-      color: var(--color-neutral-darkest);
-    }
-
-    &:read-only {
-      background-color: var(--color-neutral);
-      border-color: var(--color-neutral);
-    }
+  &:disabled,
+  &:read-only {
+    background-color: var(--color-neutral);
+    border-color: var(--color-neutral);
+    box-shadow: none;
   }
 
   &.is-inverse {
-    background: var(--color-teal);
-    border: 1px solid var(--color-teal);
+    background-color: var(--color-teal);
+    border-color: var(--color-teal);
 
     color: var(--color-neutral-lightest);
 
@@ -190,26 +183,21 @@
       color: var(--color-teal-light);
     }
 
-    &:not(:disabled):not(:read-only) {
-      &:hover {
-        border-color: var(--color-teal-light);
-      }
+    &:hover {
+      border-color: var(--color-teal-light);
+    }
 
-      &:focus {
-        border-color: var(--color-teal-light);
-        box-shadow: 0 0 0 1px var(--color-teal-light);
-      }
+    &:focus {
+      border-color: var(--color-teal-light);
+      box-shadow: 0 0 0 1px var(--color-teal-light);
+    }
 
-      &:active {
-        border-color: var(--color-teal-light);
-        box-shadow: inset 0 1px 3px 0 color(var(--color-teal-darkest) a(0.48));
-      }
+    &:active {
+      border-color: var(--color-teal-light);
+      box-shadow: inset 0 1px 3px 0 color(var(--color-teal-darkest) a(0.48));
     }
 
     &:disabled {
-      background-color: var(--color-teal-dark);
-      border-color: var(--color-teal-dark);
-
       color: var(--color-teal);
 
       &::placeholder {
@@ -217,6 +205,7 @@
       }
     }
 
+    &:disabled,
     &:read-only {
       background-color: var(--color-teal-dark);
       border-color: var(--color-teal-dark);
@@ -261,10 +250,10 @@
   align-items: center;
 }
 
-.wrapper .input {
-  border: 0 !important;
-  border-radius: 0 !important;
-  box-shadow: none !important;
+.wrapper .input-wrapper .input-inner-wrapper .input {
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .input,

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -340,8 +340,8 @@
   &:not(.is-inverse) {
     &:not(.has-focus) .input-inner-wrapper,
     &.input {
-      border-color: var(--input-error-border) !important;
-      box-shadow: 0 0 0 1px var(--input-error-border) !important;
+      border-color: var(--input-error-border);
+      box-shadow: 0 0 0 1px var(--input-error-border);
       z-index: 2;
     }
 
@@ -353,8 +353,8 @@
   &.is-inverse {
     &:not(.has-focus) .input-inner-wrapper,
     &.input {
-      border-color: var(--input-error-border-inverse) !important;
-      box-shadow: 0 0 0 1px var(--input-error-border-inverse) !important;
+      border-color: var(--input-error-border-inverse);
+      box-shadow: 0 0 0 1px var(--input-error-border-inverse);
       z-index: 2;
     }
 

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -62,7 +62,7 @@
   &.is-inverse {
     .input-inner-wrapper {
       background: var(--color-teal);
-      border: 1px solid var(--color-teal);
+      border-color: var(--color-teal);
     }
 
     .input {

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -36,14 +36,6 @@
       border: 1px solid var(--color-neutral-dark);
     }
 
-    .input {
-      color: var(--color-teal-darkest);
-
-      &::placeholder {
-        color: var(--color-neutral-darkest);
-      }
-    }
-
     &:not(.is-disabled):not(.is-read-only) {
       &:hover {
         .input-inner-wrapper {
@@ -145,8 +137,100 @@
   }
 }
 
-.input-wrapper {
+.input {
+  width: 100%;
+  z-index: 1;
+
+  &:not(.is-inverse) {
+    background: var(--color-white);
+    border: 1px solid var(--color-neutral-dark);
+
+    color: var(--color-teal-darkest);
+
+    &::placeholder {
+      color: var(--color-neutral-darkest);
+    }
+
+    &:not(:disabled):not(:read-only) {
+      &:hover {
+        border-color: var(--color-neutral-darkest);
+      }
+
+      &:focus {
+        border-color: var(--color-neutral-darkest);
+        box-shadow: 0 0 0 1px var(--color-neutral-darkest);
+      }
+
+      &:active {
+        border-color: var(--color-neutral-darkest);
+        box-shadow: inset 0 1px 3px 0 rgba(130, 130, 140, 0.48);
+      }
+    }
+
+    &:disabled {
+      background-color: var(--color-neutral);
+      border-color: var(--color-neutral);
+
+      color: var(--color-neutral-darkest);
+    }
+
+    &:read-only {
+      background-color: var(--color-neutral);
+      border-color: var(--color-neutral);
+    }
+  }
+
+  &.is-inverse {
+    background: var(--color-teal);
+    border: 1px solid var(--color-teal);
+
+    color: var(--color-neutral-lightest);
+
+    &::placeholder {
+      color: var(--color-teal-light);
+    }
+
+    &:not(:disabled):not(:read-only) {
+      &:hover {
+        border-color: var(--color-teal-light);
+      }
+
+      &:focus {
+        border-color: var(--color-teal-light);
+        box-shadow: 0 0 0 1px var(--color-teal-light);
+      }
+
+      &:active {
+        border-color: var(--color-teal-light);
+        box-shadow: inset 0 1px 3px 0 color(var(--color-teal-darkest) a(0.48));
+      }
+    }
+
+    &:disabled {
+      background-color: var(--color-teal-dark);
+      border-color: var(--color-teal-dark);
+
+      color: var(--color-teal);
+
+      &::placeholder {
+        color: var(--color-teal);
+      }
+    }
+
+    &:read-only {
+      background-color: var(--color-teal-dark);
+      border-color: var(--color-teal-dark);
+    }
+  }
+}
+
+.input-wrapper,
+.input {
   border-radius: var(--input-border-radius);
+  background: transparent;
+}
+
+.input-wrapper {
   display: flex;
 
   > * {
@@ -164,13 +248,23 @@
   }
 }
 
-.input-inner-wrapper {
+.input-inner-wrapper,
+.input {
   transition: 0.3s ease-in-out border, 0.3s ease-in-out box-shadow;
-  align-items: center;
-  display: flex;
   flex: 1;
   overflow: hidden;
   position: relative;
+}
+
+.input-inner-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.wrapper .input {
+  border: 0 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
 }
 
 .input,
@@ -182,17 +276,11 @@
 }
 
 .input {
-  position: relative;
   box-sizing: border-box;
 
   height: var(--input-height-medium);
   width: 100%;
   padding: 0 var(--input-horizontal-padding);
-
-  background: transparent;
-  border: 0;
-  border-radius: 0;
-  box-shadow: 0;
 
   font-size: var(--input-text-size);
   font-family: var(--font-family-regular);
@@ -220,6 +308,8 @@
 .suffix-wrapper {
   align-items: center;
   display: flex;
+
+  height: 100%;
 
   > * {
     white-space: nowrap;
@@ -336,7 +426,8 @@
 
 .has-error {
   &:not(.is-inverse) {
-    &:not(.has-focus) .input-inner-wrapper {
+    &:not(.has-focus) .input-inner-wrapper,
+    &.input {
       border-color: var(--input-error-border) !important;
       box-shadow: 0 0 0 1px var(--input-error-border) !important;
       z-index: 2;
@@ -348,7 +439,8 @@
   }
 
   &.is-inverse {
-    &:not(.has-focus) .input-inner-wrapper {
+    &:not(.has-focus) .input-inner-wrapper,
+    &.input {
       border-color: var(--input-error-border-inverse) !important;
       box-shadow: 0 0 0 1px var(--input-error-border-inverse) !important;
       z-index: 2;

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -26,10 +26,6 @@
 .wrapper {
   width: 100%;
 
-  &.has-focus .input-inner-wrapper {
-    z-index: 1;
-  }
-
   .input-inner-wrapper {
     background: var(--color-white);
     border: 1px solid var(--color-neutral-dark);
@@ -47,6 +43,7 @@
   &:active .input-inner-wrapper {
     border-color: var(--color-neutral-darkest);
     box-shadow: inset 0 1px 3px 0 rgba(130, 130, 140, 0.48);
+    z-index: 1;
   }
 
   &.is-disabled input {

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -185,18 +185,22 @@
     &::placeholder {
       color: var(--color-teal-light);
     }
-  }
 
-  &:disabled {
-    color: var(--color-teal);
-
-    &::placeholder {
+    &:disabled {
       color: var(--color-teal);
+
+      &::placeholder {
+        color: var(--color-teal);
+      }
     }
   }
 
   &:focus {
     outline: none;
+  }
+
+  &:disabled {
+    color: var(--color-neutral-darkest);
   }
 
   &.is-bold {

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -47,6 +47,10 @@
 }
 
 /* Focus state */
+.wrapper.has-focus .input-inner-wrapper {
+  z-index: 1;
+}
+
 .wrapper.has-focus .input-inner-wrapper,
 .input:focus {
   border-color: var(--color-neutral-darkest);
@@ -58,7 +62,6 @@
 .input:active {
   border-color: var(--color-neutral-darkest);
   box-shadow: inset 0 1px 3px 0 rgba(130, 130, 140, 0.48);
-  z-index: 1;
 }
 
 /* Disabled and Read-only state */

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -142,13 +142,6 @@
   align-items: center;
 }
 
-.wrapper .input-wrapper .input-inner-wrapper .input {
-  border: 0;
-  border-radius: 0;
-  box-shadow: none;
-  background: transparent;
-}
-
 .input,
 .input::placeholder {
   -moz-osx-font-smoothing: grayscale;
@@ -206,6 +199,13 @@
   &.is-bold {
     font-family: var(--font-family-medium);
   }
+}
+
+.wrapper .input-wrapper .input-inner-wrapper .input {
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  background: transparent;
 }
 
 .prefix-wrapper,

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -30,50 +30,35 @@
     z-index: 1;
   }
 
-  &:not(.is-inverse) {
+  .input-inner-wrapper {
+    background: var(--color-white);
+    border: 1px solid var(--color-neutral-dark);
+  }
+
+  &:hover .input-inner-wrapper {
+    border-color: var(--color-neutral-darkest);
+  }
+
+  &.has-focus .input-inner-wrapper {
+    border-color: var(--color-neutral-darkest);
+    box-shadow: 0 0 0 1px var(--color-neutral-darkest);
+  }
+
+  &:active .input-inner-wrapper {
+    border-color: var(--color-neutral-darkest);
+    box-shadow: inset 0 1px 3px 0 rgba(130, 130, 140, 0.48);
+  }
+
+  &.is-disabled input {
+    color: var(--color-neutral-darkest);
+  }
+
+  &.is-read-only,
+  &.is-disabled {
     .input-inner-wrapper {
-      background: var(--color-white);
-      border: 1px solid var(--color-neutral-dark);
-    }
-
-    &:not(.is-disabled):not(.is-read-only) {
-      &:hover {
-        .input-inner-wrapper {
-          border-color: var(--color-neutral-darkest);
-        }
-      }
-
-      &.has-focus {
-        .input-inner-wrapper {
-          border-color: var(--color-neutral-darkest);
-          box-shadow: 0 0 0 1px var(--color-neutral-darkest);
-        }
-      }
-
-      &:active {
-        .input-inner-wrapper {
-          border-color: var(--color-neutral-darkest);
-          box-shadow: inset 0 1px 3px 0 rgba(130, 130, 140, 0.48);
-        }
-      }
-    }
-
-    &.is-disabled {
-      .input-inner-wrapper {
-        background-color: var(--color-neutral);
-        border-color: var(--color-neutral);
-      }
-
-      .input {
-        color: var(--color-neutral-darkest);
-      }
-    }
-
-    &.is-read-only {
-      .input-inner-wrapper {
-        background-color: var(--color-neutral);
-        border-color: var(--color-neutral);
-      }
+      background-color: var(--color-neutral);
+      border-color: var(--color-neutral);
+      box-shadow: none;
     }
   }
 
@@ -91,44 +76,30 @@
       }
     }
 
-    &:not(.is-disabled):not(.is-read-only) {
-      &:hover {
-        .input-inner-wrapper {
-          border-color: var(--color-teal-light);
-        }
-      }
-
-      &.has-focus {
-        .input-inner-wrapper {
-          border-color: var(--color-teal-light);
-          box-shadow: 0 0 0 1px var(--color-teal-light);
-        }
-      }
-
-      &:active {
-        .input-inner-wrapper {
-          border-color: var(--color-teal-light);
-          box-shadow: inset 0 1px 3px 0 color(var(--color-teal-darkest) a(0.48));
-        }
-      }
+    &:hover .input-inner-wrapper {
+      border-color: var(--color-teal-light);
     }
 
-    &.is-disabled {
-      .input-inner-wrapper {
-        background-color: var(--color-teal-dark);
-        border-color: var(--color-teal-dark);
-      }
+    &.has-focus .input-inner-wrapper {
+      border-color: var(--color-teal-light);
+      box-shadow: 0 0 0 1px var(--color-teal-light);
+    }
 
-      .input {
+    &:active .input-inner-wrapper {
+      border-color: var(--color-teal-light);
+      box-shadow: inset 0 1px 3px 0 color(var(--color-teal-darkest) a(0.48));
+    }
+
+    &.is-disabled .input {
+      color: var(--color-teal);
+
+      &::placeholder {
         color: var(--color-teal);
-
-        &::placeholder {
-          color: var(--color-teal);
-        }
       }
     }
 
-    &.is-read-only {
+    &.is-read-only,
+    &.is-disabled {
       .input-inner-wrapper {
         background-color: var(--color-teal-dark);
         border-color: var(--color-teal-dark);

--- a/stories/input.js
+++ b/stories/input.js
@@ -19,11 +19,10 @@ import {
 import { IconCalendarSmallOutline, IconInfoBadgedSmallFilled } from '@teamleader/ui-icons';
 
 const colors = ['aqua', 'gold', 'mint', 'neutral', 'ruby', 'teal', 'violet'];
-const elements = [null, 'input', 'textarea'];
-const sizes = [null, 'small', 'medium', 'large'];
+const elements = ['input', 'textarea'];
+const sizes = ['small', 'medium', 'large'];
 const tints = ['lightest', 'light', 'normal', 'dark', 'darkest'];
 const types = [
-  null,
   'text',
   'button',
   'checkbox',
@@ -70,11 +69,11 @@ storiesOf('Inputs', module)
     <InputBase
       bold={boolean('bold', false)}
       disabled={boolean('disabled', false)}
-      element={select('element', elements) || undefined}
+      element={select('element', elements)}
       inverse={boolean('inverse', false)}
       readOnly={boolean('readOnly', false)}
-      size={select('size', sizes) || undefined}
-      type={select('type', types) || undefined}
+      size={select('size', sizes)}
+      type={select('type', types)}
       value={text('value', undefined)}
     />
   ))

--- a/stories/input.js
+++ b/stories/input.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { boolean, number, select } from '@storybook/addon-knobs/react';
+import { boolean, number, select, text } from '@storybook/addon-knobs/react';
 import {
   InputBase,
   Button,
@@ -19,8 +19,34 @@ import {
 import { IconCalendarSmallOutline, IconInfoBadgedSmallFilled } from '@teamleader/ui-icons';
 
 const colors = ['aqua', 'gold', 'mint', 'neutral', 'ruby', 'teal', 'violet'];
-const sizes = ['small', 'medium', 'large'];
+const elements = [null, 'input', 'textarea'];
+const sizes = [null, 'small', 'medium', 'large'];
 const tints = ['lightest', 'light', 'normal', 'dark', 'darkest'];
+const types = [
+  null,
+  'text',
+  'button',
+  'checkbox',
+  'color',
+  'date',
+  'datetime-local',
+  'email',
+  'file',
+  'hidden',
+  'image',
+  'month',
+  'number',
+  'password',
+  'radio',
+  'range',
+  'reset',
+  'search',
+  'submit',
+  'tel',
+  'time',
+  'url',
+  'week',
+];
 
 const prefix = [
   <Icon color="neutral" tint="darkest">
@@ -31,6 +57,13 @@ const prefix = [
 
 const suffix = [<TextSmall color="neutral">incl. BTW</TextSmall>, <Counter count={99} />, <LoadingSpinner />];
 
+const connectedLeft = <Button label="€" />;
+const connectedRight = (
+  <Button>
+    <Checkbox size="small">Discount</Checkbox>
+  </Button>
+);
+
 const props = {
   helpText: 'This is the fields help text',
   placeholder: 'Placeholder',
@@ -40,8 +73,43 @@ const props = {
 const TooltippedIcon = Tooltip(Icon);
 
 storiesOf('Inputs', module)
-  .add('Input base', () => <InputBase />)
-  .add('Single line input base', () => <SingleLineInputBase />)
+  .add('Input base', () => (
+    <InputBase
+      bold={boolean('bold', false)}
+      disabled={boolean('disabled', false)}
+      element={select('element', elements) || undefined}
+      inverse={boolean('inverse', false)}
+      readOnly={boolean('readOnly', false)}
+      size={select('size', sizes) || undefined}
+      type={select('type', types) || undefined}
+      value={text('value', undefined)}
+    />
+  ))
+  .add('Single line input base', () => {
+    const hasPrefix = boolean('render a prefix', false);
+    const hasSuffix = boolean('render a suffix', false);
+    const hasConnectedLeft = boolean('render a connectedLeft', false);
+    const hasConnectedRight = boolean('render a connectedRight', false);
+
+    return (
+      <SingleLineInputBase
+        bold={boolean('bold', false)}
+        disabled={boolean('disabled', false)}
+        element={select('element', elements) || undefined}
+        error={text('error', undefined)}
+        helpText={text('helpText', undefined)}
+        inverse={boolean('inverse', false)}
+        readOnly={boolean('readOnly', false)}
+        size={select('size', sizes) || undefined}
+        type={select('type', types) || undefined}
+        value={text('value', undefined)}
+        prefix={hasPrefix ? prefix : undefined}
+        suffix={hasSuffix ? suffix : undefined}
+        connectedLeft={hasConnectedLeft ? connectedLeft : undefined}
+        connectedRight={hasConnectedRight ? connectedRight : undefined}
+      />
+    );
+  })
   .add('Input only', () => (
     <Input
       id="input1"

--- a/stories/input.js
+++ b/stories/input.js
@@ -14,6 +14,7 @@ import {
   TextBody,
   TextSmall,
   Tooltip,
+  SingleLineInputBase,
 } from '../components';
 import { IconCalendarSmallOutline, IconInfoBadgedSmallFilled } from '@teamleader/ui-icons';
 
@@ -40,6 +41,7 @@ const TooltippedIcon = Tooltip(Icon);
 
 storiesOf('Inputs', module)
   .add('Input base', () => <InputBase />)
+  .add('Single line input base', () => <SingleLineInputBase />)
   .add('Input only', () => (
     <Input
       id="input1"

--- a/stories/input.js
+++ b/stories/input.js
@@ -14,8 +14,8 @@ import {
   TextBody,
   TextSmall,
   Tooltip,
-  SingleLineInputBase,
 } from '../components';
+
 import { IconCalendarSmallOutline, IconInfoBadgedSmallFilled } from '@teamleader/ui-icons';
 
 const colors = ['aqua', 'gold', 'mint', 'neutral', 'ruby', 'teal', 'violet'];
@@ -57,13 +57,6 @@ const prefix = [
 
 const suffix = [<TextSmall color="neutral">incl. BTW</TextSmall>, <Counter count={99} />, <LoadingSpinner />];
 
-const connectedLeft = <Button label="€" />;
-const connectedRight = (
-  <Button>
-    <Checkbox size="small">Discount</Checkbox>
-  </Button>
-);
-
 const props = {
   helpText: 'This is the fields help text',
   placeholder: 'Placeholder',
@@ -85,31 +78,6 @@ storiesOf('Inputs', module)
       value={text('value', undefined)}
     />
   ))
-  .add('Single line input base', () => {
-    const hasPrefix = boolean('render a prefix', false);
-    const hasSuffix = boolean('render a suffix', false);
-    const hasConnectedLeft = boolean('render a connectedLeft', false);
-    const hasConnectedRight = boolean('render a connectedRight', false);
-
-    return (
-      <SingleLineInputBase
-        bold={boolean('bold', false)}
-        disabled={boolean('disabled', false)}
-        element={select('element', elements) || undefined}
-        error={text('error', undefined)}
-        helpText={text('helpText', undefined)}
-        inverse={boolean('inverse', false)}
-        readOnly={boolean('readOnly', false)}
-        size={select('size', sizes) || undefined}
-        type={select('type', types) || undefined}
-        value={text('value', undefined)}
-        prefix={hasPrefix ? prefix : undefined}
-        suffix={hasSuffix ? suffix : undefined}
-        connectedLeft={hasConnectedLeft ? connectedLeft : undefined}
-        connectedRight={hasConnectedRight ? connectedRight : undefined}
-      />
-    );
-  })
   .add('Input only', () => (
     <Input
       id="input1"


### PR DESCRIPTION
### Description

In a [previous PR](https://github.com/teamleadercrm/ui/pull/411) we already split `InputBase` from `Input` in order to reduce complexity form the `Input` component and enhance compose-ability (on top of this `InputBase` both the `NumericInput` and `Input` are build).

In this PR we even take it a step further. 

The `InputBase` still has some code in there, which has no use to the [`TextArea`](https://github.com/teamleadercrm/ui/pull/427). For the later the `prefix`, `suffix`, `connectedLeft` and `connectedRight` are irrelevant.

So in this PR we similarly split the new `SingleLineInputBase` from the `InputBase`. The `SingleLineInputBase` is build on a now simplified `InputBase` and the `NumericInput` and `Input` both are build upon `SingleLineInputBase`. The responsibility of rendering those elements that are irrelevant to the `TextArea` now moves to the `SingleLineInputBase`.

This allows us to fairly easily create a `TextArea` on top of `InputBase`.

Nothing should've changed visually.

### Breaking changes

None.