### PR TITLE
Radio button: replace splitProps with pickBoxProps & omitBoxProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - `Dialog`: the body of the `Dialog` renders scrollable, when its content starts to overflow ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#456](https://github.com/teamleadercrm/ui/pull/456))
+- `RadioButton`: replaced the `splitProps` class method with our reusable `pickBoxProps` & `omitBoxProps`. ([@driesd](https://github.com/driesd) in [#460](https://github.com/teamleadercrm/ui/pull/460))
 
 ### Deprecated
 

--- a/src/components/radio/RadioButton.js
+++ b/src/components/radio/RadioButton.js
@@ -19,40 +19,6 @@ class RadioButton extends PureComponent {
     }
   };
 
-  splitProps(props) {
-    const availableBoxProps = [
-      'margin',
-      'marginVertical',
-      'marginHorizontal',
-      'marginBottom',
-      'marginLeft',
-      'marginRight',
-      'marginTop',
-      'padding',
-      'paddingHorizontal',
-      'paddingVertical',
-      'paddingBottom',
-      'paddingLeft',
-      'paddingRight',
-      'paddingTop',
-    ];
-
-    const boxProps = {};
-    const inputProps = {};
-
-    Object.keys(props).forEach(key => {
-      const value = props[key];
-
-      if (availableBoxProps.includes(key)) {
-        boxProps[key] = value;
-      } else {
-        inputProps[key] = value;
-      }
-    });
-
-    return { boxProps, inputProps };
-  }
-
   blur() {
     if (this.inputNode) {
       this.inputNode.blur();

--- a/src/components/radio/RadioButton.js
+++ b/src/components/radio/RadioButton.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import theme from './theme.css';
 import cx from 'classnames';
 import omit from 'lodash.omit';
-import Box from '../box';
+import Box, { omitBoxProps, pickBoxProps } from '../box';
 import { TextBody, TextDisplay, TextSmall } from '../typography';
 
 class RadioButton extends PureComponent {
@@ -68,8 +68,10 @@ class RadioButton extends PureComponent {
   render() {
     const { checked, disabled, className, size, label, children, onMouseEnter, onMouseLeave, ...others } = this.props;
     const rest = omit(others, ['onChange']);
-    const { boxProps, inputProps } = this.splitProps(rest);
     const TextElement = size === 'small' ? TextSmall : size === 'medium' ? TextBody : TextDisplay;
+
+    const boxProps = pickBoxProps(rest);
+    const inputProps = omitBoxProps(rest);
 
     const classNames = cx(
       theme['radiobutton'],

--- a/src/components/radio/RadioButton.js
+++ b/src/components/radio/RadioButton.js
@@ -67,11 +67,11 @@ class RadioButton extends PureComponent {
 
   render() {
     const { checked, disabled, className, size, label, children, onMouseEnter, onMouseLeave, ...others } = this.props;
-    const rest = omit(others, ['onChange']);
     const TextElement = size === 'small' ? TextSmall : size === 'medium' ? TextBody : TextDisplay;
 
-    const boxProps = pickBoxProps(rest);
-    const inputProps = omitBoxProps(rest);
+    const restProps = omit(others, ['onChange']);
+    const boxProps = pickBoxProps(restProps);
+    const inputProps = omitBoxProps(restProps);
 
     const classNames = cx(
       theme['radiobutton'],


### PR DESCRIPTION
### Description

This PR replaces the `splitProps` class method with our reusable `pickBoxProps` & `omitBoxProps` to filter out the correct props.

### Breaking changes

None.
