### PR TITLE
Add displayName to all components

### DIFF
--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -38,4 +38,6 @@ Avatar.defaultProps = {
   size: 'medium',
 };
 
+Avatar.displayName = 'Avatar';
+
 export default Avatar;

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -54,4 +54,6 @@ AvatarStack.defaultProps = {
   size: 'medium',
 };
 
+AvatarStack.displayName = 'AvatarStack';
+
 export default AvatarStack;

--- a/src/components/badge/Badge.js
+++ b/src/components/badge/Badge.js
@@ -106,4 +106,6 @@ Badge.defaultProps = {
   color: 'neutral',
 };
 
+Badge.displayName = 'Badge';
+
 export default Badge;

--- a/src/components/banner/Banner.js
+++ b/src/components/banner/Banner.js
@@ -54,4 +54,6 @@ Banner.defaultProps = {
   color: 'white',
 };
 
+Banner.displayName = 'Banner';
+
 export default Banner;

--- a/src/components/box/Box.js
+++ b/src/components/box/Box.js
@@ -139,4 +139,6 @@ Box.defaultProps = {
   padding: 0,
 };
 
+Box.displayName = 'Box';
+
 export default Box;

--- a/src/components/bullet/Bullet.js
+++ b/src/components/bullet/Bullet.js
@@ -40,4 +40,6 @@ Bullet.defaultProps = {
   size: 'medium',
 };
 
+Bullet.displayName = 'Bullet';
+
 export default Bullet;

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -172,4 +172,6 @@ Button.defaultProps = {
   type: 'button',
 };
 
+Button.displayName = 'Button';
+
 export default Button;

--- a/src/components/button/ButtonGroup.js
+++ b/src/components/button/ButtonGroup.js
@@ -71,4 +71,6 @@ ButtonGroup.defaultProps = {
   segmented: false,
 };
 
+ButtonGroup.displayName = 'ButtonGroup';
+
 export default ButtonGroup;

--- a/src/components/button/IconButton.js
+++ b/src/components/button/IconButton.js
@@ -77,4 +77,6 @@ IconButton.defaultProps = {
   type: 'button',
 };
 
+IconButton.displayName = 'IconButton';
+
 export default IconButton;

--- a/src/components/checkbox/Checkbox.js
+++ b/src/components/checkbox/Checkbox.js
@@ -143,4 +143,6 @@ Checkbox.defaultProps = {
   size: 'medium',
 };
 
+Checkbox.displayName = 'Checkbox';
+
 export default Checkbox;

--- a/src/components/compactMessage/CompactMessage.js
+++ b/src/components/compactMessage/CompactMessage.js
@@ -29,4 +29,6 @@ CompactMessage.propTypes = {
   button: PropTypes.element,
 };
 
+CompactMessage.displayName = 'CompactMessage';
+
 export default CompactMessage;

--- a/src/components/counter/Counter.js
+++ b/src/components/counter/Counter.js
@@ -51,4 +51,6 @@ Counter.defaultProps = {
   size: 'medium',
 };
 
+Counter.displayName = 'Counter';
+
 export default Counter;

--- a/src/components/datagrid/BodyRow.js
+++ b/src/components/datagrid/BodyRow.js
@@ -56,4 +56,6 @@ BodyRow.propTypes = {
   sliceTo: PropTypes.number,
 };
 
+BodyRow.displayName = 'BodyRow';
+
 export default BodyRow;

--- a/src/components/datagrid/Cell.js
+++ b/src/components/datagrid/Cell.js
@@ -69,4 +69,6 @@ Cell.defaultProps = {
   strong: false,
 };
 
+Cell.displayName = 'Cell';
+
 export default Cell;

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -225,6 +225,8 @@ DataGrid.defaultProps = {
   processing: false,
 };
 
+DataGrid.displayName = 'DataGrid';
+
 DataGrid.HeaderRow = HeaderRow;
 DataGrid.HeaderRowOverlay = HeaderRowOverlay;
 DataGrid.HeaderCell = HeaderCell;

--- a/src/components/datagrid/FooterRow.js
+++ b/src/components/datagrid/FooterRow.js
@@ -30,4 +30,6 @@ FooterRow.propTypes = {
   sliceTo: PropTypes.number,
 };
 
+FooterRow.displayName = 'FooterRow';
+
 export default FooterRow;

