### PR TITLE
DataGrid: add displayName to all subcomponents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `ProgressTracker` & `DataGrid`: added a `displayName` to their sub components to improve documentation in Storybook. ([@driesd](https://github.com/driesd) in [#462](https://github.com/teamleadercrm/ui/pull/462))
+
 ### Changed
 
 - `Dialog`: the body of the `Dialog` renders scrollable, when its content starts to overflow ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#456](https://github.com/teamleadercrm/ui/pull/456))

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -226,10 +226,16 @@ DataGrid.defaultProps = {
 };
 
 DataGrid.HeaderRow = HeaderRow;
+DataGrid.HeaderRow.displayName = 'DataGrid.HeaderRow';
 DataGrid.HeaderRowOverlay = HeaderRowOverlay;
+DataGrid.HeaderRowOverlay.displayName = 'DataGrid.HeaderRowOverlay';
 DataGrid.HeaderCell = HeaderCell;
+DataGrid.HeaderCell.displayName = 'DataGrid.HeaderCell';
 DataGrid.BodyRow = BodyRow;
+DataGrid.BodyRow.displayName = 'DataGrid.BodyRow';
 DataGrid.Cell = Cell;
+DataGrid.Cell.displayName = 'DataGrid.Cell';
 DataGrid.FooterRow = FooterRow;
+DataGrid.FooterRow.displayName = 'DataGrid.FooterRow';
 
 export default DataGrid;

--- a/src/components/progressTracker/ProgressTracker.js
+++ b/src/components/progressTracker/ProgressTracker.js
@@ -48,5 +48,6 @@ ProgressTracker.defaultProps = {
 };
 
 ProgressTracker.ProgressStep = ProgressStep;
+ProgressTracker.ProgressStep.displayName = 'ProgressTracker.ProgressStep';
 
 export default ProgressTracker;


### PR DESCRIPTION
### Description

This PR adds a `displayName` to the (static) subcomponents of:

* DataGrid
* ProgressTracker

It improves the documentation in Storybook, so the component names are now correct.

#### Screenshot before this PR

![schermafdruk 2018-11-14 10 03 35](https://user-images.githubusercontent.com/5336831/48471750-e7b16800-e7f4-11e8-8e98-6413b41fe82f.png)

![schermafdruk 2018-11-14 10 02 59](https://user-images.githubusercontent.com/5336831/48471757-ec761c00-e7f4-11e8-8a4b-85eac7156d39.png)

#### Screenshot after this PR

![schermafdruk 2018-11-14 10 04 14](https://user-images.githubusercontent.com/5336831/48471726-da947900-e7f4-11e8-9868-7d2cb0c7c46b.png)

![schermafdruk 2018-11-14 10 02 29](https://user-images.githubusercontent.com/5336831/48471732-df592d00-e7f4-11e8-97bf-f76be18f7b12.png)

### Breaking changes

None.
