### PR TITLE
Add displayName to all the Typography components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `withTheme`: added the `withTheme` HOC ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#416](https://github.com/teamleadercrm/ui/pull/416))
 - `sizes`: added general constants and a helper function to retrieve the library wide sizes ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#448](https://github.com/teamleadercrm/ui/pull/448))
+- `Typography`: added a `displayName` to all `Typography` components that are using the `textFactory`. ([@driesd](https://github.com/driesd) in [#453](https://github.com/teamleadercrm/ui/pull/453))
 
 ### Changed
 

--- a/src/components/typography/index.js
+++ b/src/components/typography/index.js
@@ -10,4 +10,12 @@ const TextDisplay = textFactory('text', 'text-display', 'p');
 const TextBody = textFactory('text', 'text-body', 'p');
 const TextSmall = textFactory('text', 'text-small', 'p');
 
+Heading1.displayName = 'Heading1';
+Heading2.displayName = 'Heading2';
+Heading3.displayName = 'Heading3';
+Heading4.displayName = 'Heading4';
+TextDisplay.displayName = 'TextDisplay';
+TextBody.displayName = 'TextBody';
+TextSmall.displayName = 'TextSmall';
+
 export { Heading1, Heading2, Heading3, Heading4, Monospaced, TextBody, TextDisplay, TextSmall };


### PR DESCRIPTION
### Description

This PR adds a `displayName` to all `Typography` components that are using the `textFactory`:
* Heading1
* Heading2
* Heading3
* Heading4
* TextDisplay
* TextBody
* TextSmall

#### Screenshot before this PR

![schermafdruk 2018-11-09 15 55 48](https://user-images.githubusercontent.com/5336831/48269479-f6380200-e437-11e8-9c74-09c94e79146b.png)

#### Screenshot after this PR

![schermafdruk 2018-11-09 15 46 38](https://user-images.githubusercontent.com/5336831/48269122-15825f80-e437-11e8-8b32-29105accf518.png)

### Breaking changes

None.