--- a/src/components/datagrid/HeaderCell.js
+++ b/src/components/datagrid/HeaderCell.js
@@ -42,4 +42,6 @@ HeaderCell.defaultProps = {
   sorted: 'none',
 };
 
+HeaderCell.displayName = 'HeaderCell';
+
 export default HeaderCell;

--- a/src/components/datagrid/HeaderRow.js
+++ b/src/components/datagrid/HeaderRow.js
@@ -56,4 +56,6 @@ HeaderRow.propTypes = {
   sliceTo: PropTypes.number,
 };
 
+HeaderRow.displayName = 'HeaderRow';
+
 export default HeaderRow;

--- a/src/components/datagrid/HeaderRowOverlay/BulkActions.js
+++ b/src/components/datagrid/HeaderRowOverlay/BulkActions.js
@@ -22,4 +22,6 @@ BulkActions.defaultProps = {
   bulkActions: [],
 };
 
+BulkActions.displayName = 'BulkActions';
+
 export default BulkActions;

--- a/src/components/datagrid/HeaderRowOverlay/HeaderRowOverlay.js
+++ b/src/components/datagrid/HeaderRowOverlay/HeaderRowOverlay.js
@@ -55,4 +55,6 @@ HeaderRowOverlay.defaultProps = {
   numSelectedRows: 0,
 };
 
+HeaderRowOverlay.displayName = 'HeaderRowOverlay';
+
 export default HeaderRowOverlay;

--- a/src/components/datagrid/HeaderRowOverlay/NumSelectedRows.js
+++ b/src/components/datagrid/HeaderRowOverlay/NumSelectedRows.js
@@ -34,4 +34,6 @@ NumSelectedRows.defaultProps = {
   numSelectedRowsLabel: () => 'selected',
 };
 
+NumSelectedRows.displayName = 'NumSelectedRows';
+
 export default NumSelectedRows;

--- a/src/components/datagrid/Row.js
+++ b/src/components/datagrid/Row.js
@@ -28,4 +28,6 @@ Row.defaultProps = {
   backgroundColor: 'white',
 };
 
+Row.displayName = 'Row';
+
 export default Row;

--- a/src/components/datepicker/DatePicker.js
+++ b/src/components/datepicker/DatePicker.js
@@ -69,4 +69,6 @@ DatePicker.defaultProps = {
   size: 'medium',
 };
 
+DatePicker.displayName = 'DatePicker';
+
 export default DatePicker;

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -143,4 +143,6 @@ DatePickerInput.defaultProps = {
   size: 'medium',
 };
 
+DatePickerInput.displayName = 'DatePickerInput';
+
 export default DatePickerInput;

--- a/src/components/datepicker/DatePickerInputRange.js
+++ b/src/components/datepicker/DatePickerInputRange.js
@@ -278,4 +278,6 @@ DatePickerInputRange.defaultProps = {
   size: 'medium',
 };
 
+DatePickerInputRange.displayName = 'DatePickerInputRange';
+
 export default DatePickerInputRange;

--- a/src/components/datepicker/DatePickerRange.js
+++ b/src/components/datepicker/DatePickerRange.js
@@ -103,4 +103,6 @@ DatePickerRange.defaultProps = {
   size: 'medium',
 };
 
+DatePickerRange.displayName = 'DatePickerRange';
+
 export default DatePickerRange;

--- a/src/components/datepicker/NavigationBar.js
+++ b/src/components/datepicker/NavigationBar.js
@@ -52,4 +52,6 @@ NavigationBar.propTypes = {
   size: PropTypes.oneOf(['small', 'medium', 'large']),
 };
 
+NavigationBar.displayName = 'NavigationBar';
+
 export default NavigationBar;

--- a/src/components/datepicker/WeekDay.js
+++ b/src/components/datepicker/WeekDay.js
@@ -22,4 +22,6 @@ WeekDay.propTypes = {
   weekday: PropTypes.number,
 };
 
+WeekDay.displayName = 'WeekDay';
+
 export default WeekDay;

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -99,4 +99,6 @@ Dialog.defaultProps = {
   size: 'medium',
 };
 
+Dialog.displayName = 'Dialog';
+
 export default Dialog;

--- a/src/components/icon/Icon.js
+++ b/src/components/icon/Icon.js
@@ -42,4 +42,6 @@ Icon.defaultProps = {
   opacity: 0.84,
 };
 
