### PR TITLE
[TU-228] LoadingBar: change default 'tint' to 'normal'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- `LoadingBar`: changed the default `tint` to `normal` to fix console warning ([@driesd](https://github.com/driesd) in [#489](https://github.com/teamleadercrm/ui/pull/489))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/loadingBar/LoadingBar.js
+++ b/src/components/loadingBar/LoadingBar.js
@@ -39,7 +39,7 @@ LoadingBar.propTypes = {
 LoadingBar.defaultProps = {
   color: 'mint',
   size: 'small',
-  tint: 'neutral',
+  tint: 'normal',
 };
 
 export default LoadingBar;


### PR DESCRIPTION
### Description

This PR fixes the console warning from our `LoadingBar` component. Before this PR the default `tint` was set to `neutral` which is not a valid tint. Now I've changed it to `normal` to solve this.

### Breaking changes

None
