### PR TITLE
[TU-250] Menu: Pass props through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Menu`: added the passing through of all properties. ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#481](https://github.com/teamleadercrm/ui/pull/481))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -209,7 +209,7 @@ class Menu extends PureComponent {
 
   render() {
     const { width, height, active, position } = this.state;
-    const { className, outline } = this.props;
+    const { className, outline, ...others } = this.props;
 
     const classNames = cx(
       theme['menu'],
@@ -221,7 +221,7 @@ class Menu extends PureComponent {
     );
 
     return (
-      <div data-teamleader-ui="menu" className={classNames} style={this.getRootStyle()}>
+      <div data-teamleader-ui="menu" className={classNames} style={this.getRootStyle()} {...others}>
         {outline ? <div className={theme['outline']} style={{ width, height }} /> : null}
         <ul
           ref={node => {


### PR DESCRIPTION
### Description

Up until now not all props were passed through in the [`Menu`](https://components.teamleader.design/?selectedKind=Menus&selectedStory=Menu&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybook-addon-background%2Fbackground-panel&background=%23ffffff) component, which we normally do for every component, to improve adaptability. This PR resolves this.

![screenshot 2018-12-21 at 15 19 18](https://user-images.githubusercontent.com/23736202/50346807-cea68000-0533-11e9-8ede-e7f90bde8016.png)
_The menu component_

### Breaking changes

- None
