### PR TITLE
Checkbox & Toggle: replace splitProps with pickBoxProps & omitBoxProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `Dialog`: the body of the `Dialog` renders scrollable, when its content starts to overflow ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#456](https://github.com/teamleadercrm/ui/pull/456))
 - `RadioButton`: replaced the `splitProps` class method with our reusable `pickBoxProps` & `omitBoxProps`. ([@driesd](https://github.com/driesd) in [#460](https://github.com/teamleadercrm/ui/pull/460))
+- `Checkbox` & `Toggle`: replaced the `splitProps` class method with our reusable `pickBoxProps` & `omitBoxProps`. ([@driesd](https://github.com/driesd) in [#463](https://github.com/teamleadercrm/ui/pull/463))
 
 ### Deprecated
 

--- a/src/components/checkbox/Checkbox.js
+++ b/src/components/checkbox/Checkbox.js
@@ -68,12 +68,12 @@ class Checkbox extends PureComponent {
 
   render() {
     const { checked, disabled, className, size, label, children, indeterminate, ...others } = this.props;
-    const rest = omit(others, ['onChange']);
     const TextElement = size === 'small' ? TextSmall : size === 'medium' ? TextBody : TextDisplay;
     const IconCheckmark = size === 'large' ? IconCheckmarkMediumOutline : IconCheckmarkSmallOutline;
 
-    const boxProps = pickBoxProps(rest);
-    const inputProps = omitBoxProps(rest);
+    const restProps = omit(others, ['onChange']);
+    const boxProps = pickBoxProps(restProps);
+    const inputProps = omitBoxProps(restProps);
 
     const classNames = cx(
       theme['checkbox'],

--- a/src/components/checkbox/Checkbox.js
+++ b/src/components/checkbox/Checkbox.js
@@ -32,40 +32,6 @@ class Checkbox extends PureComponent {
     }
   }
 
-  splitProps(props) {
-    const availableBoxProps = [
-      'margin',
-      'marginVertical',
-      'marginHorizontal',
-      'marginBottom',
-      'marginLeft',
-      'marginRight',
-      'marginTop',
-      'padding',
-      'paddingHorizontal',
-      'paddingVertical',
-      'paddingBottom',
-      'paddingLeft',
-      'paddingRight',
-      'paddingTop',
-    ];
-
-    const boxProps = {};
-    const inputProps = {};
-
-    Object.keys(props).forEach(key => {
-      const value = props[key];
-
-      if (availableBoxProps.includes(key)) {
-        boxProps[key] = value;
-      } else {
-        inputProps[key] = value;
-      }
-    });
-
-    return { boxProps, inputProps };
-  }
-
   render() {
     const { checked, disabled, className, size, label, children, indeterminate, ...others } = this.props;
     const TextElement = size === 'small' ? TextSmall : size === 'medium' ? TextBody : TextDisplay;

--- a/src/components/checkbox/Checkbox.js
+++ b/src/components/checkbox/Checkbox.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import theme from './theme.css';
 import cx from 'classnames';
 import omit from 'lodash.omit';
-import Box from '../box';
+import Box, { omitBoxProps, pickBoxProps } from '../box';
 import { TextBody, TextDisplay, TextSmall } from '../typography';
 import { IconCheckmarkSmallOutline, IconCheckmarkMediumOutline, IconMinusSmallOutline } from '@teamleader/ui-icons';
 
@@ -69,9 +69,11 @@ class Checkbox extends PureComponent {
   render() {
     const { checked, disabled, className, size, label, children, indeterminate, ...others } = this.props;
     const rest = omit(others, ['onChange']);
-    const { boxProps, inputProps } = this.splitProps(rest);
     const TextElement = size === 'small' ? TextSmall : size === 'medium' ? TextBody : TextDisplay;
     const IconCheckmark = size === 'large' ? IconCheckmarkMediumOutline : IconCheckmarkSmallOutline;
+
+    const boxProps = pickBoxProps(rest);
+    const inputProps = omitBoxProps(rest);
 
     const classNames = cx(
       theme['checkbox'],

--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -31,40 +31,6 @@ class Toggle extends PureComponent {
     }
   }
 
-  splitProps(props) {
-    const availableBoxProps = [
-      'margin',
-      'marginVertical',
-      'marginHorizontal',
-      'marginBottom',
-      'marginLeft',
-      'marginRight',
-      'marginTop',
-      'padding',
-      'paddingHorizontal',
-      'paddingVertical',
-      'paddingBottom',
-      'paddingLeft',
-      'paddingRight',
-      'paddingTop',
-    ];
-
-    const boxProps = {};
-    const inputProps = {};
-
-    Object.keys(props).forEach(key => {
-      const value = props[key];
-
-      if (availableBoxProps.includes(key)) {
-        boxProps[key] = value;
-      } else {
-        inputProps[key] = value;
-      }
-    });
-
-    return { boxProps, inputProps };
-  }
-
   render() {
     const { checked, disabled, className, size, label, children, ...others } = this.props;
 

--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -68,9 +68,9 @@ class Toggle extends PureComponent {
   render() {
     const { checked, disabled, className, size, label, children, ...others } = this.props;
 
-    const rest = omit(others, ['onChange']);
-    const boxProps = pickBoxProps(rest);
-    const inputProps = omitBoxProps(rest);
+    const restProps = omit(others, ['onChange']);
+    const boxProps = pickBoxProps(restProps);
+    const inputProps = omitBoxProps(restProps);
 
     const classNames = cx(
       theme['toggle'],

--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import theme from './theme.css';
 import cx from 'classnames';
 import omit from 'lodash.omit';
-import Box from '../box';
+import Box, { omitBoxProps, pickBoxProps } from '../box';
 import { TextBody, TextDisplay, TextSmall } from '../typography';
 
 class Toggle extends PureComponent {
@@ -67,8 +67,10 @@ class Toggle extends PureComponent {
 
   render() {
     const { checked, disabled, className, size, label, children, ...others } = this.props;
+
     const rest = omit(others, ['onChange']);
-    const { boxProps, inputProps } = this.splitProps(rest);
+    const boxProps = pickBoxProps(rest);
+    const inputProps = omitBoxProps(rest);
 
     const classNames = cx(
       theme['toggle'],


### PR DESCRIPTION
### Description

This PR replaces the `splitProps` class method with our reusable `pickBoxProps` & `omitBoxProps` to filter out the correct props.

It affects our `Checkbox` & `Toggle` component.

### Breaking changes

None.
