### PR TITLE
Storybook: add a playground story to play around

### DIFF
--- a/stories/playground.js
+++ b/stories/playground.js
@@ -1,0 +1,259 @@
+import React from 'react';
+import MomentLocaleUtils, { formatDate, parseDate } from 'react-day-picker/moment';
+import { storiesOf } from '@storybook/react';
+import { boolean } from '@storybook/addon-knobs/react';
+import { DateTime } from 'luxon';
+import { IconIdeaMediumOutline } from '@teamleader/ui-icons';
+import {
+  Banner,
+  Box,
+  Button,
+  ButtonGroup,
+  DataGrid,
+  DatePickerInput,
+  Dialog,
+  Heading3,
+  Heading4,
+  IconMenu,
+  MenuItem,
+  Label,
+  Link,
+  Popover,
+  Select,
+  StatusBullet,
+  TextBody,
+  TextSmall,
+  Toast,
+  ToastContainer,
+  Tooltip,
+  QTip,
+} from '../src';
+
+import { rows1 } from './static/data/datagrid';
+import options from './static/data/select';
+
+const inputPlaceholderToday = DateTime.fromJSDate(new Date())
+  .setLocale('nl')
+  .toLocaleString(DateTime.DATE_SHORT);
+
+const preSelectedDate = DateTime.local()
+  .plus({ days: 3 })
+  .toJSDate();
+
+const TooltippedStatusBullet = Tooltip(StatusBullet);
+
+const MyDatagrid = ({ ...props }) => (
+  <DataGrid
+    comparableId={1}
+    // onSelectionChange={handleRowSelectionChange}
+    {...props}
+  >
+    <DataGrid.HeaderRowOverlay>
+      <Button size="small" level="primary" label="Marks as paid" />
+      <ButtonGroup segmented marginHorizontal={3}>
+        <Button size="small" label="Book" />
+        <Button size="small" label="Merge" />
+      </ButtonGroup>
+      <Button size="small" level="destructive" label="Delete" />
+      <Select options={options} marginHorizontal={3} size="small" flex="1" menuIsOpen />
+    </DataGrid.HeaderRowOverlay>
+
+    <DataGrid.HeaderRow>
+      <DataGrid.HeaderCell flex="min-width" />
+      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} sorted="asc">
+        Invoice
+      </DataGrid.HeaderCell>
+      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} align="right">
+        Amount
+      </DataGrid.HeaderCell>
+      <DataGrid.HeaderCell flex="2" onClick={() => console.log('onClick: column sort')}>
+        Customer
+      </DataGrid.HeaderCell>
+      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')}>Due date</DataGrid.HeaderCell>
+      <DataGrid.HeaderCell flex="min-width" />
+    </DataGrid.HeaderRow>
+    {rows1.map((row, index) => {
+      return (
+        <DataGrid.BodyRow key={index}>
+          <DataGrid.Cell align="center" flex="min-width">
+            <TooltippedStatusBullet
+              color={row.column1}
+              tooltip={<TextSmall>Overdue</TextSmall>}
+              tooltipColor={row.column1}
+              tooltipSize="small"
+              size="medium"
+            />
+          </DataGrid.Cell>
+          <DataGrid.Cell>
+            <Link href="#" inherit={false}>
+              {row.column5}
+            </Link>{' '}
+          </DataGrid.Cell>
+          <DataGrid.Cell align="right" strong>
+            {' '}
+            {`€ ${row.column3}`}
+          </DataGrid.Cell>
+          <DataGrid.Cell flex="2">{row.column2}</DataGrid.Cell>
+          <DataGrid.Cell soft>{row.column4}</DataGrid.Cell>
+          <DataGrid.Cell align="right" flex="min-width" preventOverflow={false}>
+            <IconMenu position="top-right">
+              <MenuItem onClick={() => console.log('onClick: delete row')}>Remove row</MenuItem>
+            </IconMenu>
+          </DataGrid.Cell>
+        </DataGrid.BodyRow>
+      );
+    })}
+    <DataGrid.FooterRow backgroundColor="neutral">
+      <DataGrid.Cell flex="min-width" />
+      <DataGrid.Cell align="right" soft>
+        <Heading4>Total Excl Btw</Heading4>
+      </DataGrid.Cell>
+      <DataGrid.Cell align="right" strong>
+        € 13460.52
+      </DataGrid.Cell>
+      <DataGrid.Cell flex="2" />
+      <DataGrid.Cell />
+      <DataGrid.Cell flex="min-width" />
+    </DataGrid.FooterRow>
+
+    <DataGrid.FooterRow backgroundColor="neutral">
+      <DataGrid.Cell flex="min-width" />
+      <DataGrid.Cell align="right" soft>
+        <Heading4>+ VAT</Heading4>
+      </DataGrid.Cell>
+      <DataGrid.Cell align="right" strong>
+        € 2826.71
+      </DataGrid.Cell>
+      <DataGrid.Cell flex="2" />
+      <DataGrid.Cell />
+      <DataGrid.Cell flex="min-width" />
+    </DataGrid.FooterRow>
+
+    <DataGrid.FooterRow backgroundColor="neutral">
+      <DataGrid.Cell flex="min-width" />
+      <DataGrid.Cell align="right" soft>
+        <Heading4>Total Incl Btw</Heading4>
+      </DataGrid.Cell>
+      <DataGrid.Cell align="right" strong backgroundColor="white" border="around">
+        € 16287.23
+      </DataGrid.Cell>
+      <DataGrid.Cell flex="2" />
+      <DataGrid.Cell />
+      <DataGrid.Cell flex="min-width" />
+    </DataGrid.FooterRow>
+  </DataGrid>
+);
+
+storiesOf('Playground', module)
+  .addParameters({
+    info: {
+      source: false,
+      propTables: false,
+    },
+  })
+  .add('Z-Indexes', () => {
+    const myRef = document.querySelector('h1');
+
+    return (
+      <Box>
+        <QTip
+          icon={<IconIdeaMediumOutline />}
+          closed={!boolean('QTip is active', false)}
+          onChange={() => console.log('QTip has changed')}
+        >
+          <TextBody color="teal" tint="darkest">
+            Lorem ipsum dolor sit amet, consectetur{' '}
+            <Link href="#" inherit={false}>
+              adipiscing
+            </Link>{' '}
+            elit.
+          </TextBody>
+        </QTip>
+        <Box display="flex">
+          <Label flex="1" marginRight={3}>
+            Select your flavourite
+            <Select
+              helpText="Please select your favorite flavour"
+              options={options}
+              marginBottom={3}
+              menuIsOpen={boolean('Select is active', false)}
+            />
+          </Label>
+          <Label required flex="1" marginLeft={3}>
+            Pick a date
+            <DatePickerInput
+              formatDate={formatDate}
+              parseDate={parseDate}
+              helpText="Please pick a preferred date"
+              dayPickerProps={{
+                locale: 'nl',
+                localeUtils: MomentLocaleUtils,
+                numberOfMonths: 2,
+              }}
+              placeholder={inputPlaceholderToday}
+              selectedDate={preSelectedDate}
+              value={preSelectedDate}
+            />
+          </Label>
+        </Box>
+        <MyDatagrid
+          selectable={boolean('DataGrid selectable', true)}
+          stickyFromLeft={3}
+          stickyFromRight={1}
+          processing={boolean('DataGrid processing', false)}
+          marginTop={4}
+        />
+        <Popover
+          active={boolean('Popover is active', false)}
+          anchorEl={myRef}
+          backdrop="dark"
+          position="end"
+          direction="south"
+        >
+          <Box padding={4}>
+            <Heading3 color="teal" tint="darkest">
+              I am a Popover
+            </Heading3>
+            <Label marginTop={3} marginBottom={0} required>
+              Select your flavourite
+              <Select helpText="Please select your favorite flavour" options={options} />
+            </Label>
+          </Box>
+        </Popover>
+        <Dialog
+          active={boolean('Dialog is active', false)}
+          title="I am the Dialog title"
+          primaryAction={{ label: 'Confirm' }}
+        >
+          <TextBody color="teal" tint="darkest">
+            I am a Dialog that covers everything below
+          </TextBody>
+          <Box display="flex" marginTop={3}>
+            <Label flex="1" marginBottom={0} marginRight={2} required>
+              Select your flavourite
+              <Select helpText="Please select your favorite flavour" options={options} />
+            </Label>
+            <Label required flex="1" marginLeft={2}>
+              Pick a date
+              <DatePickerInput
+                formatDate={formatDate}
+                parseDate={parseDate}
+                helpText="Please pick a preferred date"
+                dayPickerProps={{
+                  locale: 'nl',
+                  localeUtils: MomentLocaleUtils,
+                  numberOfMonths: 1,
+                }}
+                placeholder={inputPlaceholderToday}
+                selectedDate={preSelectedDate}
+                value={preSelectedDate}
+              />
+            </Label>
+          </Box>
+        </Dialog>
+        <ToastContainer>
+          <Toast label="Your Toast is ready Sir!" />
+        </ToastContainer>
+      </Box>
+    );
+  });

--- a/stories/playground.js
+++ b/stories/playground.js
@@ -43,11 +43,7 @@ const preSelectedDate = DateTime.local()
 const TooltippedStatusBullet = Tooltip(StatusBullet);
 
 const MyDatagrid = ({ ...props }) => (
-  <DataGrid
-    comparableId={1}
-    // onSelectionChange={handleRowSelectionChange}
-    {...props}
-  >
+  <DataGrid comparableId={1} onSelectionChange={() => console.log('onSelectionChange')} {...props}>
     <DataGrid.HeaderRowOverlay>
       <Button size="small" level="primary" label="Marks as paid" />
       <ButtonGroup segmented marginHorizontal={3}>


### PR DESCRIPTION
### Description

This PR adds a `Playground` story where we can play around with e.g. z-indexes. This becomes very handy for the styleguide team when combining multiple components to see how they influence each other.

![schermafdruk 2018-11-13 14 51 56](https://user-images.githubusercontent.com/5336831/48417700-b03eaf00-e753-11e8-8b19-581adfd3aa00.png)

### Breaking changes

None, because this is `only in Storybook`, `not in the lib` bundle.