+Icon.displayName = 'Icon';
+
 export default Icon;

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -69,4 +69,6 @@ Input.defaultProps = {
   type: 'text',
 };
 
+Input.displayName = 'Input';
+
 export default Input;

--- a/src/components/input/InputBase.js
+++ b/src/components/input/InputBase.js
@@ -93,4 +93,6 @@ InputBase.defaultProps = {
   size: 'medium',
 };
 
+InputBase.displayName = 'InputBase';
+
 export default InputBase;

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -141,4 +141,6 @@ NumericInput.defaultProps = {
   spinner: true,
 };
 
+NumericInput.displayName = 'NumericInput';
+
 export default NumericInput;

--- a/src/components/input/SingleLineInputBase.js
+++ b/src/components/input/SingleLineInputBase.js
@@ -105,4 +105,6 @@ SingleLineInputBase.propTypes = {
   suffix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
 };
 
+SingleLineInputBase.displayName = 'SingleLineInputBase';
+
 export default SingleLineInputBase;

--- a/src/components/input/Textarea.js
+++ b/src/components/input/Textarea.js
@@ -44,4 +44,6 @@ Textarea.defaultProps = {
   inverse: false,
 };
 
+Textarea.displayName = 'Textarea';
+
 export default Textarea;

--- a/src/components/island/Island.js
+++ b/src/components/island/Island.js
@@ -45,4 +45,6 @@ Island.defaultProps = {
   size: 'medium',
 };
 
+Island.displayName = 'Island';
+
 export default Island;

--- a/src/components/island/IslandGroup.js
+++ b/src/components/island/IslandGroup.js
@@ -40,4 +40,6 @@ IslandGroup.defaultProps = {
   direction: 'horizontal',
 };
 
+IslandGroup.displayName = 'IslandGroup';
+
 export default IslandGroup;

--- a/src/components/label/Label.js
+++ b/src/components/label/Label.js
@@ -92,3 +92,5 @@ Label.defaultProps = {
   required: false,
   size: 'medium',
 };
+
+Label.displayName = 'Label';

--- a/src/components/link/Link.js
+++ b/src/components/link/Link.js
@@ -79,4 +79,6 @@ Link.defaultProps = {
   inherit: true,
 };
 
+Link.displayName = 'Link';
+
 export default Link;

--- a/src/components/loadingBar/LoadingBar.js
+++ b/src/components/loadingBar/LoadingBar.js
@@ -42,4 +42,6 @@ LoadingBar.defaultProps = {
   tint: 'neutral',
 };
 
+LoadingBar.displayName = 'LoadingBar';
+
 export default LoadingBar;

--- a/src/components/loadingMolecule/LoadingMolecule.js
+++ b/src/components/loadingMolecule/LoadingMolecule.js
@@ -78,4 +78,6 @@ LoadingMolecule.propTypes = {
   type: PropTypes.string,
 };
 
+LoadingMolecule.displayName = 'LoadingMolecule';
+
 export default LoadingMolecule;

--- a/src/components/loadingSpinner/LoadingSpinner.js
+++ b/src/components/loadingSpinner/LoadingSpinner.js
@@ -33,4 +33,6 @@ LoadingSpinner.defaultProps = {
   tint: 'darkest',
 };
 
+LoadingSpinner.displayName = 'LoadingSpinner';
+
 export default LoadingSpinner;

--- a/src/components/menu/IconMenu.js
+++ b/src/components/menu/IconMenu.js
@@ -80,4 +80,6 @@ IconMenu.defaultProps = {
   selectable: false,
 };
 
+IconMenu.displayName = 'IconMenu';
+
 export default IconMenu;

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -257,4 +257,6 @@ Menu.defaultProps = {
   selectable: true,
 };
 
+Menu.displayName = 'Menu';
+
 export default Menu;

--- a/src/components/menu/MenuDivider.js
+++ b/src/components/menu/MenuDivider.js
@@ -3,4 +3,6 @@ import theme from './theme.css';
 
 const MenuDivider = () => <hr data-teamleader-ui="menu-divider" className={theme['divider']} />;
 
+MenuDivider.displayName = 'MenuDivider';
+
 export default MenuDivider;

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -53,4 +53,6 @@ MenuItem.defaultProps = {
   selected: false,
 };
 
+MenuItem.displayName = 'MenuItem';
+
 export default MenuItem;

