### PR TITLE
[TU-59] Toast: prevent the spinner from being squeezed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- `Toast`: fixed the squeezed spinner when containing multiline text ([@driesd](https://github.com/driesd) in [#439](https://github.com/teamleadercrm/ui/pull/439))
+
 ## [0.18.0] - 2018-11-06
 
 ### Added

--- a/components/toast/theme.css
+++ b/components/toast/theme.css
@@ -68,6 +68,7 @@
 }
 
 .spinner {
+  flex-shrink: 0;
   margin-right: var(--toast-spacing);
 }
 


### PR DESCRIPTION
### Description

This PR prevents the `spinner` from being `squeezed` when a `Toast` has `multiline text`.

#### Screenshot before this PR

![schermafdruk 2018-11-06 14 43 06](https://user-images.githubusercontent.com/5336831/48068187-72c9a700-e1d2-11e8-9de1-03051fef2d53.png)

#### Screenshot after this PR

![schermafdruk 2018-11-06 14 42 29](https://user-images.githubusercontent.com/5336831/48068190-7826f180-e1d2-11e8-982e-df58430a8866.png)

### Breaking changes

None.
