### PR TITLE
[TU-219] DataGrid: make row fully clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - `DataGrid`: added a sort icon to the `HeaderCell` indicate a field is sortable. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#483](https://github.com/teamleadercrm/ui/pull/483))
+- `DataGrid`: made the body rows fully clickable & added a mouse over effect. ([@driesd](https://github.com/driesd) in [#473](https://github.com/teamleadercrm/ui/pull/473))
 
 ### Changed
 

--- a/src/components/datagrid/BodyRow.js
+++ b/src/components/datagrid/BodyRow.js
@@ -15,6 +15,7 @@ class BodyRow extends PureComponent {
       hovered,
       sliceFrom,
       sliceTo,
+      onClick,
       onSelectionChange,
       selected,
       selectable,
@@ -23,7 +24,13 @@ class BodyRow extends PureComponent {
 
     const childrenArray = Array.isArray(children) ? children : [children];
     const childrenSliced = childrenArray.slice(sliceFrom, sliceTo);
-    const classNames = cx(theme['body-row'], className);
+    const classNames = cx(
+      theme['body-row'],
+      {
+        [theme['has-pointer-cursor']]: onClick,
+      },
+      className,
+    );
 
     return (
       <Row

--- a/src/components/datagrid/BodyRow.js
+++ b/src/components/datagrid/BodyRow.js
@@ -7,6 +7,11 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class BodyRow extends PureComponent {
+  handleClick = event => {
+    const { onClick } = this.props;
+    onClick && onClick(event);
+  };
+
   render() {
     const {
       className,
@@ -37,6 +42,7 @@ class BodyRow extends PureComponent {
         backgroundColor={hovered ? 'neutral' : 'white'}
         className={classNames}
         data-teamleader-ui="datagrid-body-row"
+        onClick={this.handleClick}
         {...others}
       >
         {selectable && (

--- a/src/components/datagrid/BodyRow.js
+++ b/src/components/datagrid/BodyRow.js
@@ -6,10 +6,14 @@ import Row from './Row';
 import cx from 'classnames';
 import theme from './theme.css';
 
+const allowedParentNodes = ['datagrid-body-row', 'datagrid-cell'];
+
 class BodyRow extends PureComponent {
   handleClick = event => {
-    const { onClick } = this.props;
-    onClick && onClick(event);
+    if (allowedParentNodes.includes(event.target.parentNode.dataset.teamleaderUi)) {
+      const { onClick } = this.props;
+      onClick && onClick(event);
+    }
   };
 
   render() {

--- a/src/components/datagrid/BodyRow.js
+++ b/src/components/datagrid/BodyRow.js
@@ -12,6 +12,7 @@ class BodyRow extends PureComponent {
       className,
       checkboxSize,
       children,
+      hovered,
       sliceFrom,
       sliceTo,
       onSelectionChange,
@@ -25,7 +26,12 @@ class BodyRow extends PureComponent {
     const classNames = cx(theme['body-row'], className);
 
     return (
-      <Row className={classNames} data-teamleader-ui="datagrid-body-row" {...others}>
+      <Row
+        backgroundColor={hovered ? 'neutral' : 'white'}
+        className={classNames}
+        data-teamleader-ui="datagrid-body-row"
+        {...others}
+      >
         {selectable && (
           <Cell align="center" flex="min-width">
             <Checkbox checked={selected} onChange={onSelectionChange} size={checkboxSize} />
@@ -44,6 +50,8 @@ BodyRow.propTypes = {
   className: PropTypes.string,
   /** The cells to display inside the row. */
   children: PropTypes.any,
+  /** If true, the row will show a hover state */
+  hovered: PropTypes.bool,
   /** Callback function that is fired when the checkbox on the left side has changed. */
   onSelectionChange: PropTypes.func,
   /** If true, checkboxes will be rendered on the left side of each row. */

--- a/src/components/datagrid/BodyRow.js
+++ b/src/components/datagrid/BodyRow.js
@@ -52,6 +52,8 @@ BodyRow.propTypes = {
   children: PropTypes.any,
   /** If true, the row will show a hover state */
   hovered: PropTypes.bool,
+  /** Callback function that is fired when the row is clicked */
+  onClick: PropTypes.func,
   /** Callback function that is fired when the checkbox on the left side has changed. */
   onSelectionChange: PropTypes.func,
   /** If true, checkboxes will be rendered on the left side of each row. */

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -54,6 +54,20 @@ class DataGrid extends PureComponent {
     this.handleSelectionChange(selectedBodyRowIndexes, event);
   };
 
+  handleBodyRowMouseOver = (row, event) => {
+    const { onClick, onMouseOver } = row.props;
+
+    onClick && this.setState({ hoveredRow: row.key });
+    onMouseOver && onMouseOver(event);
+  };
+
+  handleBodyRowMouseOut = (row, event) => {
+    const { onClick, onMouseOut } = row.props;
+
+    onClick && this.setState({ hoveredRow: null });
+    onMouseOut && onMouseOut(event);
+  };
+
   handleBodyRowSelectionChange = (rowIndex, event) => {
     this.setState(prevState => {
       const selectedRows = prevState.selectedRows.includes(rowIndex)
@@ -150,6 +164,8 @@ class DataGrid extends PureComponent {
                   return React.cloneElement(child, {
                     checkboxSize,
                     hovered: hoveredRow === child.key,
+                    onMouseOver: event => this.handleBodyRowMouseOver(child, event),
+                    onMouseOut: event => this.handleBodyRowMouseOut(child, event),
                     onSelectionChange: (checked, event) => this.handleBodyRowSelectionChange(child.key, event),
                     selected: selectedRows.indexOf(child.key) !== -1,
                     selectable,
@@ -175,6 +191,8 @@ class DataGrid extends PureComponent {
               } else if (isComponentOfType(BodyRow, child)) {
                 return React.cloneElement(child, {
                   hovered: hoveredRow === child.key,
+                  onMouseOver: event => this.handleBodyRowMouseOver(child, event),
+                  onMouseOut: event => this.handleBodyRowMouseOut(child, event),
                   sliceFrom: stickyFromLeft > 0 ? stickyFromLeft : 0,
                   sliceTo: stickyFromRight > 0 ? -stickyFromRight : undefined,
                   ref: rowNode => this.rowNodes.set(key, rowNode),
@@ -190,6 +208,8 @@ class DataGrid extends PureComponent {
                 } else if (isComponentOfType(BodyRow, child)) {
                   return React.cloneElement(child, {
                     hovered: hoveredRow === child.key,
+                    onMouseOver: event => this.handleBodyRowMouseOver(child, event),
+                    onMouseOut: event => this.handleBodyRowMouseOut(child, event),
                     sliceFrom: -stickyFromRight,
                   });
                 }

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -108,7 +108,7 @@ class DataGrid extends PureComponent {
       stickyFromRight,
       ...others
     } = this.props;
-    const { selectedRows } = this.state;
+    const { hoveredRow, selectedRows } = this.state;
 
     const classNames = cx(theme['data-grid'], className);
     const rest = omit(others, ['comparableId', 'onSelectionChange']);
@@ -149,6 +149,7 @@ class DataGrid extends PureComponent {
                 } else if (isComponentOfType(BodyRow, child)) {
                   return React.cloneElement(child, {
                     checkboxSize,
+                    hovered: hoveredRow === child.key,
                     onSelectionChange: (checked, event) => this.handleBodyRowSelectionChange(child.key, event),
                     selected: selectedRows.indexOf(child.key) !== -1,
                     selectable,
@@ -165,8 +166,15 @@ class DataGrid extends PureComponent {
           )}
           <div className={cx(theme['section'], theme['is-scrollable'])} ref={node => (this.scrollableNode = node)}>
             {React.Children.map(children, (child, key) => {
-              if (!isComponentOfType(HeaderRowOverlay, child)) {
+              if (isComponentOfType(HeaderRow, child) || isComponentOfType(FooterRow, child)) {
                 return React.cloneElement(child, {
+                  sliceFrom: stickyFromLeft > 0 ? stickyFromLeft : 0,
+                  sliceTo: stickyFromRight > 0 ? -stickyFromRight : undefined,
+                  ref: rowNode => this.rowNodes.set(key, rowNode),
+                });
+              } else if (isComponentOfType(BodyRow, child)) {
+                return React.cloneElement(child, {
+                  hovered: hoveredRow === child.key,
                   sliceFrom: stickyFromLeft > 0 ? stickyFromLeft : 0,
                   sliceTo: stickyFromRight > 0 ? -stickyFromRight : undefined,
                   ref: rowNode => this.rowNodes.set(key, rowNode),
@@ -177,8 +185,13 @@ class DataGrid extends PureComponent {
           {stickyFromRight > 0 && (
             <div className={cx(theme['section'], theme['has-blend-left'])}>
               {React.Children.map(children, child => {
-                if (!isComponentOfType(HeaderRowOverlay, child)) {
+                if (isComponentOfType(HeaderRow, child) || isComponentOfType(FooterRow, child)) {
                   return React.cloneElement(child, { sliceFrom: -stickyFromRight });
+                } else if (isComponentOfType(BodyRow, child)) {
+                  return React.cloneElement(child, {
+                    hovered: hoveredRow === child.key,
+                    sliceFrom: -stickyFromRight,
+                  });
                 }
               })}
             </div>

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -19,6 +19,7 @@ import { isArray } from 'util';
 
 class DataGrid extends PureComponent {
   state = {
+    hoveredRow: null,
     selectedRows: [],
   };
 

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -55,14 +55,14 @@ class DataGrid extends PureComponent {
     this.handleSelectionChange(selectedBodyRowIndexes, event);
   };
 
-  handleBodyRowMouseOver = (row, event) => {
+  handleBodyRowMouseEnter = (row, event) => {
     const { onClick, onMouseOver } = row.props;
 
     onClick && this.setState({ hoveredRow: row.key });
     onMouseOver && onMouseOver(event);
   };
 
-  handleBodyRowMouseOut = (row, event) => {
+  handleBodyRowMouseLeave = (row, event) => {
     const { onClick, onMouseOut } = row.props;
 
     onClick && this.setState({ hoveredRow: null });
@@ -181,8 +181,8 @@ class DataGrid extends PureComponent {
                   return React.cloneElement(child, {
                     checkboxSize,
                     hovered: hoveredRow === child.key,
-                    onMouseOver: event => this.handleBodyRowMouseOver(child, event),
-                    onMouseOut: event => this.handleBodyRowMouseOut(child, event),
+                    onMouseEnter: event => this.handleBodyRowMouseEnter(child, event),
+                    onMouseLeave: event => this.handleBodyRowMouseLeave(child, event),
                     onSelectionChange: (checked, event) => this.handleBodyRowSelectionChange(child.key, event),
                     selected: selectedRows.indexOf(child.key) !== -1,
                     selectable,
@@ -208,8 +208,8 @@ class DataGrid extends PureComponent {
               } else if (isComponentOfType(BodyRow, child)) {
                 return React.cloneElement(child, {
                   hovered: hoveredRow === child.key,
-                  onMouseOver: event => this.handleBodyRowMouseOver(child, event),
-                  onMouseOut: event => this.handleBodyRowMouseOut(child, event),
+                  onMouseEnter: event => this.handleBodyRowMouseEnter(child, event),
+                  onMouseLeave: event => this.handleBodyRowMouseLeave(child, event),
                   sliceFrom: stickyFromLeft > 0 ? stickyFromLeft : 0,
                   sliceTo: stickyFromRight > 0 ? -stickyFromRight : undefined,
                   ref: rowNode => this.rowNodes.set(key, rowNode),
@@ -225,8 +225,8 @@ class DataGrid extends PureComponent {
                 } else if (isComponentOfType(BodyRow, child)) {
                   return React.cloneElement(child, {
                     hovered: hoveredRow === child.key,
-                    onMouseOver: event => this.handleBodyRowMouseOver(child, event),
-                    onMouseOut: event => this.handleBodyRowMouseOut(child, event),
+                    onMouseEnter: event => this.handleBodyRowMouseEnter(child, event),
+                    onMouseLeave: event => this.handleBodyRowMouseLeave(child, event),
                     sliceFrom: -stickyFromRight,
                   });
                 }

--- a/src/components/datagrid/theme.css
+++ b/src/components/datagrid/theme.css
@@ -68,6 +68,10 @@
   }
 }
 
+.has-pointer-cursor {
+  cursor: pointer;
+}
+
 .is-sticky-left {
   max-width: 60%;
 }

--- a/stories/datagrid.js
+++ b/stories/datagrid.js
@@ -63,7 +63,7 @@ storiesOf('DataGrids', module)
       </DataGrid.HeaderRow>
       {rows1.map((row, index) => {
         return (
-          <DataGrid.BodyRow key={index}>
+          <DataGrid.BodyRow key={index} onClick={event => console.log('onClick:', row.column5, event)}>
             <DataGrid.Cell align="center" flex="min-width">
               <TooltippedStatusBullet
                 color={row.column1}
@@ -126,7 +126,7 @@ storiesOf('DataGrids', module)
       </DataGrid.HeaderRow>
       {rows2.map((row, index) => {
         return (
-          <DataGrid.BodyRow key={index}>
+          <DataGrid.BodyRow key={index} onClick={event => console.log('onClick:', row.column5, event)}>
             <DataGrid.Cell align="center" flex="min-width">
               <TooltippedStatusBullet
                 color={row.column1}
@@ -194,7 +194,7 @@ storiesOf('DataGrids', module)
       </DataGrid.HeaderRow>
       {rows1.map((row, index) => {
         return (
-          <DataGrid.BodyRow key={index}>
+          <DataGrid.BodyRow key={index} onClick={event => console.log('onClick:', row.column5, event)}>
             <DataGrid.Cell align="center" flex="min-width">
               <TooltippedStatusBullet
                 color={row.column1}
@@ -259,7 +259,7 @@ storiesOf('DataGrids', module)
       </DataGrid.HeaderRow>
       {rows1.map((row, index) => {
         return (
-          <DataGrid.BodyRow key={index}>
+          <DataGrid.BodyRow key={index} onClick={event => console.log('onClick:', row.column5, event)}>
             <DataGrid.Cell align="center" flex="min-width">
               <TooltippedStatusBullet
                 color={row.column1}


### PR DESCRIPTION
### Description

This PR makes a DataGrid row fully clickable & adds a hover effect on it to have a visual indication.

#### Screenshot before this PR

![schermafdruk 2018-11-23 11 26 24](https://user-images.githubusercontent.com/5336831/48938845-b4688a80-ef12-11e8-9934-9c86ec2c93ce.png)

#### Screenshot after this PR

![schermafdruk 2018-11-23 11 26 08](https://user-images.githubusercontent.com/5336831/48938861-c0544c80-ef12-11e8-995e-20133381f73c.png)

### Breaking changes

None.
