### PR TITLE
[TU-261] Popover: fix cross browser height

### DIFF
--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -44,15 +44,15 @@ class Popover extends PureComponent {
     }
   };
 
-  getMaxHeight = () => {
+  getHeight = () => {
     const { fullHeight } = this.props;
-    const { maxHeight } = this.state.positioning;
+    const { height } = this.state.positioning;
 
-    if (!fullHeight && maxHeight > MAX_HEIGHT_DEFAULT) {
+    if (!fullHeight && height > MAX_HEIGHT_DEFAULT) {
       return MAX_HEIGHT_DEFAULT;
     }
 
-    return maxHeight;
+    return height;
   };
 
   setPlacementThrottled = throttle(this.setPlacement, 250);
@@ -116,7 +116,7 @@ class Popover extends PureComponent {
                   header={header}
                   body={children}
                   footer={footer}
-                  style={{ maxHeight: this.getMaxHeight() }}
+                  style={{ height: this.getHeight() }}
                 />
                 <ReactResizeDetector
                   handleHeight

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -44,15 +44,15 @@ class Popover extends PureComponent {
     }
   };
 
-  getHeight = () => {
+  getMaxHeight = () => {
     const { fullHeight } = this.props;
-    const { height } = this.state.positioning;
+    const { maxHeight } = this.state.positioning;
 
-    if (!fullHeight && height > MAX_HEIGHT_DEFAULT) {
+    if (!fullHeight && maxHeight > MAX_HEIGHT_DEFAULT) {
       return MAX_HEIGHT_DEFAULT;
     }
 
-    return height;
+    return maxHeight;
   };
 
   setPlacementThrottled = throttle(this.setPlacement, 250);
@@ -116,7 +116,7 @@ class Popover extends PureComponent {
                   header={header}
                   body={children}
                   footer={footer}
-                  style={{ height: this.getHeight() }}
+                  style={{ maxHeight: this.getMaxHeight() }}
                 />
                 <ReactResizeDetector
                   handleHeight

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -9,6 +9,7 @@ import ReactResizeDetector from 'react-resize-detector';
 import { events } from '../utils';
 import { calculatePositions } from './positionCalculation';
 import ScrollContainer from '../scrollContainer';
+import Box from '../box';
 import theme from './theme.css';
 
 const MAX_HEIGHT_DEFAULT = 240;
@@ -20,11 +21,11 @@ class Popover extends PureComponent {
 
   componentDidMount() {
     document.body.appendChild(this.popoverRoot);
-    events.addEventsToWindow({ scroll: this.setPlacementThrottled });
+    events.addEventsToWindow({ resize: this.setPlacementThrottled, scroll: this.setPlacementThrottled });
   }
 
   componentWillUnmount() {
-    events.removeEventsFromWindow({ scroll: this.setPlacementThrottled });
+    events.removeEventsFromWindow({ resize: this.setPlacementThrottled, scroll: this.setPlacementThrottled });
     document.body.removeChild(this.popoverRoot);
   }
 
@@ -47,6 +48,8 @@ class Popover extends PureComponent {
   getMaxHeight = () => {
     const { fullHeight } = this.props;
     const { maxHeight } = this.state.positioning;
+
+    console.log(maxHeight);
 
     if (!fullHeight && maxHeight > MAX_HEIGHT_DEFAULT) {
       return MAX_HEIGHT_DEFAULT;
@@ -111,13 +114,15 @@ class Popover extends PureComponent {
                 }}
               >
                 <div className={theme['arrow']} style={{ left: `${arrowLeft}px`, top: `${arrowTop}px` }} />
-                <ScrollContainer
-                  className={theme['inner']}
-                  header={header}
-                  body={children}
-                  footer={footer}
-                  style={{ maxHeight: this.getMaxHeight() }}
-                />
+                <Box display="flex">
+                  <ScrollContainer
+                    className={theme['inner']}
+                    header={header}
+                    body={children}
+                    footer={footer}
+                    style={{ maxHeight: this.getMaxHeight() }}
+                  />
+                </Box>
                 <ReactResizeDetector
                   handleHeight
                   handleWidth

--- a/src/components/popover/positionCalculation.js
+++ b/src/components/popover/positionCalculation.js
@@ -261,13 +261,22 @@ const getPosition = ({ direction, position, anchorPosition, popoverDimensions })
   }
 };
 
-const getMaxHeightValue = ({ direction, anchorPosition }) => {
+const getHeightValue = ({ direction, anchorPosition, popoverHeight }) => {
+  let heightValue;
+
   switch (direction) {
     case DIRECTION_NORTH:
-      return anchorPosition.top - POPUP_OFFSET * 2;
+      heightValue = anchorPosition.top - POPUP_OFFSET * 2;
+      break;
     case DIRECTION_SOUTH:
-      return window.innerHeight - anchorPosition.bottom - POPUP_OFFSET * 2;
+      heightValue = window.innerHeight - anchorPosition.bottom - POPUP_OFFSET * 2;
   }
+
+  if (heightValue > popoverHeight) {
+    return popoverHeight;
+  }
+
+  return heightValue;
 };
 
 export const calculatePositions = (anchorEl, popoverEl, inputDirection, inputPosition, inputOffsetCorrection) => {
@@ -278,9 +287,10 @@ export const calculatePositions = (anchorEl, popoverEl, inputDirection, inputPos
   const position = getPosition({ direction, position: inputPosition, anchorPosition, popoverDimensions });
 
   return {
-    maxHeight: getMaxHeightValue({
+    height: getHeightValue({
       direction,
       anchorPosition,
+      popoverHeight: popoverDimensions.height,
     }),
     ...getPositionValues({
       direction,

--- a/src/components/popover/positionCalculation.js
+++ b/src/components/popover/positionCalculation.js
@@ -261,22 +261,13 @@ const getPosition = ({ direction, position, anchorPosition, popoverDimensions })
   }
 };
 
-const getHeightValue = ({ direction, anchorPosition, popoverHeight }) => {
-  let heightValue;
-
+const getMaxHeightValue = ({ direction, anchorPosition }) => {
   switch (direction) {
     case DIRECTION_NORTH:
-      heightValue = anchorPosition.top - POPUP_OFFSET * 2;
-      break;
+      return anchorPosition.top - POPUP_OFFSET * 2;
     case DIRECTION_SOUTH:
-      heightValue = window.innerHeight - anchorPosition.bottom - POPUP_OFFSET * 2;
+      return window.innerHeight - anchorPosition.bottom - POPUP_OFFSET * 2;
   }
-
-  if (heightValue > popoverHeight) {
-    return popoverHeight;
-  }
-
-  return heightValue;
 };
 
 export const calculatePositions = (anchorEl, popoverEl, inputDirection, inputPosition, inputOffsetCorrection) => {
@@ -287,10 +278,9 @@ export const calculatePositions = (anchorEl, popoverEl, inputDirection, inputPos
   const position = getPosition({ direction, position: inputPosition, anchorPosition, popoverDimensions });
 
   return {
-    height: getHeightValue({
+    maxHeight: getMaxHeightValue({
       direction,
       anchorPosition,
-      popoverHeight: popoverDimensions.height,
     }),
     ...getPositionValues({
       direction,

--- a/src/components/scrollContainer/ScrollContainer.js
+++ b/src/components/scrollContainer/ScrollContainer.js
@@ -12,9 +12,9 @@ class ScrollContainer extends PureComponent {
 
     return (
       <Box className={classNames} display="flex" flexDirection="column" {...others}>
-        {header && <header>{header}</header>}
+        {header && <header className={theme['scroll-container-header']}>{header}</header>}
         {body && <div className={theme['scroll-container-body']}>{body}</div>}
-        {footer && <footer>{footer}</footer>}
+        {footer && <footer className={theme['scroll-container-footer']}>{footer}</footer>}
       </Box>
     );
   }

--- a/src/components/scrollContainer/theme.css
+++ b/src/components/scrollContainer/theme.css
@@ -3,6 +3,8 @@
 }
 
 .scroll-container-body {
-  flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: auto;
   overflow: auto;
 }


### PR DESCRIPTION
### Description

This PR aims to fix a bug in IE11(/10), where the `Popover`s body collapses.

The solution currently applied is based upon: a [flexbugs workaround](https://github.com/philipwalton/flexbugs#workaround-2) and [this JSFiddle](https://jsfiddle.net/gktpsyv5/).

🚨 **Disclaimer**
The current solution works, but only partially. The `Popover` does not stretch itself fully anymore, once it has been squashed first (by resizing the window, in IE only). This is an edge case, but we can still put effort in fixing it.

This is in relation with the dimensions of the body's content (the less height, the less the `Popover` stretches again.) Also the `max-height` keeps being set correctly.

#### Screenshot before this PR
![screenshot 2019-01-02 at 17 53 33](https://user-images.githubusercontent.com/23736202/50647384-b3e2fb00-0f78-11e9-8280-c48aa55509f3.png)

#### Screenshot after this PR

### Breaking changes
