### PR TITLE
[TU-215] DataGrid: border & rounded corners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@
 
 ### Fixed
 
-- `DataGrid`: prevented the `grey border` from overlaying the `LoadingBar`. ([@driesd](https://github.com/driesd) in [#469](https://github.com/teamleadercrm/ui/pull/469))
-
 ## [0.19.1] - 2018-11-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `DataGrid`: added a `bordered` boolean prop. If `true`, the Datagrid will have rounded corners and a border around it. ([@driesd](https://github.com/driesd) in [#468](https://github.com/teamleadercrm/ui/pull/468))
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- `DataGrid`: prevented the `grey border` from overlaying the `LoadingBar`. ([@driesd](https://github.com/driesd) in [#469](https://github.com/teamleadercrm/ui/pull/469))
+
 ## [0.19.1] - 2018-11-16
 
 ### Added

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -200,6 +200,8 @@ class DataGrid extends PureComponent {
 }
 
 DataGrid.propTypes = {
+  /** If true, datagrid will have a border and rounded corners. */
+  bordered: PropTypes.bool,
   /** The size of the checkbox rendered on the left side of each row */
   checkboxSize: PropTypes.oneOf(['small', 'medium', 'large']),
   /** The content to display inside the data grid. */
@@ -221,6 +223,7 @@ DataGrid.propTypes = {
 };
 
 DataGrid.defaultProps = {
+  bordered: false,
   checkboxSize: 'small',
   processing: false,
 };

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -124,12 +124,13 @@ class DataGrid extends PureComponent {
       stickyFromRight,
       ...others
     } = this.props;
-    const { selectedRows } = this.state;
+    const { isOverflowing, selectedRows } = this.state;
 
     const classNames = cx(
       theme['data-grid'],
       {
         [theme['is-bordered']]: bordered,
+        [theme['is-overflowing']]: isOverflowing,
       },
       className,
     );

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -137,8 +137,8 @@ class DataGrid extends PureComponent {
     return (
       <Box data-teamleader-ui="data-grid" className={classNames} {...rest}>
         {processing && (
-          <div className={cx(theme['loading-bar'])}>
-            <LoadingBar />
+          <div>
+            <LoadingBar className={cx(theme['loading-bar'])} />
           </div>
         )}
         {selectedRows.length > 0 &&

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -136,11 +136,7 @@ class DataGrid extends PureComponent {
 
     return (
       <Box data-teamleader-ui="data-grid" className={classNames} {...rest}>
-        {processing && (
-          <div>
-            <LoadingBar className={cx(theme['loading-bar'])} />
-          </div>
-        )}
+        {processing && <LoadingBar className={cx(theme['loading-bar'])} />}
         {selectedRows.length > 0 &&
           React.Children.map(children, child => {
             if (isComponentOfType(HeaderRowOverlay, child)) {

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -137,8 +137,8 @@ class DataGrid extends PureComponent {
     return (
       <Box data-teamleader-ui="data-grid" className={classNames} {...rest}>
         {processing && (
-          <div>
-            <LoadingBar className={cx(theme['loading-bar'])} />
+          <div className={cx(theme['loading-bar'])}>
+            <LoadingBar />
           </div>
         )}
         {selectedRows.length > 0 &&

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -136,7 +136,11 @@ class DataGrid extends PureComponent {
 
     return (
       <Box data-teamleader-ui="data-grid" className={classNames} {...rest}>
-        {processing && <LoadingBar className={cx(theme['loading-bar'])} />}
+        {processing && (
+          <div>
+            <LoadingBar className={cx(theme['loading-bar'])} />
+          </div>
+        )}
         {selectedRows.length > 0 &&
           React.Children.map(children, child => {
             if (isComponentOfType(HeaderRowOverlay, child)) {

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -113,6 +113,7 @@ class DataGrid extends PureComponent {
 
   render() {
     const {
+      bordered,
       checkboxSize,
       children,
       className,
@@ -124,7 +125,14 @@ class DataGrid extends PureComponent {
     } = this.props;
     const { selectedRows } = this.state;
 
-    const classNames = cx(theme['data-grid'], className);
+    const classNames = cx(
+      theme['data-grid'],
+      {
+        [theme['is-bordered']]: bordered,
+      },
+      className,
+    );
+
     const rest = omit(others, ['comparableId', 'onSelectionChange']);
 
     const sectionLeftClassNames = cx(theme['section'], theme['is-sticky-left'], {

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -13,9 +13,8 @@ import HeaderRow from './HeaderRow';
 import BodyRow from './BodyRow';
 import cx from 'classnames';
 import omit from 'lodash.omit';
-import throttle from 'lodash.throttle';
+import ReactResizeDetector from 'react-resize-detector';
 import theme from './theme.css';
-import { events } from '../utils';
 import { isArray } from 'util';
 
 class DataGrid extends PureComponent {
@@ -26,20 +25,6 @@ class DataGrid extends PureComponent {
 
   rowNodes = new Map();
   scrollableNode = null;
-
-  setCalculatedRowWidthThrottled = () => throttle(this.setCalculatedRowWidth, 16);
-
-  componentDidMount() {
-    events.addEventsToWindow({
-      resize: this.setCalculatedRowWidthThrottled,
-    });
-  }
-
-  componentWillUnmount() {
-    events.removeEventsFromWindow({
-      resize: this.setCalculatedRowWidthThrottled,
-    });
-  }
 
   componentDidUpdate(prevProps) {
     this.handleResize();
@@ -211,6 +196,7 @@ class DataGrid extends PureComponent {
             </div>
           )}
         </Box>
+        <ReactResizeDetector handleWidth onResize={this.handleResize} refreshMode="throttle" refreshRate={16} />
       </Box>
     );
   }

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -42,7 +42,7 @@ class DataGrid extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    this.setCalculatedRowWidth();
+    this.handleResize();
 
     if (prevProps.comparableId !== this.props.comparableId) {
       this.handleSelectionChange([]);
@@ -84,6 +84,15 @@ class DataGrid extends PureComponent {
     });
   };
 
+  handleResize = () => {
+    if (isElementOverflowingX(this.scrollableNode) && this.rowNodes) {
+      this.setCalculatedRowWidth();
+      this.setState({ isOverflowing: true });
+    } else {
+      this.setState({ isOverflowing: false });
+    }
+  };
+
   handleSelectionChange(selection, event = null) {
     if (this.props.onSelectionChange) {
       this.props.onSelectionChange(selection, event);
@@ -91,25 +100,23 @@ class DataGrid extends PureComponent {
   }
 
   setCalculatedRowWidth = () => {
-    if (isElementOverflowingX(this.scrollableNode) && this.rowNodes) {
-      const rowDOMNodes = [];
-      let maxRowWidth = 0;
+    const rowDOMNodes = [];
+    let maxRowWidth = 0;
 
-      [...this.rowNodes.values()].filter(rowNode => rowNode != null).forEach(rowNode => {
-        const rowDOMNode = ReactDOM.findDOMNode(rowNode);
+    [...this.rowNodes.values()].filter(rowNode => rowNode != null).forEach(rowNode => {
+      const rowDOMNode = ReactDOM.findDOMNode(rowNode);
 
-        if (rowDOMNode) {
-          const totalRowChildrenWidth = [...rowDOMNode.children]
-            .map(child => child.offsetWidth)
-            .reduce((accumulatedChildWidth, currentChildWidth) => accumulatedChildWidth + currentChildWidth);
+      if (rowDOMNode) {
+        const totalRowChildrenWidth = [...rowDOMNode.children]
+          .map(child => child.offsetWidth)
+          .reduce((accumulatedChildWidth, currentChildWidth) => accumulatedChildWidth + currentChildWidth);
 
-          maxRowWidth = maxRowWidth < totalRowChildrenWidth ? totalRowChildrenWidth : maxRowWidth;
-          rowDOMNodes.push(rowDOMNode);
-        }
-      });
+        maxRowWidth = maxRowWidth < totalRowChildrenWidth ? totalRowChildrenWidth : maxRowWidth;
+        rowDOMNodes.push(rowDOMNode);
+      }
+    });
 
-      rowDOMNodes.forEach(rowDOMNode => (rowDOMNode.style.minWidth = `${maxRowWidth}px`));
-    }
+    rowDOMNodes.forEach(rowDOMNode => (rowDOMNode.style.minWidth = `${maxRowWidth}px`));
   };
 
   render() {

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -20,6 +20,7 @@ import { isArray } from 'util';
 
 class DataGrid extends PureComponent {
   state = {
+    isOverflowing: false,
     selectedRows: [],
   };
 

--- a/src/components/datagrid/HeaderRowOverlay/theme.css
+++ b/src/components/datagrid/HeaderRowOverlay/theme.css
@@ -7,6 +7,7 @@
   right: 0;
   height: 48px;
   z-index: 3;
+  border-top-right-radius: 4px;
 
   &.data-grid-checkbox-size-small {
     left: 60px;

--- a/src/components/datagrid/theme.css
+++ b/src/components/datagrid/theme.css
@@ -127,11 +127,9 @@
 }
 
 .loading-bar {
-  background: var(--color-neutral-lightest);
   position: absolute;
   top: 48px;
   left: 0;
-  right: 0;
   z-index: 3;
 }
 

--- a/src/components/datagrid/theme.css
+++ b/src/components/datagrid/theme.css
@@ -81,6 +81,24 @@
   .section:last-child .row:first-child .cell:last-child {
     border-top-right-radius: 4px;
   }
+
+  &:not(.is-overflowing) {
+    .section:first-child .row:last-child,
+    .section:first-child .row:last-child .cell:first-child {
+      border-bottom-left-radius: 4px;
+    }
+
+    .section:last-child .row:last-child,
+    .section:last-child .row:last-child .cell:last-child {
+      border-bottom-right-radius: 4px;
+    }
+
+    .row:last-child {
+      .cell {
+        border-bottom: 0;
+      }
+    }
+  }
 }
 
 .is-sticky-left {

--- a/src/components/datagrid/theme.css
+++ b/src/components/datagrid/theme.css
@@ -127,9 +127,11 @@
 }
 
 .loading-bar {
+  background: var(--color-neutral-lightest);
   position: absolute;
   top: 48px;
   left: 0;
+  right: 0;
   z-index: 3;
 }
 

--- a/src/components/datagrid/theme.css
+++ b/src/components/datagrid/theme.css
@@ -68,6 +68,21 @@
   }
 }
 
+.is-bordered {
+  border: 1px solid var(--color-neutral);
+  border-radius: 4px;
+
+  .section:first-child .row:first-child,
+  .section:first-child .row:first-child .cell:first-child {
+    border-top-left-radius: 4px;
+  }
+
+  .section:last-child .row:first-child,
+  .section:last-child .row:first-child .cell:last-child {
+    border-top-right-radius: 4px;
+  }
+}
+
 .is-sticky-left {
   max-width: 60%;
 }

--- a/stories/datagrid.js
+++ b/stories/datagrid.js
@@ -30,6 +30,7 @@ storiesOf('DataGrids', module)
   })
   .add('Basic', () => (
     <DataGrid
+      bordered={boolean('bordered', false)}
       selectable={boolean('Selectable', true)}
       comparableId={1}
       onSelectionChange={handleRowSelectionChange}
@@ -86,6 +87,8 @@ storiesOf('DataGrids', module)
             <DataGrid.Cell soft>{row.column4}</DataGrid.Cell>
             <DataGrid.Cell align="right" flex="min-width" preventOverflow={false}>
               <IconMenu position="top-right">
+                <MenuItem onClick={() => console.log('onClick: delete row')}>Duplicate row</MenuItem>
+                <MenuItem onClick={() => console.log('onClick: delete row')}>Inactive row</MenuItem>
                 <MenuItem onClick={() => console.log('onClick: delete row')}>Remove row</MenuItem>
               </IconMenu>
             </DataGrid.Cell>
@@ -96,6 +99,7 @@ storiesOf('DataGrids', module)
   ))
   .add('with footer', () => (
     <DataGrid
+      bordered={boolean('bordered', false)}
       selectable={boolean('Selectable', true)}
       comparableId={1}
       onSelectionChange={handleRowSelectionChange}
@@ -149,6 +153,8 @@ storiesOf('DataGrids', module)
             <DataGrid.Cell soft>{row.column4}</DataGrid.Cell>
             <DataGrid.Cell align="right" flex="min-width" preventOverflow={false}>
               <IconMenu position="top-right">
+                <MenuItem onClick={() => console.log('onClick: delete row')}>Duplicate row</MenuItem>
+                <MenuItem onClick={() => console.log('onClick: delete row')}>Inactive row</MenuItem>
                 <MenuItem onClick={() => console.log('onClick: delete row')}>Remove row</MenuItem>
               </IconMenu>
             </DataGrid.Cell>
@@ -162,6 +168,7 @@ storiesOf('DataGrids', module)
   ))
   .add('with sticky columns', () => (
     <DataGrid
+      bordered={boolean('bordered', false)}
       selectable={boolean('Selectable', true)}
       stickyFromLeft={number('Sticky from left', 3)}
       stickyFromRight={number('Sticky from right', 1)}
@@ -217,6 +224,8 @@ storiesOf('DataGrids', module)
             <DataGrid.Cell soft>{row.column4}</DataGrid.Cell>
             <DataGrid.Cell align="right" flex="min-width" preventOverflow={false}>
               <IconMenu position="top-right">
+                <MenuItem onClick={() => console.log('onClick: delete row')}>Duplicate row</MenuItem>
+                <MenuItem onClick={() => console.log('onClick: delete row')}>Inactive row</MenuItem>
                 <MenuItem onClick={() => console.log('onClick: delete row')}>Remove row</MenuItem>
               </IconMenu>
             </DataGrid.Cell>
@@ -227,6 +236,7 @@ storiesOf('DataGrids', module)
   ))
   .add('Advanced', () => (
     <DataGrid
+      bordered={boolean('bordered', false)}
       selectable={boolean('Selectable', true)}
       stickyFromLeft={number('Sticky from left', 3)}
       stickyFromRight={number('Sticky from right', 1)}
@@ -282,6 +292,8 @@ storiesOf('DataGrids', module)
             <DataGrid.Cell soft>{row.column4}</DataGrid.Cell>
             <DataGrid.Cell align="right" flex="min-width" preventOverflow={false}>
               <IconMenu position="top-right">
+                <MenuItem onClick={() => console.log('onClick: delete row')}>Duplicate row</MenuItem>
+                <MenuItem onClick={() => console.log('onClick: delete row')}>Inactive row</MenuItem>
                 <MenuItem onClick={() => console.log('onClick: delete row')}>Remove row</MenuItem>
               </IconMenu>
             </DataGrid.Cell>


### PR DESCRIPTION
### Description

This PR adds a `bordered` boolean prop. If `true`, the `Datagrid` will have rounded corners and a border around it.

**Note:** I had to `revert` the `4 latest commits` that were meant to for a next PR. Sorry for that 🙈 

#### Screenshot before this PR

![schermafdruk 2018-11-16 15 11 54](https://user-images.githubusercontent.com/5336831/48626529-5a1b7700-e9b2-11e8-9ca7-c4026fe691ba.png)

#### Screenshot after this PR

![schermafdruk 2018-11-16 15 11 32](https://user-images.githubusercontent.com/5336831/48626541-6273b200-e9b2-11e8-965b-47d2ec596cbd.png)

### Breaking changes

None.
