### PR TITLE
[TU-247] Input: Placeholder styling support for IE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Input`, `NumericInput`, `TextArea`, `DatePickerInput` & `DatePickerInputRange`: fixed the placeholder styling in IE10+. ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#480](https://github.com/teamleadercrm/ui/pull/480))
+
 ## [0.19.3] - 2018-12-10
 
 ### Added

--- a/src/components/datepicker/theme.css
+++ b/src/components/datepicker/theme.css
@@ -225,6 +225,10 @@
           color: var(--color-neutral-darkest);
         }
 
+        input:-ms-input-placeholder {
+          color: var(--color-neutral-darkest);
+        }
+
         &:hover {
           border-color: var(--color-neutral-darkest);
         }
@@ -247,6 +251,10 @@
         }
 
         input::placeholder {
+          color: var(--color-neutral-dark);
+        }
+
+        input:-ms-input-placeholder {
           color: var(--color-neutral-dark);
         }
       }
@@ -280,6 +288,10 @@
           color: var(--color-teal-light);
         }
 
+        input:-ms-input-placeholder {
+          color: var(--color-teal-light);
+        }
+
         &:hover {
           border-color: var(--color-teal-light);
         }
@@ -301,6 +313,10 @@
         .container:not(.date-picker) + .container:not(.date-picker)::before {
           color: var(--color-teal);
         }
+
+        input:-ms-input-placeholder {
+          color: var(--color-teal);
+        }
       }
     }
 
@@ -315,6 +331,10 @@
         }
 
         input::placeholder {
+          color: var(--color-teal);
+        }
+
+        input:-ms-input-placeholder {
           color: var(--color-teal);
         }
       }

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -170,6 +170,10 @@
     color: var(--color-neutral-darkest);
   }
 
+  &:-ms-input-placeholder {
+    color: var(--color-neutral-darkest);
+  }
+
   height: var(--input-height-medium);
   width: 100%;
   padding: 0 var(--input-horizontal-padding);
@@ -194,10 +198,18 @@
       color: var(--color-teal-light);
     }
 
+    &:-ms-input-placeholder {
+      color: var(--color-teal-light);
+    }
+
     &:disabled {
       color: var(--color-teal);
 
       &::placeholder {
+        color: var(--color-teal);
+      }
+
+      &:-ms-input-placeholder {
         color: var(--color-teal);
       }
     }


### PR DESCRIPTION
### Description

The placeholder of the inputs in Internet Explorer, were not rendering according to the design. Which we fix in this PR.

#### Screenshot before this PR
![screenshot 2018-12-17 at 11 32 06](https://user-images.githubusercontent.com/23736202/50081708-6da74100-01ef-11e9-8000-da6de870e4b4.png)

#### Screenshot after this PR
![screenshot 2018-12-17 at 11 31 39](https://user-images.githubusercontent.com/23736202/50081726-78fa6c80-01ef-11e9-9436-8d67363182f7.png)

### Breaking changes

- None
