### PR TITLE
[TU-196] NumericInput: Spinner buttons submit forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - `Input`: fixed the focus state that didn't work when you had custom `onFocus`/`onBlur` event handlers ([@lowiebenoot](https://github.com/lowiebenoot) in [#428](https://github.com/teamleadercrm/ui/pull/428))
 - `NumericInput`: fixed calling the onChange handler in the `NumericInput` component, which was not called when using the spinner controls ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#430](https://github.com/teamleadercrm/ui/pull/430))
+- `NumericInput`: fixed the undesired behaviour of automatically submitting the form when using the spinner controls in the `NumericInput` component, by setting their `type` attribute ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#431](https://github.com/teamleadercrm/ui/pull/431))
 - `Button`: fixed the faulty border style of our primary & secondary button when disabled ([@driesd](https://github.com/driesd) in [#424](https://github.com/teamleadercrm/ui/pull/424))
 
 ## [0.17.0] - 2018-10-26

--- a/components/input/NumericInput.js
+++ b/components/input/NumericInput.js
@@ -12,6 +12,7 @@ class SpinnerControls extends PureComponent {
       color: inverse ? 'teal' : 'neutral',
       element: 'button',
       tint: inverse ? 'lightest' : 'darkest',
+      type: 'button',
     };
 
     return (


### PR DESCRIPTION
### Description

Currently the buttons in the `NumericInput`s spinner controls don't have a type defined. This has as a result that when used in a form, they will automatically submit it.

This sets PR fixes this, by setting the `type` attribute of the buttons to `'button'`.

Nothing changed visually.

### Breaking changes

None.
