### PR TITLE
Maintenance: add 'constants' folder in gulpfile to be transpiled by babel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- `Gulpfile`: fixed the `babel` error by adding the `constants` folder to the `js` task. ([@driesd](https://github.com/driesd) in [#440](https://github.com/teamleadercrm/ui/pull/440))
 - `Toast`: fixed the squeezed spinner when containing multiline text ([@driesd](https://github.com/driesd) in [#439](https://github.com/teamleadercrm/ui/pull/439))
 - `Toast`: fixed the faulty text color [introduced](https://github.com/teamleadercrm/ui/pull/429) by replacing the `soft` prop with `tint` on `Typography` components. ([@driesd](https://github.com/driesd) in [#438](https://github.com/teamleadercrm/ui/pull/438))
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,7 @@ const postcss = require('gulp-postcss');
 
 gulp.task('js', function() {
   return gulp
-    .src(['./components/**/*.js'])
+    .src(['./components/**/*.js', './constants/**/*.js'])
     .pipe(babel())
     .pipe(gulp.dest('./lib'));
 });


### PR DESCRIPTION
### Description

This PR fixes the `babel` error when running `npm i`, by adding the `constants` folder to the `js` task in our `gulpfile`.

### Breaking changes

None.
