### PR TITLE
[TU-101] Badge: prevent text wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- `Badge`: fixed the unwanted text wrapping ([@driesd](https://github.com/driesd) in [#446](https://github.com/teamleadercrm/ui/pull/446))
+
 ## [0.18.1] - 2018-11-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Fixed
 
-- `Badge`: fixed the unwanted text wrapping ([@driesd](https://github.com/driesd) in [#446](https://github.com/teamleadercrm/ui/pull/446))
+- `Badge`: a badge now no longer wraps text and overflow is prevented ([@driesd](https://github.com/driesd) in [#446](https://github.com/teamleadercrm/ui/pull/446))
 
 ## [0.18.1] - 2018-11-07
 

--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -18,6 +18,7 @@
   position: relative;
   text-decoration: none;
   transition: background-color var(--animation-duration) var(--animation-curve-fast-out-slow-in);
+  max-width: 100%;
 
   svg {
     -ms-transform: translateY(-1px);
@@ -33,6 +34,8 @@
   }
 
   .label {
+    overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
   }
 

--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -32,6 +32,10 @@
     opacity: 0.86;
   }
 
+  .label {
+    white-space: nowrap;
+  }
+
   &.neutral {
     &:not(.is-inverse) {
       background-color: color(var(--color-neutral-darkest) a(12%));


### PR DESCRIPTION
### Description

This PR prevents the text in our `Badge` component from wrapping.

#### Screenshot before this PR

![schermafdruk 2018-11-08 16 14 29](https://user-images.githubusercontent.com/5336831/48207946-0f767b00-e372-11e8-828c-f44cf553d30f.png)

#### Screenshot after this PR

![schermafdruk 2018-11-08 16 14 15](https://user-images.githubusercontent.com/5336831/48207972-169d8900-e372-11e8-9640-db9d8b65e4e0.png)

### Breaking changes

None.
