### PR TITLE
withTheme: Document change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `withTheme`: added the `withTheme` HOC ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#416](https://github.com/teamleadercrm/ui/pull/416))
+
 ### Changed
 
 - `Link`: inverted the hover & active underline styling when a Link is `inherit` and `contains an icon` ([@driesd](https://github.com/driesd) in [#435](https://github.com/teamleadercrm/ui/pull/435))


### PR DESCRIPTION
### Description

In [the PR](https://github.com/teamleadercrm/ui/pull/416) adding the `withTheme` HOC, I did not update the changelog.
I initially did this because the `withTheme` is for internal use only and does not really change anything for the users of the ui library.

But I've changed my mind, as I think its useful to also document such changes so we can trace them more easily. 
