### PR TITLE
Input: fix focus state when you have custom onFocus/onBlur event handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Input`: fixed the focus state that didn't work when you had custom `onFocus`/`onBlur` event handlers ([@lowiebenoot](https://github.com/lowiebenoot) in [#428](https://github.com/teamleadercrm/ui/pull/428))
+
 ## [0.17.0] - 2018-10-26
 
 ### Added

--- a/components/input/InputBase.js
+++ b/components/input/InputBase.js
@@ -18,12 +18,6 @@ class InputBase extends PureComponent {
     }
   };
 
-  handleChange = event => {
-    if (this.props.onChange) {
-      this.props.onChange(event);
-    }
-  };
-
   handleFocus = event => {
     this.setState({ inputHasFocus: true });
     if (this.props.onFocus) {
@@ -50,7 +44,6 @@ class InputBase extends PureComponent {
       'connectedRight',
       'helpText',
       'inverse',
-      'onChange',
       'prefix',
       'size',
       'suffix',
@@ -60,7 +53,6 @@ class InputBase extends PureComponent {
       className: classNames,
       ...restProps,
       onBlur: this.handleBlur,
-      onChange: this.handleChange,
       onFocus: this.handleFocus,
     };
 
@@ -140,8 +132,6 @@ InputBase.propTypes = {
   onBlur: PropTypes.func,
   /** Callback function that is fired when focusing the input field. */
   onFocus: PropTypes.func,
-  /** Callback function that is fired when the component's value changes. */
-  onChange: PropTypes.func,
   /** The text string/element to use as a prefix inside the input field */
   prefix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
   /** Boolean indicating whether the input should render as read only. */

--- a/components/input/InputBase.js
+++ b/components/input/InputBase.js
@@ -58,10 +58,10 @@ class InputBase extends PureComponent {
 
     const props = {
       className: classNames,
+      ...restProps,
       onBlur: this.handleBlur,
       onChange: this.handleChange,
       onFocus: this.handleFocus,
-      ...restProps,
     };
 
     return <input {...props} />;


### PR DESCRIPTION
### Description

When we provide our own onFocus/onBlur/onChange handlers, the internal ones would not be called anymore, as they get overwritten. This resulted in not having the focus state anymore when having custom onFocus/onBlur handlers (which is the case when you use `redux-form`).

* fixed the focus state that didn't work when you had custom `onFocus`/`onBlur` event handlers
* removed a useless `onChange` handler
