### PR TITLE
DataGrid: Indicate a column can be sorted by passing false as the sorted prop

### DIFF
--- a/src/components/datagrid/Cell.js
+++ b/src/components/datagrid/Cell.js
@@ -34,7 +34,13 @@ class Cell extends PureComponent {
 
     return (
       <Box className={classNames} data-teamleader-ui="datagrid-cell" boxSizing="content-box" {...others}>
-        {preventOverflow ? <div className={theme['has-overflow-prevention']}>{children}</div> : children}
+        {preventOverflow ? (
+          <Box className={theme['has-overflow-prevention']} display="flex" alignItems="center">
+            {children}
+          </Box>
+        ) : (
+          children
+        )}
       </Box>
     );
   }

--- a/src/components/datagrid/HeaderCell.js
+++ b/src/components/datagrid/HeaderCell.js
@@ -3,9 +3,27 @@ import PropTypes from 'prop-types';
 import theme from './theme.css';
 import Cell from './Cell';
 import cx from 'classnames';
-import { IconChevronDownSmallOutline, IconChevronUpSmallOutline } from '@teamleader/ui-icons';
+import { IconChevronDownSmallOutline, IconChevronUpSmallOutline, IconSortSmallOutline } from '@teamleader/ui-icons';
 
 class HeaderCell extends PureComponent {
+  renderSortedIndicators = () => {
+    const { sorted } = this.props;
+
+    if (sorted === 'asc') {
+      return <IconChevronUpSmallOutline />;
+    }
+
+    if (sorted === 'desc') {
+      return <IconChevronDownSmallOutline />;
+    }
+
+    if (!sorted) {
+      return <IconSortSmallOutline />;
+    }
+
+    return null;
+  };
+
   render() {
     const { children, className, onClick, sorted, ...others } = this.props;
 
@@ -21,7 +39,7 @@ class HeaderCell extends PureComponent {
     return (
       <Cell className={classNames} onClick={onClick} {...others}>
         {children}
-        {sorted !== 'none' ? sorted === 'asc' ? <IconChevronUpSmallOutline /> : <IconChevronDownSmallOutline /> : null}
+        {this.renderSortedIndicators()}
       </Cell>
     );
   }

--- a/src/components/datagrid/HeaderCell.js
+++ b/src/components/datagrid/HeaderCell.js
@@ -13,7 +13,7 @@ class HeaderCell extends PureComponent {
       theme['header-cell'],
       {
         [theme['is-sortable']]: onClick,
-        [theme['is-sorted']]: sorted !== 'none',
+        [theme['is-sorted']]: sorted === 'asc' || sorted === 'desc',
       },
       className,
     );
@@ -35,7 +35,7 @@ HeaderCell.propTypes = {
   /** Callback function that is fired when clicking on the cell. */
   onClick: PropTypes.func,
   /** The order in which the grid rows will be sorted. */
-  sorted: PropTypes.oneOf(['none', 'asc', 'desc']),
+  sorted: PropTypes.oneOf(['none', false, 'asc', 'desc']),
 };
 
 HeaderCell.defaultProps = {

--- a/src/components/datagrid/theme.css
+++ b/src/components/datagrid/theme.css
@@ -114,15 +114,21 @@
 .is-sortable {
   svg {
     margin-left: var(--spacer-smallest);
+    color: var(--color-teal-light);
   }
 
   &:hover {
     color: var(--color-teal-darkest);
     cursor: pointer;
+
+    & svg {
+      color: var(--color-teal-darkest);
+    }
   }
 }
 
-.is-sorted {
+.is-sorted,
+.is-sorted svg {
   color: var(--color-teal-darkest);
 }
 


### PR DESCRIPTION
### Description

This PR allows to pass `false` to the sorted prop on the `HeaderCell`. This way we can indicate a field is sortable by showing the icon for it.

#### Screenshot before this PR

##### Not sorted on anything

<img width="465" alt="screenshot 2018-12-25 at 11 26 40" src="https://user-images.githubusercontent.com/10011712/50420605-02d1b780-0838-11e9-8fcd-8cded9d45124.png">

##### Sorted on a column

<img width="440" alt="screenshot 2018-12-25 at 11 27 33" src="https://user-images.githubusercontent.com/10011712/50420620-1ed55900-0838-11e9-9711-e0f44a6428be.png">

#### Screenshot after this PR

##### Not sorted on anything

<img width="438" alt="screenshot 2018-12-25 at 11 28 28" src="https://user-images.githubusercontent.com/10011712/50420649-3c0a2780-0838-11e9-8c1c-a5cabeba9ac5.png">

##### Sorted on a single field

<img width="459" alt="screenshot 2018-12-25 at 11 29 08" src="https://user-images.githubusercontent.com/10011712/50420674-580dc900-0838-11e9-8c14-575c7deb035a.png">

### Breaking changes

- None.
