### PR TITLE
[TU-155] Datagrid: prevent grey border from overlaying the loading bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `DataGrid`: prevented the `grey border` from overlaying the `LoadingBar`. ([@driesd](https://github.com/driesd) in [#469](https://github.com/teamleadercrm/ui/pull/469))
+
 ## [0.19.1] - 2018-11-16
 
 ### Added

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -134,7 +134,11 @@ class DataGrid extends PureComponent {
 
     return (
       <Box data-teamleader-ui="data-grid" className={classNames} {...rest}>
-        {processing && <LoadingBar className={cx(theme['loading-bar'])} />}
+        {processing && (
+          <div>
+            <LoadingBar className={cx(theme['loading-bar'])} />
+          </div>
+        )}
         {selectedRows.length > 0 &&
           React.Children.map(children, child => {
             if (isComponentOfType(HeaderRowOverlay, child)) {

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -135,8 +135,8 @@ class DataGrid extends PureComponent {
     return (
       <Box data-teamleader-ui="data-grid" className={classNames} {...rest}>
         {processing && (
-          <div>
-            <LoadingBar className={cx(theme['loading-bar'])} />
+          <div className={cx(theme['loading-bar'])}>
+            <LoadingBar />
           </div>
         )}
         {selectedRows.length > 0 &&

--- a/src/components/datagrid/theme.css
+++ b/src/components/datagrid/theme.css
@@ -94,9 +94,11 @@
 }
 
 .loading-bar {
+  background: var(--color-neutral-lightest);
   position: absolute;
   top: 48px;
   left: 0;
+  right: 0;
   z-index: 3;
 }
 


### PR DESCRIPTION
### Description

This PR adds a `wrapper` with `white background` around the `LoadingBar` of our `DataGrid` component. This way we make sure the underlaying grey border stays behind the LoadingBar.

#### Screenshot before this PR

![schermafdruk 2018-11-16 15 46 49](https://user-images.githubusercontent.com/5336831/48628205-e334ad00-e9b6-11e8-84a5-9336517279db.png)

#### Screenshot after this PR

![schermafdruk 2018-11-16 15 29 42](https://user-images.githubusercontent.com/5336831/48628135-ba141c80-e9b6-11e8-951c-fb3d20ba32be.png)

### Breaking changes

None.
