### PR TITLE
Maintenance: only set optimization.minimize to false when not undefined

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -55,7 +55,9 @@ module.exports = (storybookBaseConfig, configType) => {
     ],
   });
 
-  storybookBaseConfig.optimization.minimize = false;
+  if (storybookBaseConfig.optimization) {
+    storybookBaseConfig.optimization.minimize = false;
+  }
 
   storybookBaseConfig.plugins.map(plugin => {
     if (plugin instanceof webpack.DefinePlugin) {


### PR DESCRIPTION
### Description

This PR sets the `webpack config` variable `storybookBaseConfig.optimization.minimize` to false when `storybookBaseConfig.optimization` is not undefined.

Error before this PR when running `npm start`:
```
TypeError: Cannot set property 'minimize' of undefined at module.exports (teamleader-ui/.storybook/webpack.config.js:
```
### Breaking changes

None.