### PR TITLE
[TU-161] NumericInput: disable spinner controls on min/max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- `NumericInput`: the respective spinner controls render as disabled, when the minimum or maximum value of the input has been reached. ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#447](https://github.com/teamleadercrm/ui/pull/447))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -7,7 +7,7 @@ import theme from './theme.css';
 
 class SpinnerControls extends PureComponent {
   render() {
-    const { inverse, handleOnSpinnerUpClick, handleOnSpinnerDownClick } = this.props;
+    const { inverse, spinnerUpProps, spinnerDownProps } = this.props;
     const iconProps = {
       color: inverse ? 'teal' : 'neutral',
       element: 'button',
@@ -17,10 +17,10 @@ class SpinnerControls extends PureComponent {
 
     return (
       <div className={theme['spinner']}>
-        <Icon className={theme['spinner-up']} onClick={handleOnSpinnerUpClick} {...iconProps}>
+        <Icon className={theme['spinner-up']} {...spinnerUpProps} {...iconProps}>
           <IconChevronUpSmallOutline />
         </Icon>
-        <Icon className={theme['spinner-down']} onClick={handleOnSpinnerDownClick} {...iconProps}>
+        <Icon className={theme['spinner-down']} {...spinnerDownProps} {...iconProps}>
           <IconChevronDownSmallOutline />
         </Icon>
       </div>
@@ -88,8 +88,14 @@ class NumericInput extends PureComponent {
     ...this.props.suffix,
     <SpinnerControls
       inverse={this.props.inverse}
-      handleOnSpinnerUpClick={this.handleIncreaseValue}
-      handleOnSpinnerDownClick={this.handleDecreaseValue}
+      spinnerUpProps={{
+        onClick: this.handleIncreaseValue,
+        disabled: false,
+      }}
+      spinnerDownProps={{
+        onClick: this.handleDecreaseValue,
+        disabled: false,
+      }}
     />,
   ];
 

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -84,17 +84,20 @@ class NumericInput extends PureComponent {
     this.updateStep(-1);
   };
 
+  isMaxReached = () => this.state.value >= this.props.max;
+  isMinReached = () => this.state.value <= this.props.min;
+
   getSuffixWithSpinner = () => [
     ...this.props.suffix,
     <SpinnerControls
       inverse={this.props.inverse}
       spinnerUpProps={{
         onClick: this.handleIncreaseValue,
-        disabled: false,
+        disabled: this.isMaxReached(),
       }}
       spinnerDownProps={{
         onClick: this.handleDecreaseValue,
-        disabled: false,
+        disabled: this.isMinReached(),
       }}
     />,
   ];

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -275,6 +275,11 @@
   &:focus {
     outline: none;
   }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.24;
+  }
 }
 
 .error {


### PR DESCRIPTION
### Description

In this PR we render respective spinner of the [`NumericInput`](https://components.teamleader.design/?selectedKind=Inputs&selectedStory=Numeric&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs&background=%23ffffff) as disabled, when the minimum or maximum value has been reached.

#### Screenshot before this PR

![screenshot 2018-11-08 at 16 31 17](https://user-images.githubusercontent.com/23736202/48208749-ccb5a280-e373-11e8-9700-a1e60bbf7670.png)

#### Screenshot after this PR

![screenshot 2018-11-08 at 16 30 49](https://user-images.githubusercontent.com/23736202/48208763-d3dcb080-e373-11e8-958a-e27dcd7a0143.png)

### Breaking changes

None.
