### PR TITLE
Toast: text color fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- `Toast`: fixed the faulty text color [introduced](https://github.com/teamleadercrm/ui/pull/429) by replacing the `soft` prop with `tint` on `Typography` components. ([@driesd](https://github.com/driesd) in [#438](https://github.com/teamleadercrm/ui/pull/438))
+
 ## [0.18.0] - 2018-11-06
 
 ### Added

--- a/components/toast/Toast.js
+++ b/components/toast/Toast.js
@@ -91,7 +91,7 @@ class Toast extends PureComponent {
       <div data-teamleader-ui="toast" onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
         <div className={classNames}>
           {processing && <LoadingSpinner className={theme['spinner']} color="neutral" tint="lightest" />}
-          <TextBody className={theme['label']} color="white">
+          <TextBody className={theme['label']} color="neutral" tint="lightest">
             {label}
             {children}
           </TextBody>


### PR DESCRIPTION
### Description

This PR fixes the text color of our `Toast` component. This was a bug [introduced](https://github.com/teamleadercrm/ui/pull/429) by replacing the `soft` prop with `tint` on `Typography` components.

#### Screenshot before this PR

![schermafdruk 2018-11-06 14 22 56](https://user-images.githubusercontent.com/5336831/48067022-7e679e80-e1cf-11e8-8a66-a7be6bcdbbc1.png)

#### Screenshot after this PR

![schermafdruk 2018-11-06 14 20 09](https://user-images.githubusercontent.com/5336831/48066903-1f098e80-e1cf-11e8-99eb-4ae58132a39c.png)

### Breaking changes

None.
