### PR TITLE
Popover: Fix update of dimension and position

### DIFF
--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -20,11 +20,11 @@ class Popover extends PureComponent {
 
   componentDidMount() {
     document.body.appendChild(this.popoverRoot);
-    events.addEventsToWindow({ scroll: this.setPlacementThrottled });
+    events.addEventsToWindow({ resize: this.setPlacementThrottled, scroll: this.setPlacementThrottled });
   }
 
   componentWillUnmount() {
-    events.removeEventsFromWindow({ scroll: this.setPlacementThrottled });
+    events.removeEventsFromWindow({ resize: this.setPlacementThrottled, scroll: this.setPlacementThrottled });
     document.body.removeChild(this.popoverRoot);
   }
 


### PR DESCRIPTION
### Description

In #485, I made the mistake to remove a resize listener on the window 😬.
In the `Popover` the `ReactResizeDetector` checks only the resizing of the `Popover` itself, but not of that of the window.

This PR just adds the resize listener to the window again.

Luckily this is still caught before the release :+1:.

There are no visual changes.

### Breaking changes

None.
