### PR TITLE
Remove blue ouline when clicking on a Link with element='button'

### DIFF
--- a/src/components/link/theme.css
+++ b/src/components/link/theme.css
@@ -19,6 +19,10 @@
     margin-left: var(--spacer-smallest);
   }
 
+  &:active {
+    outline: 0;
+  }
+
   &:not(.inherit) {
     color: var(--color-aqua-dark);
     font-family: var(--font-family-regular);


### PR DESCRIPTION
### Description

This PR **removes** the `blue outline` when clicking on a `Link` with `element='button'`.

#### Screenshot before this PR

[add screenshot here]

#### Screenshot after this PR

[add screenshot here]

### Breaking changes

None.