### PR TITLE
[TU-204] Dialog: make body scrollable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Dialog`: the body of the `Dialog` renders scrollable, when its content starts to overflow ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#456](https://github.com/teamleadercrm/ui/pull/456))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -1,6 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import omit from 'lodash.omit';
+import cx from 'classnames';
+
+import theme from './theme.css';
 
 import { Banner, Box, Button, ButtonGroup, DialogBase, Heading2, Heading3, Link } from '../../index';
 import { COLORS } from '../../constants';
@@ -29,7 +32,9 @@ class Dialog extends PureComponent {
   };
 
   render() {
-    const { children, primaryAction, secondaryAction, tertiaryAction, title, ...otherProps } = this.props;
+    const { children, className, primaryAction, secondaryAction, tertiaryAction, title, ...otherProps } = this.props;
+
+    const classNames = cx(theme['dialog'], className);
 
     const restProps = omit(otherProps, [
       'headerColor',
@@ -40,7 +45,7 @@ class Dialog extends PureComponent {
     ]);
 
     return (
-      <DialogBase {...restProps}>
+      <DialogBase className={classNames} {...restProps}>
         {title && this.getHeader()}
         <Box padding={4}>{children}</Box>
         {this.getFooter()}
@@ -50,6 +55,8 @@ class Dialog extends PureComponent {
 }
 
 Dialog.propTypes = {
+  /** A class name for the wrapper to apply custom styles. */
+  className: PropTypes.string,
   /** The color of the header of the dialog. */
   headerColor: PropTypes.oneOf(COLORS),
   /** The icon in the header of the dialog. */

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -47,7 +47,9 @@ class Dialog extends PureComponent {
     return (
       <DialogBase className={classNames} {...restProps}>
         {title && this.getHeader()}
-        <Box padding={4}>{children}</Box>
+        <Box className={theme['dialog-body']} padding={4}>
+          {children}
+        </Box>
         {this.getFooter()}
       </DialogBase>
     );

--- a/src/components/dialog/DialogBase.js
+++ b/src/components/dialog/DialogBase.js
@@ -35,7 +35,7 @@ class DialogBase extends PureComponent {
       return null;
     }
 
-    const dialogClassNames = cx(theme['dialog'], theme[`is-${size}`], className);
+    const dialogClassNames = cx(theme['dialog-base'], theme[`is-${size}`], className);
 
     const dialog = (
       <Transition timeout={0} in={active} appear>

--- a/src/components/dialog/theme.css
+++ b/src/components/dialog/theme.css
@@ -19,7 +19,7 @@
   z-index: 600;
 }
 
-.dialog {
+.dialog-base {
   composes: box-shadow-300;
   background-color: var(--dialog-background-color);
   border-radius: var(--dialog-border-radius);
@@ -44,11 +44,11 @@
   position: relative;
 }
 
-.is-entering .dialog {
+.is-entering .dialog-base {
   opacity: 0;
 }
 
-.is-entered .dialog {
+.is-entered .dialog-base {
   opacity: 1;
   transform: translateY(0%);
 }

--- a/src/components/dialog/theme.css
+++ b/src/components/dialog/theme.css
@@ -76,3 +76,8 @@
     width: 100vw;
   }
 }
+
+.dialog-body {
+  flex: 1;
+  overflow: auto;
+}


### PR DESCRIPTION
### Description

In this PR, I make the body of the [`Dialog`](https://components.teamleader.design/?selectedKind=Dialogs&selectedStory=Dialog&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs&background=%23ffffff) scrollable.

Something we're still missing from the [specs](https://zpl.io/a7ZEgqM), is the line separating the footer and the body of the `Dialog`, this one should only be rendered when the body can be scrolled (aka there's content hidden underneath the footer).

But the most important part is that the body now is scrollable, instead of pushing the footer out of view. So let's get this merged first!

#### Screenshot before this PR

![screenshot 2018-11-13 at 13 33 12](https://user-images.githubusercontent.com/23736202/48413666-b2e7d700-e748-11e8-9793-d2605dbc8b43.png)

#### Screenshot after this PR

![screenshot 2018-11-13 at 13 36 39](https://user-images.githubusercontent.com/23736202/48413818-2ee21f00-e749-11e8-8f6e-8af19a400c50.png)

### Breaking changes

None.
