### PR TITLE
[TU-153] Dialog: separate footer and body 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Dialog`: added a top border to the footer, when the content of the body overflows ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#461](https://github.com/teamleadercrm/ui/pull/461))
+
 ### Changed
 
 - `Dialog`: the body of the `Dialog` renders scrollable, when its content starts to overflow ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#456](https://github.com/teamleadercrm/ui/pull/456))

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -18,7 +18,8 @@ class Dialog extends PureComponent {
   };
 
   componentDidUpdate(prevProps) {
-    if (this.props.active !== prevProps.active) {
+    if (this.props.active && !prevProps.active) {
+      console.log('Trigger check from CDU');
       this.setIsBodyOverflowing();
     }
   }

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -1,14 +1,22 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, createRef } from 'react';
 import PropTypes from 'prop-types';
 import omit from 'lodash.omit';
 import cx from 'classnames';
+import ReactResizeDetector from 'react-resize-detector';
 
 import theme from './theme.css';
 
 import { Banner, Box, Button, ButtonGroup, DialogBase, Heading2, Heading3, Link } from '../../index';
 import { COLORS } from '../../constants';
+import { isElementOverflowingY } from '../utils/utils';
 
 class Dialog extends PureComponent {
+  bodyRef = createRef();
+
+  state = {
+    isBodyOverFlowing: false,
+  };
+
   getHeader = () => {
     const { headerColor, headerIcon, headingLevel, onCloseClick, title } = this.props;
 
@@ -21,14 +29,27 @@ class Dialog extends PureComponent {
 
   getFooter = () => {
     const { tertiaryAction, secondaryAction, primaryAction } = this.props;
+    const { isBodyOverFlowing } = this.state;
 
     return (
-      <ButtonGroup justifyContent="flex-end" padding={4}>
+      <ButtonGroup
+        className={isBodyOverFlowing ? theme['has-border'] : undefined}
+        justifyContent="flex-end"
+        padding={4}
+      >
         {tertiaryAction && <Link inherit={false} {...tertiaryAction} />}
         {secondaryAction && <Button {...secondaryAction} />}
         <Button level="primary" {...primaryAction} />
       </ButtonGroup>
     );
+  };
+
+  setIsBodyOverflowing = () => {
+    if (isElementOverflowingY(this.bodyRef.current.node)) {
+      this.setState({ isBodyOverFlowing: true });
+    } else {
+      this.setState({ isBodyOverFlowing: false });
+    }
   };
 
   render() {
@@ -47,10 +68,11 @@ class Dialog extends PureComponent {
     return (
       <DialogBase className={classNames} {...restProps}>
         {title && this.getHeader()}
-        <Box className={theme['dialog-body']} padding={4}>
+        <Box className={theme['dialog-body']} padding={4} ref={this.bodyRef}>
           {children}
         </Box>
         {this.getFooter()}
+        <ReactResizeDetector handleHeight onResize={this.setIsBodyOverflowing} />
       </DialogBase>
     );
   }

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -17,6 +17,12 @@ class Dialog extends PureComponent {
     isBodyOverFlowing: false,
   };
 
+  componentDidUpdate(prevProps) {
+    if (this.props.active !== prevProps.active) {
+      this.setIsBodyOverflowing();
+    }
+  }
+
   getHeader = () => {
     const { headerColor, headerIcon, headingLevel, onCloseClick, title } = this.props;
 
@@ -45,7 +51,9 @@ class Dialog extends PureComponent {
   };
 
   setIsBodyOverflowing = () => {
-    this.setState({ isBodyOverFlowing: isElementOverflowingY(this.bodyRef.current.node) });
+    if (this.bodyRef.current) {
+      this.setState({ isBodyOverFlowing: isElementOverflowingY(this.bodyRef.current.node) });
+    }
   };
 
   render() {

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -19,7 +19,6 @@ class Dialog extends PureComponent {
 
   componentDidUpdate(prevProps) {
     if (this.props.active && !prevProps.active) {
-      console.log('Trigger check from CDU');
       this.setIsBodyOverflowing();
     }
   }

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -45,11 +45,7 @@ class Dialog extends PureComponent {
   };
 
   setIsBodyOverflowing = () => {
-    if (isElementOverflowingY(this.bodyRef.current.node)) {
-      this.setState({ isBodyOverFlowing: true });
-    } else {
-      this.setState({ isBodyOverFlowing: false });
-    }
+    this.setState({ isBodyOverFlowing: isElementOverflowingY(this.bodyRef.current.node) });
   };
 
   render() {

--- a/src/components/dialog/theme.css
+++ b/src/components/dialog/theme.css
@@ -81,3 +81,7 @@
   flex: 1;
   overflow: auto;
 }
+
+.has-border {
+  border-top: 1px solid var(--color-neutral);
+}


### PR DESCRIPTION
### Description

When the body of a [`Dialog`](https://components.teamleader.design/?selectedKind=Dialogs&selectedStory=Dialog&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs&background=%23ffffff) is overflowing, there used to be a weird transition between it and the footer.

But fear no more, as in this PR we render a border on top of the footer, when the body is scrollable (as in the [specs](https://zpl.io/a7ZEgqM)).

You might be wondering: "But hey, if the `setIsBodyOverflowing` only is called on resize, then how can the border be correctly rendered when you initially open the `Dialog`? 🤔"

Well, this is because scrolling on the page is locked when you open the `Dialog`.
This triggers the resize, thus also setting the border correctly when initially opening the `Dialog`.

If this was not the case, I'd have to call `setIsBodyOverflowing` in `componentDidUpdate` (if the `active` prop changed).

_**Q: Do you guys think I still have to add this or is it good as is?**_ 

#### Screenshot before this PR

<img width="585" alt="screenshot 2018-11-13 at 20 19 45" src="https://user-images.githubusercontent.com/23736202/48437400-8bf9c700-e781-11e8-842a-9d5806467783.png">

#### Screenshot after this PR

<img width="586" alt="screenshot 2018-11-13 at 20 19 13" src="https://user-images.githubusercontent.com/23736202/48437409-92883e80-e781-11e8-8e10-358d56f6b9bf.png">

### Breaking changes

None.
