### PR TITLE
[TU-224] Popover: work around default stretching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Popover`: added the `fullHeight` property, if set to false the `Popover` does not stretch more than a set value ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#467](https://github.com/teamleadercrm/ui/pull/467))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -13,7 +13,7 @@ import theme from './theme.css';
 class Popover extends PureComponent {
   popoverRoot = document.createElement('div');
 
-  state = { positioning: { left: 0, top: 0, arrowLeft: 0, arrowTop: 0, maxPopoverHeight: 'initial' } };
+  state = { positioning: { left: 0, top: 0, arrowLeft: 0, arrowTop: 0, maxHeight: 'initial' } };
 
   componentDidMount() {
     document.body.appendChild(this.popoverRoot);
@@ -52,13 +52,13 @@ class Popover extends PureComponent {
 
   getMaxHeight = () => {
     const { fullHeight } = this.props;
-    const { maxPopoverHeight } = this.state.positioning;
+    const { maxHeight } = this.state.positioning;
 
-    if (!fullHeight && maxPopoverHeight > 240) {
+    if (!fullHeight && maxHeight > 240) {
       return 240;
     }
 
-    return maxPopoverHeight;
+    return maxHeight;
   };
 
   setPlacementThrottled = throttle(this.setPlacement, 250);

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -54,7 +54,7 @@ class Popover extends PureComponent {
     const { fullHeight } = this.props;
     const { maxPopoverHeight } = this.state.positioning;
 
-    if (!fullHeight) {
+    if (!fullHeight && maxPopoverHeight > 240) {
       return 240;
     }
 

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -10,6 +10,8 @@ import { events } from '../utils';
 import { calculatePositions } from './positionCalculation';
 import theme from './theme.css';
 
+const MAX_HEIGHT_DEFAULT = 240;
+
 class Popover extends PureComponent {
   popoverRoot = document.createElement('div');
 
@@ -54,8 +56,8 @@ class Popover extends PureComponent {
     const { fullHeight } = this.props;
     const { maxHeight } = this.state.positioning;
 
-    if (!fullHeight && maxHeight > 240) {
-      return 240;
+    if (!fullHeight && maxHeight > MAX_HEIGHT_DEFAULT) {
+      return MAX_HEIGHT_DEFAULT;
     }
 
     return maxHeight;

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -56,7 +56,7 @@ class Popover extends PureComponent {
     const { fullHeight } = this.props;
     const { maxHeight } = this.state.positioning;
 
-    if (!fullHeight && maxHeight > MAX_HEIGHT_DEFAULT) {
+    if (!fullHeight && (maxHeight > MAX_HEIGHT_DEFAULT || maxHeight === 'initial')) {
       return MAX_HEIGHT_DEFAULT;
     }
 

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -50,10 +50,21 @@ class Popover extends PureComponent {
     }
   };
 
+  getMaxHeight = () => {
+    const { fullHeight } = this.props;
+    const { maxPopoverHeight } = this.state.positioning;
+
+    if (!fullHeight) {
+      return 240;
+    }
+
+    return maxPopoverHeight;
+  };
+
   setPlacementThrottled = throttle(this.setPlacement, 250);
 
   render() {
-    const { left, top, arrowLeft, arrowTop, maxPopoverHeight } = this.state.positioning;
+    const { left, top, arrowLeft, arrowTop } = this.state.positioning;
 
     const {
       active,
@@ -61,7 +72,6 @@ class Popover extends PureComponent {
       children,
       className,
       color,
-      fullHeight,
       lockScroll,
       onOverlayClick,
       onEscKeyDown,
@@ -74,8 +84,6 @@ class Popover extends PureComponent {
     if (!active) {
       return null;
     }
-
-    console.log(maxPopoverHeight);
 
     const popover = (
       <Transition timeout={0} in={active} appear>
@@ -107,7 +115,7 @@ class Popover extends PureComponent {
                 }}
               >
                 <div className={theme['arrow']} style={{ left: `${arrowLeft}px`, top: `${arrowTop}px` }} />
-                <div className={theme['inner']} style={{ maxHeight: fullHeight ? maxPopoverHeight : '240px' }}>
+                <div className={theme['inner']} style={{ maxHeight: this.getMaxHeight() }}>
                   <div
                     ref={node => {
                       this.popoverContentNode = node;
@@ -169,7 +177,7 @@ Popover.defaultProps = {
   active: true,
   backdrop: 'dark',
   direction: 'south',
-  fullHeight: false,
+  fullHeight: true,
   color: 'neutral',
   lockScroll: true,
   offsetCorrection: 0,

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -61,6 +61,7 @@ class Popover extends PureComponent {
       children,
       className,
       color,
+      fullHeight,
       lockScroll,
       onOverlayClick,
       onEscKeyDown,
@@ -73,6 +74,8 @@ class Popover extends PureComponent {
     if (!active) {
       return null;
     }
+
+    console.log(maxPopoverHeight);
 
     const popover = (
       <Transition timeout={0} in={active} appear>
@@ -104,7 +107,7 @@ class Popover extends PureComponent {
                 }}
               >
                 <div className={theme['arrow']} style={{ left: `${arrowLeft}px`, top: `${arrowTop}px` }} />
-                <div className={theme['inner']} style={{ maxHeight: maxPopoverHeight }}>
+                <div className={theme['inner']} style={{ maxHeight: fullHeight ? maxPopoverHeight : '240px' }}>
                   <div
                     ref={node => {
                       this.popoverContentNode = node;
@@ -140,6 +143,8 @@ Popover.propTypes = {
   color: PropTypes.oneOf(['aqua', 'gold', 'mint', 'neutral', 'ruby', 'teal', 'violet']),
   /** The direction in which the Popover is rendered, is overridden with the opposite direction if the Popover cannot be entirely displayed in the current direction. */
   direction: PropTypes.oneOf(['north', 'south', 'east', 'west']),
+  /** If true, the Popover stretches to fit its content vertically */
+  fullHeight: PropTypes.bool,
   /** The scroll state of the body, if true it will not be scrollable. */
   lockScroll: PropTypes.bool,
   /** The amount of extra translation on the Popover (has no effect if position is "middle" or "center"). */
@@ -164,6 +169,7 @@ Popover.defaultProps = {
   active: true,
   backdrop: 'dark',
   direction: 'south',
+  fullHeight: false,
   color: 'neutral',
   lockScroll: true,
   offsetCorrection: 0,

--- a/src/components/popover/positionCalculation.js
+++ b/src/components/popover/positionCalculation.js
@@ -261,7 +261,7 @@ const getPosition = ({ direction, position, anchorPosition, popoverDimensions })
   }
 };
 
-const getMaxPopoverHeight = ({ direction, anchorPosition, popoverContentEl }) => {
+const getMaxHeight = ({ direction, anchorPosition, popoverContentEl }) => {
   const directionContentRendersOnScreen = isInViewport({
     direction,
     anchorPosition,
@@ -274,7 +274,7 @@ const getMaxPopoverHeight = ({ direction, anchorPosition, popoverContentEl }) =>
   });
 
   if (!directionContentRendersOnScreen && !oppositeDirectionContentRendersOnScreen) {
-    return getMaxPopoverHeightValue({
+    return getMaxHeightValue({
       direction,
       anchorPosition,
     });
@@ -283,7 +283,7 @@ const getMaxPopoverHeight = ({ direction, anchorPosition, popoverContentEl }) =>
   return 'initial';
 };
 
-const getMaxPopoverHeightValue = ({ direction, anchorPosition }) => {
+const getMaxHeightValue = ({ direction, anchorPosition }) => {
   switch (direction) {
     case DIRECTION_NORTH:
       return anchorPosition.top - POPUP_OFFSET * 2;
@@ -307,7 +307,7 @@ export const calculatePositions = (
   const position = getPosition({ direction, position: inputPosition, anchorPosition, popoverDimensions });
 
   return {
-    maxPopoverHeight: getMaxPopoverHeight({
+    maxHeight: getMaxHeight({
       direction,
       anchorPosition,
       popoverContentEl,

--- a/stories/popover.js
+++ b/stories/popover.js
@@ -49,6 +49,7 @@ storiesOf('Popover', module)
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
           direction={select('Direction', directions, 'south')}
+          fullHeight={boolean('fullHeight', true)}
           position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
@@ -70,6 +71,7 @@ storiesOf('Popover', module)
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
           direction={select('Direction', directions, 'south')}
+          fullHeight={boolean('fullHeight', true)}
           position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
@@ -94,6 +96,7 @@ storiesOf('Popover', module)
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
           direction={select('Direction', directions, 'south')}
+          fullHeight={boolean('fullHeight', true)}
           position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
@@ -119,6 +122,7 @@ storiesOf('Popover', module)
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
           direction="south"
+          fullHeight={boolean('fullHeight', true)}
           position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
@@ -143,6 +147,7 @@ storiesOf('Popover', module)
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
           direction={select('Direction', directions, 'south')}
+          fullHeight={boolean('fullHeight', true)}
           position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
@@ -168,6 +173,7 @@ storiesOf('Popover', module)
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
           direction={select('Direction', directions, 'south')}
+          fullHeight={boolean('fullHeight', true)}
           position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
@@ -195,6 +201,7 @@ storiesOf('Popover', module)
           backdrop={select('Backdrop', backdrops, 'transparent')}
           color={select('Color', colors, 'neutral')}
           direction={select('Direction', directions, 'south')}
+          fullHeight={boolean('fullHeight', true)}
           position={select('Position', positions, 'center')}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
@@ -203,10 +210,13 @@ storiesOf('Popover', module)
           offsetCorrection={number('Offset correction', 0)}
         >
           <Box padding={4}>
-            <ul>
-              <li>Lorem ipsum</li>
-              <li>dolor sit amet</li>
-            </ul>
+            <TextBody>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+              dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+              ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+              fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+              mollit anim id est laborum.
+            </TextBody>
           </Box>
         </Popover>
       </State>


### PR DESCRIPTION
### Description

Up in this PR: the [`Popover`](https://components.teamleader.design/?selectedKind=Popover&selectedStory=Basic&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs&background=%23ffffff)!

The `Popover` stretches itself (in height) according to its contents.
It only stopped stretching until it filled all the available space from its anchor point to the edge of the viewport. This made the `Popover` less clear in some cases.

In this PR we keep this default stretching behaviour, but introduce the `fullHeight` prop. Setting this prop to false, will set the height of the `Popover` to a set - to keep things consistent - value.

The `Popover` also squashes itself when its contents would overflow the edge of the viewport. This behaviour is preserved. When the set height would cause the `Popover` to overflow, the `Popover` skips this set value and also starts squashing.

#### Screenshot before this PR

![screenshot 2018-11-19 at 11 08 46](https://user-images.githubusercontent.com/23736202/48700140-90900680-ebeb-11e8-9251-515e8f94c3f2.png)

#### Screenshot after this PR

![screenshot 2018-11-19 at 11 08 58](https://user-images.githubusercontent.com/23736202/48700152-971e7e00-ebeb-11e8-81f0-aeca45c1e899.png)

### Breaking changes

None.
