### PR TITLE
Link: blur after click

### DIFF
--- a/components/link/Link.js
+++ b/components/link/Link.js
@@ -37,6 +37,10 @@ Link.propTypes = {
   iconPlacement: PropTypes.oneOf(['left', 'right']),
   inherit: PropTypes.bool,
   element: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+  /** Callback function that is fired when mouse leaves the component. */
+  onMouseLeave: PropTypes.func,
+  /** Callback function that is fired when the mouse button is released. */
+  onMouseUp: PropTypes.func,
 };
 
 Link.defaultProps = {

--- a/components/link/Link.js
+++ b/components/link/Link.js
@@ -6,6 +6,26 @@ import theme from './theme.css';
 class Link extends PureComponent {
   linkNode = createRef();
 
+  blur() {
+    if (this.linkNode.current.blur) {
+      this.linkNode.current.blur();
+    }
+  }
+
+  handleMouseUp = event => {
+    const { onMouseUp } = this.props;
+
+    this.blur();
+    onMouseUp && onMouseUp(event);
+  };
+
+  handleMouseLeave = event => {
+    const { onMouseLeave } = this.props;
+
+    this.blur();
+    onMouseLeave && onMouseLeave(event);
+  };
+
   render() {
     const { children, className, icon, iconPlacement, element, inherit, ...others } = this.props;
 
@@ -21,7 +41,14 @@ class Link extends PureComponent {
     const Element = element;
 
     return (
-      <Element ref={this.linkNode} className={classNames} data-teamleader-ui="link" {...others}>
+      <Element
+        ref={this.linkNode}
+        className={classNames}
+        data-teamleader-ui="link"
+        onMouseUp={this.handleMouseUp}
+        onMouseLeave={this.handleMouseLeave}
+        {...others}
+      >
         {icon && iconPlacement === 'left' && icon}
         <ChildrenWrapper>{children}</ChildrenWrapper>
         {icon && iconPlacement === 'right' && icon}

--- a/components/link/Link.js
+++ b/components/link/Link.js
@@ -1,9 +1,11 @@
-import React, { Fragment, PureComponent } from 'react';
+import React, { createRef, Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import theme from './theme.css';
 
 class Link extends PureComponent {
+  linkNode = createRef();
+
   render() {
     const { children, className, icon, iconPlacement, element, inherit, ...others } = this.props;
 
@@ -19,7 +21,7 @@ class Link extends PureComponent {
     const Element = element;
 
     return (
-      <Element className={classNames} data-teamleader-ui="link" {...others}>
+      <Element ref={this.linkNode} className={classNames} data-teamleader-ui="link" {...others}>
         {icon && iconPlacement === 'left' && icon}
         <ChildrenWrapper>{children}</ChildrenWrapper>
         {icon && iconPlacement === 'right' && icon}


### PR DESCRIPTION
### Description

This PR makes sure that there is no visual focus indication after a `Link` was clicked.

#### Screenshot before this PR

Before the Link was clicked:

![schermafdruk 2018-11-06 13 34 12](https://user-images.githubusercontent.com/5336831/48064794-2b8ae880-e1c9-11e8-9486-e8bf2d7e04bd.png)

After the Link was clicked:

![schermafdruk 2018-11-06 13 26 08](https://user-images.githubusercontent.com/5336831/48064786-275ecb00-e1c9-11e8-9501-bac0e266a39f.png)

#### Screenshot after this PR

Before the Link was clicked:

![schermafdruk 2018-11-06 13 34 12](https://user-images.githubusercontent.com/5336831/48064794-2b8ae880-e1c9-11e8-9486-e8bf2d7e04bd.png)


After the Link was clicked:

![schermafdruk 2018-11-06 13 34 12](https://user-images.githubusercontent.com/5336831/48064794-2b8ae880-e1c9-11e8-9486-e8bf2d7e04bd.png)

### Breaking changes

None
