### PR TITLE
[TU-253] Menu: Recalculate dimensions on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - `Input`, `NumericInput`, `TextArea`, `DatePickerInput` & `DatePickerInputRange`: fixed the placeholder styling in IE10+. ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#480](https://github.com/teamleadercrm/ui/pull/480))
+- `Menu`: fixed the rendering of the `Menu`, when its `children` change. By recalculating the `width` and `height` property, when the component updates. ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#482](https://github.com/teamleadercrm/ui/pull/482))
 
 ## [0.19.3] - 2018-12-10
 

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -59,6 +59,11 @@ class Menu extends PureComponent {
     if (prevState.position !== this.state.position && this.state.position === POSITION.AUTO) {
       this.setState({ position: this.calculatePosition() });
     }
+
+    const { width, height } = this.menuNode.getBoundingClientRect();
+    if (prevState.width !== width || prevState.height !== height) {
+      this.setState({ width, height }); // eslint-disable-line
+    }
   }
 
   show() {


### PR DESCRIPTION
### Description

When the [`Menu`](https://components.teamleader.design/?selectedKind=Menus&selectedStory=Menu&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybook-addon-background%2Fbackground-panel&background=%23ffffff) updates, it's calculated dimensions don't update. This results in some visual bugs.

#### Screenshot before this PR
![screenshot 2018-12-21 at 16 18 35](https://user-images.githubusercontent.com/23736202/50349446-16c9a080-053c-11e9-8fde-1dd87ada826a.png)

#### Screenshot after this PR
![screenshot 2018-12-21 at 16 17 43](https://user-images.githubusercontent.com/23736202/50349455-1d581800-053c-11e9-881c-2c8628e1bad8.png)

### Breaking changes

- None