### PR TITLE
Maintenance: uglify our js code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- `Maintenance`: added `uglify` to our gulpfile so the code in the output `lib` folder gets minified. ([@driesd](https://github.com/driesd) in [#452](https://github.com/teamleadercrm/ui/pull/452))
 - `withTheme`: added the `withTheme` HOC ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#416](https://github.com/teamleadercrm/ui/pull/416))
 
 ### Changed

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,11 +2,13 @@ const path = require('path');
 const gulp = require('gulp');
 const babel = require('gulp-babel');
 const postcss = require('gulp-postcss');
+const uglify = require('gulp-uglify');
 
 gulp.task('js', function() {
   return gulp
     .src(['./src/**/*.js'])
     .pipe(babel())
+    .pipe(uglify())
     .pipe(gulp.dest('./lib'));
 });
 

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "gulp": "^3.9.1",
     "gulp-babel": "8.0.0-beta.2",
     "gulp-postcss": "^7.0.0",
+    "gulp-uglify": "^3.0.1",
     "html-webpack-plugin": "^4.0.0-alpha.2",
     "husky": "^0.14.3",
     "image-webpack-loader": "^4.1.0",


### PR DESCRIPTION
### Description

This PR `uglifies` (minifies) our `JS code` in the output `lib` folder.

Bundle size **before** this PR: **731Kb** (731.361 bytes)
Bundle size **after** this PR: **614Kb** (614.276 bytes)

Total **win**: **117Kb** (117.085 bytes)

### Breaking changes

None.