--- a/src/components/message/Message.js
+++ b/src/components/message/Message.js
@@ -42,4 +42,6 @@ Message.defaultProps = {
   imagePositioning: 'left',
 };
 
+Message.displayName = 'Message';
+
 export default Message;

--- a/src/components/overlay/Overlay.js
+++ b/src/components/overlay/Overlay.js
@@ -110,4 +110,6 @@ Overlay.defaultProps = {
   lockScroll: true,
 };
 
+Overlay.displayName = 'Overlay';
+
 export default Overlay;

--- a/src/components/pagination/Pagination.js
+++ b/src/components/pagination/Pagination.js
@@ -119,4 +119,6 @@ Pagination.defaultProps = {
   maxNumPagesVisible: 7,
 };
 
+Pagination.displayName = 'Pagination';
+
 export default Pagination;

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -171,4 +171,6 @@ Popover.defaultProps = {
   tint: 'lightest',
 };
 
+Popover.displayName = 'Popover';
+
 export default Popover;

--- a/src/components/progressTracker/ProgressStep.js
+++ b/src/components/progressTracker/ProgressStep.js
@@ -39,4 +39,6 @@ ProgressStep.defaultProps = {
   completed: false,
 };
 
+ProgressStep.displayName = 'ProgressStep';
+
 export default ProgressStep;

--- a/src/components/progressTracker/ProgressTracker.js
+++ b/src/components/progressTracker/ProgressTracker.js
@@ -47,6 +47,8 @@ ProgressTracker.defaultProps = {
   color: 'neutral',
 };
 
+ProgressTracker.displayName = 'ProgressTracker';
+
 ProgressTracker.ProgressStep = ProgressStep;
 
 export default ProgressTracker;

--- a/src/components/qTip/QTip.js
+++ b/src/components/qTip/QTip.js
@@ -46,4 +46,6 @@ QTip.propTypes = {
   onChange: PropTypes.func.isRequired,
 };
 
+QTip.displayName = 'QTip';
+
 export default QTip;

--- a/src/components/radio/RadioButton.js
+++ b/src/components/radio/RadioButton.js
@@ -137,4 +137,6 @@ RadioButton.defaultProps = {
   size: 'medium',
 };
 
+RadioButton.displayName = 'RadioButton';
+
 export default RadioButton;

--- a/src/components/radio/RadioGroup.js
+++ b/src/components/radio/RadioGroup.js
@@ -47,4 +47,6 @@ RadioGroup.defaultProps = {
   disabled: false,
 };
 
+RadioGroup.displayName = 'RadioGroup';
+
 export default RadioGroup;

--- a/src/components/section/Section.js
+++ b/src/components/section/Section.js
@@ -45,4 +45,6 @@ Section.defaultProps = {
   size: 'medium',
 };
 
+Section.displayName = 'Section';
+
 export default Section;

--- a/src/components/select/AsyncSelect.js
+++ b/src/components/select/AsyncSelect.js
@@ -165,4 +165,6 @@ AsyncSelect.defaultProps = {
   pageSize: 10,
 };
 
+AsyncSelect.displayName = 'AsyncSelect';
+
 export default AsyncSelect;

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -315,4 +315,6 @@ Select.defaultProps = {
   size: 'medium',
 };
 
+Select.displayName = 'Select';
+
 export default Select;

--- a/src/components/statusBullet/StatusBullet.js
+++ b/src/components/statusBullet/StatusBullet.js
@@ -30,4 +30,6 @@ StatusBullet.defaultProps = {
   size: 'medium',
 };
 
+StatusBullet.displayName = 'StatusBullet';
+
 export default StatusBullet;

--- a/src/components/statusLabel/StatusLabel.js
+++ b/src/components/statusLabel/StatusLabel.js
@@ -44,4 +44,6 @@ StatusLabel.defaultProps = {
   size: 'medium',
 };
 
+StatusLabel.displayName = 'StatusLabel';
+
 export default StatusLabel;

--- a/src/components/tab/IconTab.js
+++ b/src/components/tab/IconTab.js
@@ -61,4 +61,6 @@ IconTab.defaultProps = {
   active: false,
 };
 
+IconTab.displayName = 'IconTab';
+
 export default IconTab;

--- a/src/components/tab/TabGroup.js
+++ b/src/components/tab/TabGroup.js
@@ -35,4 +35,6 @@ TabGroup.defaultProps = {
   inverted: false,
 };
 
