### PR TITLE
[TU-152] Button (link): background color update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Button`: changed the background colors, of the active and hover states of the `Button` with the `type` property set to `'link'` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#436](https://github.com/teamleadercrm/ui/pull/436))
+
 ### Deprecated
 
 ### Removed

--- a/components/button/theme.css
+++ b/components/button/theme.css
@@ -396,16 +396,13 @@
     color: var(--color-teal-lightest);
 
     &:not(.is-disabled) {
-      &:hover {
-        background-color: var(--color-teal);
-      }
-
       &:focus {
         box-shadow: 0 0 0 2px var(--color-teal);
       }
 
+      &:hover,
       &:active {
-        background-color: color(var(--color-teal-lightest) a(0.24));
+        background-color: var(--color-teal);
       }
     }
 

--- a/components/button/theme.css
+++ b/components/button/theme.css
@@ -374,16 +374,13 @@
     color: var(--color-aqua-dark);
 
     &:not(.is-disabled) {
-      &:hover {
-        background-color: var(--color-neutral-light);
-      }
-
       &:focus {
         box-shadow: 0 0 0 2px var(--color-aqua-light);
       }
 
+      &:hover,
       &:active {
-        background-color: var(--color-neutral-light);
+        background-color: color(var(--color-neutral) a(0.48));
       }
     }
 
@@ -402,7 +399,7 @@
 
       &:hover,
       &:active {
-        background-color: var(--color-teal);
+        background-color: color(var(--color-teal) a(0.48));
       }
     }
 


### PR DESCRIPTION
### Description

The `Button` where the `level` prop is set to `'link'`, gets a background color in its active and hover states. 

This color was opaque. Due to that, it seemed like this button type did not have  hover state (when inverse) when placed on a background of the same color, certainly as the button does not have a border.

In this PR this is fixed by changing the background colors in those states, to a darker/lighter color that are transparent.

You'll notice the new colors are visually not entirely the same as the old ones, as from design we also wanted to tweak them a little bit, you can find the updated spec [here](https://zpl.io/V09xPRo).

#### Screenshot before this PR

![screenshot 2018-11-06 at 11 55 06](https://user-images.githubusercontent.com/23736202/48059970-d942cb00-e1ba-11e8-9a08-c1f0274de98a.png)
![screenshot 2018-11-06 at 11 56 00](https://user-images.githubusercontent.com/23736202/48060001-fbd4e400-e1ba-11e8-92d6-567d0a2f5b0e.png)

#### Screenshot after this PR

![screenshot 2018-11-06 at 11 54 59](https://user-images.githubusercontent.com/23736202/48059975-dcd65200-e1ba-11e8-9535-282d3351d416.png)
![screenshot 2018-11-06 at 11 56 12](https://user-images.githubusercontent.com/23736202/48060006-00010180-e1bb-11e8-9e80-0c6f72101ee6.png)

### Breaking changes

None.
