### PR TITLE
[TU-194] NumericInput: Fix change via spinner 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - `Input`: fixed the focus state that didn't work when you had custom `onFocus`/`onBlur` event handlers ([@lowiebenoot](https://github.com/lowiebenoot) in [#428](https://github.com/teamleadercrm/ui/pull/428))
+- `NumericInput`: fixed calling the onChange handler in the `NumericInput` component, which was not called when using the spinner controls ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#430](https://github.com/teamleadercrm/ui/pull/430))
 - `Button`: fixed the faulty border style of our primary & secondary button when disabled ([@driesd](https://github.com/driesd) in [#424](https://github.com/teamleadercrm/ui/pull/424))
 
 ## [0.17.0] - 2018-10-26

--- a/components/input/NumericInput.js
+++ b/components/input/NumericInput.js
@@ -49,13 +49,14 @@ class NumericInput extends PureComponent {
   };
 
   updateStep = n => {
-    const { step } = this.props;
+    const { onChange, step } = this.props;
 
     const currentValue = this.toNumber(this.state.value || 0);
     const newValue = this.parseValue(currentValue + step * n);
 
     if (newValue !== currentValue) {
       this.setState({ value: newValue });
+      onChange && onChange(null, newValue);
     }
   };
 


### PR DESCRIPTION
### Description

The `onChange` handler was not called when using the spinner controls, this caused the input to not update its value when wrapping it in for example redux forms.

This PR fixes this by calling the passed down `onChange` handler by calling it with as the first argument `null`, as normally this'd be the inputs `onChange` event to which we don't have access.

Nothing changed visually.

### Breaking changes

None.