+TabGroup.displayName = 'TabGroup';
+
 export default TabGroup;

--- a/src/components/tab/TitleTab.js
+++ b/src/components/tab/TitleTab.js
@@ -75,4 +75,6 @@ TitleTab.defaultProps = {
   size: 'medium',
 };
 
+TitleTab.displayName = 'TitleTab';
+
 export default TitleTab;

--- a/src/components/tag/Tag.js
+++ b/src/components/tag/Tag.js
@@ -73,4 +73,6 @@ Tag.defaultProps = {
   color: 'neutral',
 };
 
+Tag.displayName = 'Tag';
+
 export default Tag;

--- a/src/components/toast/Toast.js
+++ b/src/components/toast/Toast.js
@@ -125,4 +125,6 @@ Toast.propTypes = {
   timeout: PropTypes.number,
 };
 
+Toast.displayName = 'Toast';
+
 export default Toast;

--- a/src/components/toast/ToastContainer.js
+++ b/src/components/toast/ToastContainer.js
@@ -45,4 +45,6 @@ ToastContainer.propTypes = {
   className: PropTypes.string,
 };
 
+ToastContainer.displayName = 'ToastContainer';
+
 export default ToastContainer;

--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -131,4 +131,6 @@ Toggle.defaultProps = {
   size: 'medium',
 };
 
+Toggle.displayName = 'Toggle';
+
 export default Toggle;

--- a/src/components/typography/Monospaced.js
+++ b/src/components/typography/Monospaced.js
@@ -29,4 +29,6 @@ Monospaced.defaultProps = {
   element: 'span',
 };
 
+Monospaced.displayName = 'Monospaced';
+
 export default Monospaced;

--- a/src/components/typography/index.js
+++ b/src/components/typography/index.js
@@ -10,4 +10,13 @@ const TextDisplay = textFactory('text', 'text-display', 'p');
 const TextBody = textFactory('text', 'text-body', 'p');
 const TextSmall = textFactory('text', 'text-small', 'p');
 
+Heading1.displayName = 'Heading1';
+Heading2.displayName = 'Heading2';
+Heading3.displayName = 'Heading3';
+Heading4.displayName = 'Heading4';
+
+TextDisplay.displayName = 'TextDisplay';
+TextBody.displayName = 'TextBody';
+TextSmall.displayName = 'TextSmall';
+
 export { Heading1, Heading2, Heading3, Heading4, Monospaced, TextBody, TextDisplay, TextSmall };

--- a/src/components/validationText/ErrorText.js
+++ b/src/components/validationText/ErrorText.js
@@ -35,3 +35,5 @@ ErrorText.defaultProps = {
   children: 'This is the error text',
   inverse: false,
 };
+
+ErrorText.displayName = 'ErrorText';

--- a/src/components/validationText/HelpText.js
+++ b/src/components/validationText/HelpText.js
@@ -35,3 +35,5 @@ HelpText.defaultProps = {
   children: 'This is the help text',
   inverse: false,
 };
+
+HelpText.displayName = 'HelpText';

--- a/src/components/validationText/ValidationText.js
+++ b/src/components/validationText/ValidationText.js
@@ -26,4 +26,6 @@ ValidationText.propTypes = {
   inverse: PropTypes.bool,
 };
 
+ValidationText.displayName = 'ValidationText';
+
 export default ValidationText;


### PR DESCRIPTION
### Description

Due to Storybook's minification, all our component names are reduced to one or two random characters:
* `<n .../>`
* `<t .../>`
* `<Kn .../>`
* ...

This PR adds a displayName to all components, which solves the above issue.

#### Screenshot before this PR

![schermafdruk 2018-11-09 12 06 50](https://user-images.githubusercontent.com/5336831/48259369-063fe980-e418-11e8-9609-7c42ac2428cd.png)

![schermafdruk 2018-11-09 12 07 00](https://user-images.githubusercontent.com/5336831/48259382-0d66f780-e418-11e8-84ff-069a388e55b0.png)

#### Screenshot after this PR

![schermafdruk 2018-11-09 12 06 30](https://user-images.githubusercontent.com/5336831/48259387-11931500-e418-11e8-876c-126c02bd0b2e.png)

![schermafdruk 2018-11-09 12 07 11](https://user-images.githubusercontent.com/5336831/48259391-15269c00-e418-11e8-9484-a0bdee5afb24.png)

### Breaking changes

None.
