### PR TITLE
[TU-193] Avatar multiple shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### Added
 
-- `Avatar`: added the `type` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#451](https://github.com/teamleadercrm/ui/pull/451))
-- `Avatar`: added a rounded square as a possible shape, to get this shape set the `type` prop to `'company'` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#451](https://github.com/teamleadercrm/ui/pull/451))
+- `Avatar`: added the `shape` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#451](https://github.com/teamleadercrm/ui/pull/451))
+- `Avatar`: added a rounded square as a possible shape, to get this shape set the `shape` prop to `'rounded'` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#451](https://github.com/teamleadercrm/ui/pull/451))
 - `withTheme`: added the `withTheme` HOC ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#416](https://github.com/teamleadercrm/ui/pull/416))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Avatar`: added the `type` prop ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#451](https://github.com/teamleadercrm/ui/pull/451))
+- `Avatar`: added a rounded square as a possible shape, to get this shape set the `type` prop to `'company'` ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#451](https://github.com/teamleadercrm/ui/pull/451))
 - `withTheme`: added the `withTheme` HOC ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#416](https://github.com/teamleadercrm/ui/pull/416))
 
 ### Changed

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -6,9 +6,9 @@ import theme from './theme.css';
 
 class Avatar extends PureComponent {
   render() {
-    const { children, className, image, imageAlt, imageClassName, size, type, ...others } = this.props;
+    const { children, className, image, imageAlt, imageClassName, shape, size, ...others } = this.props;
 
-    const avatarClassNames = cx(theme['avatar'], theme[size], theme[`is-${type}`], className);
+    const avatarClassNames = cx(theme['avatar'], theme[`is-${shape}`], theme[size], className);
 
     return (
       <Box className={avatarClassNames} {...others} data-teamleader-ui="avatar">
@@ -30,13 +30,14 @@ Avatar.propTypes = {
   imageAlt: PropTypes.string,
   /** A class name for the image to give custom styles. */
   imageClassName: PropTypes.string,
+  /** The shape of the avatar. */
+  shape: PropTypes.oneOf(['circle', 'rounded']),
   /** The size of the avatar. */
   size: PropTypes.oneOf(['tiny', 'small', 'medium']),
-  /** The type of the entity displayed in the avatar. */
-  type: PropTypes.oneOf(['company', 'contact']),
 };
 
 Avatar.defaultProps = {
+  shape: 'circle',
   size: 'medium',
 };
 

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -6,9 +6,9 @@ import theme from './theme.css';
 
 class Avatar extends PureComponent {
   render() {
-    const { children, className, image, imageAlt, imageClassName, size, ...others } = this.props;
+    const { children, className, image, imageAlt, imageClassName, size, type, ...others } = this.props;
 
-    const avatarClassNames = cx(theme['avatar'], theme[size], className);
+    const avatarClassNames = cx(theme['avatar'], theme[size], theme[`is-${type}`], className);
 
     return (
       <Box className={avatarClassNames} {...others} data-teamleader-ui="avatar">
@@ -32,6 +32,8 @@ Avatar.propTypes = {
   imageClassName: PropTypes.string,
   /** The size of the avatar. */
   size: PropTypes.oneOf(['tiny', 'small', 'medium']),
+  /** The type of the entity displayed in the avatar. */
+  type: PropTypes.oneOf(['company', 'contact']),
 };
 
 Avatar.defaultProps = {

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -10,9 +10,8 @@
   --small-size: 36px;
   --medium-size: 48px;
 
-  --default-image-border-radius: 50%;
-  --type-company-image-border-radius: 4px;
-  --type-contact-image-border-radius: var(--default-image-border-radius);
+  --shape-circle-image-border-radius: 50%;
+  --shape-rounded-image-border-radius: 4px;
 }
 
 /* Avatar */
@@ -20,12 +19,12 @@
   display: inline-block;
   position: relative;
 
-  &.is-company .image {
-    border-radius: var(--type-company-image-border-radius);
+  &.is-circle .image {
+    border-radius: var(--shape-circle-image-border-radius);
   }
 
-  &.is-contact .image {
-    border-radius: 50%;
+  &.is-rounded .image {
+    border-radius: var(--shape-rounded-image-border-radius);
   }
 }
 
@@ -36,7 +35,6 @@
 
 .image {
   display: block;
-  border-radius: var(--default-image-border-radius);
   overflow: hidden;
 }
 

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -9,12 +9,24 @@
   --tiny-size: 24px;
   --small-size: 36px;
   --medium-size: 48px;
+
+  --default-image-border-radius: 50%;
+  --type-company-image-border-radius: 4px;
+  --type-contact-image-border-radius: var(--default-image-border-radius);
 }
 
 /* Avatar */
 .avatar {
   display: inline-block;
   position: relative;
+
+  &.is-company .image {
+    border-radius: var(--type-company-image-border-radius);
+  }
+
+  &.is-contact .image {
+    border-radius: 50%;
+  }
 }
 
 .children {
@@ -24,7 +36,7 @@
 
 .image {
   display: block;
-  border-radius: 50%;
+  border-radius: var(--default-image-border-radius);
   overflow: hidden;
 }
 

--- a/stories/avatars.js
+++ b/stories/avatars.js
@@ -6,6 +6,7 @@ import avatars from './static/data/avatar';
 
 const directions = ['horizontal', 'vertical'];
 const sizes = ['tiny', 'small', 'medium'];
+const types = [null, 'company', 'contact'];
 
 const TooltippedAvatar = Tooltip(Avatar);
 
@@ -15,7 +16,9 @@ storiesOf('Avatars', module)
       propTablesExclude: [Bullet, Counter],
     },
   })
-  .add('sizes', () => <Avatar image={avatars[0].image} size={select('Size', sizes, 'medium')} />)
+  .add('sizes', () => (
+    <Avatar image={avatars[0].image} size={select('Size', sizes, 'medium')} type={select('type', types) || undefined} />
+  ))
   .add('stacked', () => (
     <AvatarStack
       direction={select('Direction', directions, 'horizontal')}

--- a/stories/avatars.js
+++ b/stories/avatars.js
@@ -6,7 +6,7 @@ import avatars from './static/data/avatar';
 
 const directions = ['horizontal', 'vertical'];
 const sizes = ['tiny', 'small', 'medium'];
-const types = [null, 'company', 'contact'];
+const shapes = [null, 'circle', 'rounded'];
 
 const TooltippedAvatar = Tooltip(Avatar);
 
@@ -17,7 +17,11 @@ storiesOf('Avatars', module)
     },
   })
   .add('sizes', () => (
-    <Avatar image={avatars[0].image} size={select('Size', sizes, 'medium')} type={select('type', types) || undefined} />
+    <Avatar
+      image={avatars[0].image}
+      size={select('Size', sizes, 'medium')}
+      shape={select('shape', shapes) || undefined}
+    />
   ))
   .add('stacked', () => (
     <AvatarStack


### PR DESCRIPTION
### Description

In this PR we add (next to the circle) an extra possible shape for the [`Avatar`](https://components.teamleader.design/?selectedKind=Avatars&selectedStory=sizes&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs&background=%23ffffff): a rounded square.

A contact should be displayed in a circle, while a company in a rounded square ( for more: [see the specs](https://zpl.io/VxnJEMx)).

Therefore the shape is based on the new `type` prop, which values can be `'company'` or `'contact'`.

When no `type` is supplied the `Avatar` will still be displayed as a circle.

#### Screenshot before this PR

![screenshot 2018-11-09 at 14 30 09](https://user-images.githubusercontent.com/23736202/48265143-021dc700-e42c-11e8-9ee1-3389a880516f.png)

#### Screenshot after this PR

![screenshot 2018-11-09 at 14 30 17](https://user-images.githubusercontent.com/23736202/48265149-0649e480-e42c-11e8-8322-d704b088aefa.png)

### Breaking changes

None.