### PR TITLE
[TU-208] Add size constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Added
 
 - `withTheme`: added the `withTheme` HOC ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#416](https://github.com/teamleadercrm/ui/pull/416))
-- `sizes`: added general constants and a helper function to retrieve the library wide sizes ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#443](https://github.com/teamleadercrm/ui/pull/443))
+- `sizes`: added general constants and a helper function to retrieve the library wide sizes ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#448](https://github.com/teamleadercrm/ui/pull/448))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - `withTheme`: added the `withTheme` HOC ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#416](https://github.com/teamleadercrm/ui/pull/416))
+- `sizes`: added general constants and a helper function to retrieve the library wide sizes ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#443](https://github.com/teamleadercrm/ui/pull/443))
 
 ### Changed
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,4 +1,17 @@
 import { COLOR, COLORS, TINTS, colorsWithout, tintsWithout } from './colors';
-import { SIZES, sizesWithout, TINY, SMALL, MEDIUM, LARGE } from './sizes';
+import { SIZES, sizesWithout, TINY, SMALL, MEDIUM, LARGE, FULLSCREEN } from './sizes';
 
-export { COLOR, COLORS, TINTS, colorsWithout, tintsWithout, SIZES, sizesWithout, TINY, SMALL, MEDIUM, LARGE };
+export {
+  COLOR,
+  COLORS,
+  TINTS,
+  colorsWithout,
+  tintsWithout,
+  SIZES,
+  sizesWithout,
+  TINY,
+  SMALL,
+  MEDIUM,
+  LARGE,
+  FULLSCREEN,
+};

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,3 +1,4 @@
 import { COLOR, COLORS, TINTS, colorsWithout, tintsWithout } from './colors';
+import { SIZES, sizesWithout, TINY, SMALL, MEDIUM, LARGE } from './sizes';
 
-export { COLOR, COLORS, TINTS, colorsWithout, tintsWithout };
+export { COLOR, COLORS, TINTS, colorsWithout, tintsWithout, SIZES, sizesWithout, TINY, SMALL, MEDIUM, LARGE };

--- a/src/constants/sizes.js
+++ b/src/constants/sizes.js
@@ -1,0 +1,10 @@
+import without from 'lodash.without';
+
+export const TINY = 'tiny';
+export const SMALL = 'small';
+export const MEDIUM = 'medium';
+export const LARGE = 'large';
+export const FULLSCREEN = 'fullscreen';
+
+export const SIZES = [TINY, SMALL, MEDIUM, LARGE, FULLSCREEN];
+export const sizesWithout = sizesToExclude => without(SIZES, ...sizesToExclude);

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,19 @@ import Tooltip from './components/tooltip';
 import QTip from './components/qTip';
 import ProgressTracker from './components/progressTracker';
 
-import { COLOR, COLORS, TINTS, colorsWithout, tintsWithout } from './constants';
+import {
+  COLOR,
+  COLORS,
+  TINTS,
+  colorsWithout,
+  tintsWithout,
+  SIZES,
+  sizesWithout,
+  TINY,
+  SMALL,
+  MEDIUM,
+  LARGE,
+} from './constants';
 
 export {
   Avatar,
@@ -121,4 +133,10 @@ export {
   TINTS,
   colorsWithout,
   tintsWithout,
+  SIZES,
+  sizesWithout,
+  TINY,
+  SMALL,
+  MEDIUM,
+  LARGE,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ import {
   SMALL,
   MEDIUM,
   LARGE,
+  FULLSCREEN,
 } from './constants';
 
 export {
@@ -139,4 +140,5 @@ export {
   SMALL,
   MEDIUM,
   LARGE,
+  FULLSCREEN,
 };


### PR DESCRIPTION
### Description

In this PR we also add the sizes we use in our library to our constants.
As the colors and tints [before](https://github.com/teamleadercrm/ui/pull/425) them.

This PR adds:

1. **constants**
- `TINY`: the string `'tiny'`
- `SMALL`: the string `'small'`
- `MEDIUM`: the string `'medium'`
- `LARGE`: the string `'large'`
- `FULLSCREEN`: the string `'fullscreen'`
- `SIZES`: the array with all the sizes in lowercase 

2. a **function**
- `sizesWithout`: a function which returns all the size names without the ones passed as an argument

### Breaking changes

None.
