### PR TITLE
DatePicker: don't change date when a disabled date was selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Fixed
 
+- `DatePicker`: the `DatePickerInput` doesn't select a date anymore when that date has been disabled ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#465](https://github.com/teamleadercrm/ui/pull/465))
+
 ## [0.19.0] - 2018-11-12
 
 ### Added

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -36,8 +36,11 @@ class DatePickerInput extends PureComponent {
     this.setState({ inputHasFocus: true }, () => this.props.onFocus && this.props.onFocus());
   };
 
-  handleInputDateChange = date => {
-    this.setState({ selectedDate: date }, () => this.props.onChange(date));
+  handleInputDateChange = (date, modifiers = {}) => {
+    if (modifiers.disabled) {
+      return;
+    }
+    this.setState({ selectedDay: date }, () => this.props.onChange(date));
   };
 
   renderDayPickerInput = () => {


### PR DESCRIPTION
### Description

When a disabled day is selected (by typing for example), you don't want run the handler.
see: http://react-day-picker.js.org/examples/disabled-interaction

### Breaking changes

- None.