### PR TITLE
[TU-227] DataGrid: use Array.isArray instead of isArray from node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- `DataGrid`: replaced the deprecated `isArray` function from node by the official `Array.isArray` function. ([@driesd](https://github.com/driesd) in [#488](https://github.com/teamleadercrm/ui/pull/488))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -15,7 +15,6 @@ import cx from 'classnames';
 import omit from 'lodash.omit';
 import ReactResizeDetector from 'react-resize-detector';
 import theme from './theme.css';
-import { isArray } from 'util';
 
 class DataGrid extends PureComponent {
   state = {
@@ -158,7 +157,7 @@ class DataGrid extends PureComponent {
                   return React.cloneElement(child, {
                     checkboxSize,
                     onSelectionChange: this.handleHeaderRowSelectionChange,
-                    selected: selectedRows.length === children.find(child => isArray(child)).length,
+                    selected: selectedRows.length === children.find(child => Array.isArray(child)).length,
                     selectable,
                     sliceTo: stickyFromLeft > 0 ? stickyFromLeft : 0,
                   });


### PR DESCRIPTION
### Description

This PR replaces the deprecated node `isArray` function by the official `Array.isArray` function.

### Breaking changes

None
