### PR TITLE
[TU-114] Passport & EmptyPassport components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - `DataGrid`: added a `bordered` boolean prop. If `true`, the Datagrid will have rounded corners and a border around it. ([@driesd](https://github.com/driesd) in [#472](https://github.com/teamleadercrm/ui/pull/472))
+- `Passport` & `EmptyPassport`: added these new components to the library. ([@driesd](https://github.com/driesd) in [#474](https://github.com/teamleadercrm/ui/pull/474))
 - `Popover`: added the `fullHeight` property, if set to false the `Popover` does not stretch more than a set value ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#467](https://github.com/teamleadercrm/ui/pull/467))
 
 ### Changed

--- a/src/components/passport/EmptyPassport.js
+++ b/src/components/passport/EmptyPassport.js
@@ -1,0 +1,54 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import theme from './theme.css';
+import Avatar from '../avatar';
+import Box from '../box';
+import Link from '../link';
+import Popover from '../popover';
+import { Heading3, TextBody } from '../typography';
+
+class EmptyPassport extends PureComponent {
+  render() {
+    const { avatar, link, className, description, title, ...others } = this.props;
+
+    return (
+      <Popover {...others} backdrop="transparent" className={cx(theme['passport-empty'], className)}>
+        <Box paddingHorizontal={4} paddingVertical={5}>
+          <Box display="flex" flexDirection="column" alignItems="center">
+            {avatar && <Avatar {...avatar} size="small" marginBottom={4} />}
+            <Heading3 color="teal">{title}</Heading3>
+            <TextBody color="neutral" marginTop={2}>
+              {description}
+            </TextBody>
+            {link && (
+              <TextBody marginTop={4}>
+                <Link {...link} inherit={false} />
+              </TextBody>
+            )}
+          </Box>
+        </Box>
+      </Popover>
+    );
+  }
+}
+
+EmptyPassport.propTypes = {
+  /** Object containing the props of an avatar. */
+  avatar: PropTypes.object,
+  /** The class names for the wrapper to apply custom styling. */
+  className: PropTypes.string,
+  /** The description of the empty Passport. */
+  description: PropTypes.string,
+  /** Object containing the props of a Link. */
+  link: PropTypes.object,
+  /** The title of the empty Passport. */
+  title: PropTypes.string,
+};
+
+EmptyPassport.defaultProps = {
+  description: "It looks like you haven't added any contact information yet.",
+  title: 'No information to show',
+};
+
+export default EmptyPassport;

--- a/src/components/passport/EmptyPassport.js
+++ b/src/components/passport/EmptyPassport.js
@@ -17,10 +17,12 @@ class EmptyPassport extends PureComponent {
         <Box paddingHorizontal={4} paddingVertical={5}>
           <Box display="flex" flexDirection="column" alignItems="center">
             {avatar && <Avatar {...avatar} size="small" marginBottom={4} />}
-            <Heading3 color="teal">{title}</Heading3>
-            <TextBody color="neutral" marginTop={2}>
-              {description}
-            </TextBody>
+            {title && <Heading3 color="teal">{title}</Heading3>}
+            {description && (
+              <TextBody color="neutral" marginTop={2}>
+                {description}
+              </TextBody>
+            )}
             {link && (
               <TextBody marginTop={4}>
                 <Link {...link} inherit={false} />

--- a/src/components/passport/EmptyPassport.js
+++ b/src/components/passport/EmptyPassport.js
@@ -46,9 +46,4 @@ EmptyPassport.propTypes = {
   title: PropTypes.string,
 };
 
-EmptyPassport.defaultProps = {
-  description: "It looks like you haven't added any contact information yet.",
-  title: 'No information to show',
-};
-
 export default EmptyPassport;

--- a/src/components/passport/EmptyPassport.js
+++ b/src/components/passport/EmptyPassport.js
@@ -17,7 +17,7 @@ class EmptyPassport extends PureComponent {
         <Box paddingHorizontal={4} paddingVertical={5}>
           <Box display="flex" flexDirection="column" alignItems="center">
             {avatar && <Avatar {...avatar} size="small" marginBottom={4} />}
-            {title && <Heading3 color="teal">{title}</Heading3>}
+            <Heading3 color="teal">{title}</Heading3>
             {description && (
               <TextBody color="neutral" marginTop={2}>
                 {description}
@@ -45,7 +45,7 @@ EmptyPassport.propTypes = {
   /** Object containing the props of a Link. */
   link: PropTypes.object,
   /** The title of the empty Passport. */
-  title: PropTypes.string,
+  title: PropTypes.string.isRequired,
 };
 
 export default EmptyPassport;

--- a/src/components/passport/Passport.js
+++ b/src/components/passport/Passport.js
@@ -1,0 +1,97 @@
+import React, { Fragment, PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import theme from './theme.css';
+import Avatar from '../avatar';
+import Box from '../box';
+import Icon from '../icon';
+import Link from '../link';
+import Popover from '../popover';
+import { Heading3, TextBody } from '../typography';
+
+class Passport extends PureComponent {
+  renderDescription = () => {
+    const { description } = this.props;
+
+    if (!description) {
+      return null;
+    }
+
+    if (Array.isArray(description)) {
+      return (
+        <Fragment>
+          {description.map((child, index) => (
+            <TextBody color="teal" key={index}>
+              {child}
+            </TextBody>
+          ))}
+        </Fragment>
+      );
+    } else {
+      return <TextBody color="teal">{description}</TextBody>;
+    }
+  };
+
+  renderTitle = () => {
+    const { title } = this.props;
+
+    return (
+      <Heading3 className={cx(theme['prevent-overflow'], theme['prevent-wrap'], theme['show-ellipsis'])} color="teal">
+        {typeof title === 'string' ? title : <Link {...title} inherit={false} />}
+      </Heading3>
+    );
+  };
+
+  render() {
+    const { avatar, className, links, ...others } = this.props;
+
+    return (
+      <Popover {...others} backdrop="transparent" className={cx(theme['passport'], className)}>
+        <Box padding={3}>
+          <Box display="flex">
+            <Box flex="48px 0 0" paddingRight={3}>
+              <Avatar {...avatar} size="small" />
+            </Box>
+            <Box className={theme['prevent-overflow']}>
+              {this.renderTitle()}
+              {this.renderDescription()}
+            </Box>
+          </Box>
+          {links && (
+            <Box marginTop={3}>
+              {links.map(({ icon, ...link }, index) => (
+                <Box alignItems="flex-start" display="flex" key={index}>
+                  <Box display="flex" flex="48px 0 0" justifyContent="center" paddingRight={3}>
+                    {icon && (
+                      <Icon color="aqua" tint="dark">
+                        {icon}
+                      </Icon>
+                    )}
+                  </Box>
+                  <TextBody className={cx(theme['prevent-overflow'], theme['prevent-wrap'], theme['show-ellipsis'])}>
+                    <Link {...link} inherit={false} />
+                  </TextBody>
+                </Box>
+              ))}
+            </Box>
+          )}
+        </Box>
+      </Popover>
+    );
+  }
+}
+
+Passport.propTypes = {
+  /** Object containing the props of an Avatar. */
+  avatar: PropTypes.object.isRequired,
+  /** The class names for the wrapper to apply custom styling. */
+  className: PropTypes.string,
+  /** The description of the Passport. */
+  description: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
+  /** Array of objects containing the props of a Link. */
+  links: PropTypes.array,
+  /** The title of the Passport (can be a string of an object containing the props of a Link). */
+  title: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
+};
+
+export default Passport;

--- a/src/components/passport/index.js
+++ b/src/components/passport/index.js
@@ -1,0 +1,5 @@
+import EmptyPassport from './EmptyPassport';
+import Passport from './Passport';
+
+export default Passport;
+export { EmptyPassport, Passport };

--- a/src/components/passport/theme.css
+++ b/src/components/passport/theme.css
@@ -1,0 +1,19 @@
+.passport {
+  width: 300px;
+}
+
+.passport-empty {
+  max-width: 240px !important;
+}
+
+.prevent-overflow {
+  overflow: hidden;
+}
+
+.prevent-wrap {
+  white-space: nowrap;
+}
+
+.show-ellipsis {
+  text-overflow: ellipsis;
+}

--- a/src/components/passport/theme.css
+++ b/src/components/passport/theme.css
@@ -4,6 +4,7 @@
 
 .passport-empty {
   max-width: 240px !important;
+  text-align: center;
 }
 
 .prevent-overflow {

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ import LoadingBar from './components/loadingBar';
 import LoadingMolecule from './components/loadingMolecule';
 import LoadingSpinner from './components/loadingSpinner';
 import Pagination from './components/pagination';
+import Passport, { EmptyPassport } from './components/passport';
 import Popover from './components/popover';
 import { RadioButton, RadioGroup } from './components/radio';
 import Section from './components/section';
@@ -83,6 +84,7 @@ export {
   DatePickerInputRange,
   Dialog,
   DialogBase,
+  EmptyPassport,
   ErrorText,
   Heading1,
   Heading2,
@@ -108,6 +110,7 @@ export {
   Monospaced,
   NumericInput,
   Overlay,
+  Passport,
   Pagination,
   Popover,
   ProgressTracker,

--- a/stories/passport.js
+++ b/stories/passport.js
@@ -1,0 +1,117 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Store, State } from '@sambego/storybook-state';
+import { IconBuildingSmallOutline, IconPhoneSmallOutline, IconMailSmallOutline } from '@teamleader/ui-icons';
+import { Badge, Box, EmptyPassport, Passport } from '../src';
+import contactAvatar from './static/avatars/2.png';
+import companyAvatar from './static/avatars/3.png';
+import emptyAvatar from './static/avatars/4.png';
+
+const store = new Store({
+  active: false,
+});
+
+const contactLinks = [
+  {
+    children: 'Dunder Miflin',
+    icon: <IconBuildingSmallOutline />,
+    href: '/companies.php?id=2',
+    title: 'Dunder Miflin',
+  },
+  {
+    children: '+1 257 689 5454',
+    icon: <IconPhoneSmallOutline />,
+    onClick: () => console.log('Clicked on telephone number'),
+    title: 'Dial +1 257 689 5454',
+  },
+  {
+    children: 'david.brent@dundermiflin.com',
+    icon: <IconMailSmallOutline />,
+    href: 'mailto:david.brent@dundermiflin.com',
+    title: 'Mail to david.brent@dundermiflin.com',
+  },
+];
+
+const companyLinks = [
+  {
+    children: '+1 257 689 5454',
+    icon: <IconPhoneSmallOutline />,
+    onClick: () => console.log('Clicked on telephone number'),
+    title: 'Dial +1 257 689 5454',
+  },
+  {
+    children: 'david.brent@dundermiflin.com',
+    icon: <IconMailSmallOutline />,
+    href: 'mailto:david.brent@dundermiflin.com',
+    title: 'Mail to david.brent@dundermiflin.com',
+  },
+];
+
+const handleButtonClick = event => {
+  store.set({ anchorEl: event.currentTarget, active: true });
+};
+
+const handleCloseClick = () => {
+  store.set({ active: false });
+};
+
+storiesOf('Passport', module)
+  .addParameters({
+    info: {
+      propTablesExclude: [Badge, State, Box],
+    },
+  })
+  .add('Contact', () => (
+    <Box display="flex" justifyContent="center">
+      <Badge onClick={handleButtonClick} icon={<IconBuildingSmallOutline />} inherit={false}>
+        David Brent
+      </Badge>
+      <State store={store}>
+        <Passport
+          active={false}
+          description="Regional manager"
+          onEscKeyDown={handleCloseClick}
+          onOverlayClick={handleCloseClick}
+          avatar={{ image: contactAvatar }}
+          links={contactLinks}
+          title={{ children: 'David Brent', href: 'https://www.teamleader.eu' }}
+        />
+      </State>
+    </Box>
+  ))
+  .add('Company', () => (
+    <Box display="flex" justifyContent="center">
+      <Badge onClick={handleButtonClick} icon={<IconBuildingSmallOutline />} inherit={false}>
+        Dunder Miflin
+      </Badge>
+      <State store={store}>
+        <Passport
+          active={false}
+          description={['1725 Slough Avenue', 'Sranton, PA 18540', 'United Kingdom']}
+          onEscKeyDown={handleCloseClick}
+          onOverlayClick={handleCloseClick}
+          avatar={{ image: companyAvatar, shape: 'rounded' }}
+          links={companyLinks}
+          title="Dunder Miflin"
+        />
+      </State>
+    </Box>
+  ))
+  .add('Empty', () => (
+    <Box display="flex" justifyContent="center">
+      <Badge onClick={handleButtonClick} icon={<IconBuildingSmallOutline />} inherit={false}>
+        No information
+      </Badge>
+      <State store={store}>
+        <EmptyPassport
+          active={false}
+          link={{ children: 'Start now', href: 'https://www.teamleader.eu' }}
+          description="It looks like you haven't added any contact information yet."
+          onEscKeyDown={handleCloseClick}
+          onOverlayClick={handleCloseClick}
+          avatar={{ image: emptyAvatar }}
+          title="No information to show"
+        />
+      </State>
+    </Box>
+  ));


### PR DESCRIPTION
### Description

This PR adds two new components:
* Passport
* EmptyPassport

#### Passport (with contact info)

![schermafdruk 2018-11-27 13 43 11](https://user-images.githubusercontent.com/5336831/49083570-48a55b00-f24d-11e8-8963-b56f4c7dbb79.png)

#### Passport (with overflowing contact info)

![schermafdruk 2018-11-27 13 39 23](https://user-images.githubusercontent.com/5336831/49083605-67a3ed00-f24d-11e8-8eda-fafd4ba8f5f2.png)

#### Passport (with company info)

![schermafdruk 2018-11-27 13 39 57](https://user-images.githubusercontent.com/5336831/49083633-78ecf980-f24d-11e8-9531-d64b9743c6fc.png)

#### EmptyPassport

![schermafdruk 2018-11-27 13 40 41](https://user-images.githubusercontent.com/5336831/49083652-86a27f00-f24d-11e8-9a22-fd1046c90184.png)

### Breaking changes

None.
