### PR TITLE
Menu: compose from Popover

### DIFF
--- a/src/components/menu/IconMenu.js
+++ b/src/components/menu/IconMenu.js
@@ -1,58 +1,53 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import cx from 'classnames';
 import { IconMoreMediumOutline } from '@teamleader/ui-icons';
 import IconButton from '../button/IconButton.js';
 import Menu from './Menu.js';
-import theme from './theme.css';
-import Box from '../box';
-
+import Box, { omitBoxProps, pickBoxProps } from '../box';
 class IconMenu extends PureComponent {
   state = {
     active: false,
+    anchorEl: null,
+    selectedValue: null,
   };
 
-  handleButtonClick = event => {
+  constructor(props) {
+    super(props);
+    this.buttonRef = React.createRef();
+  }
+
+  componentDidMount() {
+    this.setState({ anchorEl: this.buttonRef.current.buttonNode });
+  }
+
+  handleOnSelect = value => {
+    if (this.props.onSelect) {
+      this.props.onSelect();
+    }
+
+    this.setState({ selectedValue: value });
+    this.toggleActive();
+  };
+
+  toggleActive = () => {
     this.setState({ active: !this.state.active });
-    if (this.props.onClick) {
-      this.props.onClick(event);
-    }
-  };
-
-  handleMenuHide = () => {
-    this.setState({ active: false });
-    if (this.props.onHide) {
-      this.props.onHide();
-    }
   };
 
   render() {
-    const {
-      children,
-      className,
-      icon,
-      onHide, // eslint-disable-line
-      onSelect,
-      onShow,
-      position,
-      selectable,
-      selected,
-      ...other
-    } = this.props;
+    const { active, anchorEl, selectedValue } = this.state;
+    const { children, icon, ...others } = this.props;
 
     const buttonIcon = icon || <IconMoreMediumOutline />;
 
     return (
-      <Box data-teamleader-ui="icon-menu" {...other} className={cx(theme['icon-menu'], className)}>
-        <IconButton className={theme['icon']} icon={buttonIcon} onClick={this.handleButtonClick} />
+      <Box data-teamleader-ui="icon-menu" {...pickBoxProps(others)}>
+        <IconButton ref={this.buttonRef} icon={buttonIcon} onClick={this.toggleActive} />
         <Menu
-          active={this.state.active}
-          onHide={this.handleMenuHide}
-          onSelect={onSelect}
-          onShow={onShow}
-          position={position}
-          selectable={selectable}
-          selected={selected}
+          active={active}
+          anchorEl={anchorEl}
+          selectedValue={selectedValue}
+          onSelect={this.handleOnSelect}
+          {...omitBoxProps(others)}
         >
           {children}
         </Menu>
@@ -62,22 +57,12 @@ class IconMenu extends PureComponent {
 }
 
 IconMenu.propTypes = {
+  /** The items wrapped by the Menu. */
   children: PropTypes.node,
-  className: PropTypes.string,
+  /** The icon rendered by the IconButton */
   icon: PropTypes.element,
-  onClick: PropTypes.func,
-  onHide: PropTypes.func,
+  /** The function executed, when a MenuItem (that was passed as a child) has been clicked. */
   onSelect: PropTypes.func,
-  onShow: PropTypes.func,
-  position: PropTypes.string,
-  selectable: PropTypes.bool,
-  selected: PropTypes.any,
-};
-
-IconMenu.defaultProps = {
-  className: '',
-  position: 'auto',
-  selectable: false,
 };
 
 export default IconMenu;

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -1,121 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ReactDOM from 'react-dom';
-import cx from 'classnames';
-import { events } from '../utils';
-import { getViewport } from '../utils/utils';
 import MenuItem from './MenuItem.js';
-import theme from './theme.css';
-
-const POSITION = {
-  AUTO: 'auto',
-  STATIC: 'static',
-  TOP_LEFT: 'top-left',
-  TOP_RIGHT: 'top-right',
-  BOTTOM_LEFT: 'bottom-left',
-  BOTTOM_RIGHT: 'bottom-right',
-};
+import Popover from '../popover';
 
 class Menu extends PureComponent {
-  state = {};
-
-  componentDidMount() {
-    const { width, height } = this.menuNode.getBoundingClientRect();
-    this.setState({ width, height });
-
-    const { position } = this.props;
-    if (position === POSITION.AUTO) {
-      this.setState({ position: this.calculatePosition() });
-    }
-  }
-
-  static getDerivedStateFromProps(props, state) {
-    const newStateSlice = {};
-
-    if (props.active !== state.active) {
-      newStateSlice.active = props.active;
-    }
-
-    if (props.position !== state.position) {
-      newStateSlice.position = props.position;
-    }
-
-    if (newStateSlice.active || newStateSlice.position) {
-      return newStateSlice;
-    }
-
-    return null;
-  }
-
-  componentDidUpdate(prevState) {
-    if (prevState.active && !this.state.active) {
-      this.hide();
-    }
-
-    if (!prevState.active && this.state.active) {
-      this.show();
-    }
-
-    if (prevState.position !== this.state.position && this.state.position === POSITION.AUTO) {
-      this.setState({ position: this.calculatePosition() });
-    }
-
-    const { width, height } = this.menuNode.getBoundingClientRect();
-    if (prevState.width !== width || prevState.height !== height) {
-      this.setState({ width, height }); // eslint-disable-line
-    }
-  }
-
-  show() {
-    const { onShow } = this.props;
-
-    if (onShow) {
-      onShow();
-    }
-
-    this.setState({ active: true });
-
-    this.addEvents();
-  }
-
-  hide() {
-    const { onHide } = this.props;
-
-    if (onHide) {
-      onHide();
-    }
-
-    this.setState({ active: false });
-
-    this.removeEvents();
-  }
-
-  componentWillUnmount() {
-    if (this.state.active) {
-      this.removeEvents();
-    }
-  }
-
-  addEvents() {
-    events.addEventsToDocument({
-      click: this.handleDocumentClick,
-      touchstart: this.handleDocumentClick,
-    });
-  }
-
-  removeEvents() {
-    events.removeEventsFromDocument({
-      click: this.handleDocumentClick,
-      touchstart: this.handleDocumentClick,
-    });
-  }
-
-  handleDocumentClick = event => {
-    if (this.state.active && !events.targetIsDescendant(event, ReactDOM.findDOMNode(this))) {
-      this.hide();
-    }
-  };
-
   handleSelect = (item, event) => {
     const { onSelect } = this.props;
     const { value, onClick } = item.props;
@@ -128,69 +16,9 @@ class Menu extends PureComponent {
       event.persist();
       onClick(event);
     }
-
-    this.hide();
   };
 
-  calculatePosition() {
-    const parentNode = ReactDOM.findDOMNode(this).parentNode;
-
-    if (!parentNode) {
-      return;
-    }
-
-    const { top, left, height, width } = parentNode.getBoundingClientRect();
-    const { height: vh, width: vw } = getViewport();
-
-    const toTop = top < vh / 2 - height / 2;
-    const toLeft = left < vw / 2 - width / 2;
-
-    return `${toTop ? 'top' : 'bottom'}${toLeft ? 'Left' : 'Right'}`;
-  }
-
-  getRootStyle() {
-    const { width, height, position } = this.state;
-
-    if (position !== POSITION.STATIC) {
-      return { width, height };
-    }
-  }
-
-  getMenuStyle() {
-    const { active } = this.state;
-
-    if (active) {
-      return this.getActiveMenuStyle();
-    }
-
-    return this.getMenuStyleByPosition();
-  }
-
-  getActiveMenuStyle() {
-    const { width, height } = this.state;
-    return { clip: `rect(0 ${width}px ${height}px 0)` };
-  }
-
-  getMenuStyleByPosition() {
-    const { width, height, position } = this.state;
-
-    switch (position) {
-      case POSITION.TOP_RIGHT:
-        return { clip: `rect(0 ${width}px 0 ${width}px)` };
-      case POSITION.BOTTOM_RIGHT:
-        return { clip: `rect(${height}px ${width}px ${height}px ${width}px)` };
-      case POSITION.BOTTOM_LEFT:
-        return { clip: `rect(${height}px 0 ${height}px 0)` };
-      case POSITION.TOP_LEFT:
-        return { clip: 'rect(0 0 0 0)' };
-      default:
-        return {};
-    }
-  }
-
-  getItems() {
-    const { children, selectable, selected } = this.props;
-
+  getItems = (children, selectedValue) => {
     // Because React Hot Loader creates proxied versions of your components,
     // comparing reference types of elements won't work
     // https://github.com/gaearon/react-hot-loader/blob/master/docs/Known%20Limitations.md#checking-element-types
@@ -203,63 +31,34 @@ class Menu extends PureComponent {
 
       if (item.type === MenuItemType) {
         return React.cloneElement(item, {
-          selected: typeof item.props.value !== 'undefined' && selectable && item.props.value === selected,
+          selected: typeof item.props.value !== 'undefined' && item.props.value === selectedValue,
           onClick: this.handleSelect.bind(this, item),
         });
       } else {
         return React.cloneElement(item);
       }
     });
-  }
+  };
 
   render() {
-    const { width, height, active, position } = this.state;
-    const { className, outline, ...others } = this.props;
-
-    const classNames = cx(
-      theme['menu'],
-      theme[position],
-      {
-        [theme['active']]: active,
-      },
-      className,
-    );
-
+    const { children, onSelect, selectedValue, ...others } = this.props;
     return (
-      <div data-teamleader-ui="menu" className={classNames} style={this.getRootStyle()} {...others}>
-        {outline ? <div className={theme['outline']} style={{ width, height }} /> : null}
-        <ul
-          ref={node => {
-            this.menuNode = node;
-          }}
-          className={theme['menu-inner']}
-          style={this.getMenuStyle()}
-        >
-          {this.getItems()}
-        </ul>
-      </div>
+      <Popover backdrop="transperant" {...others}>
+        {this.getItems(children, selectedValue)}
+      </Popover>
     );
   }
 }
 
 Menu.propTypes = {
+  /** The state of the Menu, when true the Menu is rendered otherwise it is not. */
   active: PropTypes.bool,
+  /** The items wrapped by the Menu. */
   children: PropTypes.node,
-  className: PropTypes.string,
-  onHide: PropTypes.func,
+  /** The function executed, when a MenuItem (that was passed as a child) has been clicked. */
   onSelect: PropTypes.func,
-  onShow: PropTypes.func,
-  outline: PropTypes.bool,
-  position: PropTypes.oneOf(Object.keys(POSITION).map(key => POSITION[key])),
-  selectable: PropTypes.bool,
-  selected: PropTypes.any,
-};
-
-Menu.defaultProps = {
-  active: false,
-  outline: true,
-  position: POSITION.STATIC,
-  selectable: true,
+  /** When set, the MenuItem (that was passed as a child) whose value property equals this property, will be rendered in its selected state. */
+  selectedValue: PropTypes.any,
 };
 
 export default Menu;

--- a/stories/menu.js
+++ b/stories/menu.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { IconAddSmallOutline, IconUserSmallFilled, IconClockSmallOutline } from '@teamleader/ui-icons';
-import { IconMenu, Menu, MenuItem, MenuDivider } from '../src';
+import { Box, IconMenu, Menu, MenuItem, MenuDivider } from '../src';
 
 storiesOf('Menus', module)
   .add('Menu', () => (
@@ -16,9 +16,11 @@ storiesOf('Menus', module)
     </Menu>
   ))
   .add('IconMenu', () => (
-    <IconMenu position="top-left">
-      <MenuItem value="foo" caption="Caption" />
-      <MenuItem value="bar" caption="Caption & Shortcut" shortcut="Ctrl + P" />
-      <MenuItem caption="Disabled ..." disabled shortcut="Ctrl + P" />
-    </IconMenu>
+    <Box display="flex" justifyContent="center">
+      <IconMenu>
+        <MenuItem value="foo" caption="Caption" />
+        <MenuItem value="bar" caption="Caption & Shortcut" shortcut="Ctrl + P" />
+        <MenuItem caption="Disabled ..." disabled shortcut="Ctrl + P" />
+      </IconMenu>
+    </Box>
   ));


### PR DESCRIPTION
## :construction: This PR serves as a proposal on a new approach to the `Menu`

### Menu
#### CHANGED
  - prop changes:
    - outline is not a valid property anymore
    - onHide and onShow are not valid anymore, since their call has been removed
    - position is not a valid property anymore, handle positioning by passing the Popover properties position and direction
    - selectable is not a valid property anymore, as by passing a value for selected(Value) property you already indirectly declare you want to select an item
    - selected is renamed to selectedValue
  - visual changes:
    - the in and out animations are now the more simple fade animation of the Popover
    - the Popover now has a little arrow by default (Stephen is on board to remove the arrow on the Popover)
  - behavioural changes:
    - the Menu does not close automatically, when the document is clicked outside of the Menu
    - the Menu can't be opened standalone (without errors)
  - technical changes:
    - the Menu does not have an internal state anymore, it cointained positioning/dimension calculations and the active sate. These respectivily are now handled by the Popover and had to be kept by the parent container anyway.
  - ! Since it in essentially renders a Popover, it inherits all of its behaviour, props,... (some of which already popped up in the above)

#### IDEAS/QUESTIONS
  - Should Popover (and thus automatically the Menu too) automatically close itself when the overlay is clicked or the ESC key is pressed? (Stephen is on board with this behaviour)
  - Should we pass the anchor element as a prop (and render the element inside the Popover component), instead of sending down a reference
  - Should the MenuItems (which are li-elements) be rendered in a ul or ol element to be more semantically correct?
  - Should the Menu not be a standalone component?

### IconMenu
#### CHANGED
  - prop changes:
    - onClick (called in IconButtons onClick), since its call has been removed
  - behaviour/technical changes
    - the selectedValue is now handled inside the component itself (should we reintroduce the isSelectable prop?)
  - ! Since it composes the Menu component, a lot of similar things changed

#### IDEAS/QUESTIONS
  - Shouldn't we allow to render any kind of action trigger (e.g. also Buttons, instead of only IconButtons)? (Stephen is on board with this kind of behaviour)
    - We can maybe merge the IconMenu and the Menu into one component
  - Should the Menu itself keep track of the selectedValue (and reintroduce the isSelectable prop)?