### PR TITLE
[TU-248] Message button placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- `Message`: swapped the Link and the Button placement & always align them on the right. ([@driesd](https://github.com/driesd) in [#493](https://github.com/teamleadercrm/ui/pull/493))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/message/Message.js
+++ b/src/components/message/Message.js
@@ -20,7 +20,7 @@ class Message extends PureComponent {
           {hasAction && (
             <ButtonGroup justifyContent={imagePositioning === 'center' ? 'center' : 'flex-end'} marginTop={4}>
               {link}
-              {button && React.cloneElement(button, { className: theme['button'] })}
+              {button}
             </ButtonGroup>
           )}
         </div>

--- a/src/components/message/Message.js
+++ b/src/components/message/Message.js
@@ -19,8 +19,8 @@ class Message extends PureComponent {
           {children}
           {hasAction && (
             <ButtonGroup className={theme['actions']} marginTop={4}>
-              {button && React.cloneElement(button, { className: theme['button'] })}
               {link}
+              {button && React.cloneElement(button, { className: theme['button'] })}
             </ButtonGroup>
           )}
         </div>

--- a/src/components/message/Message.js
+++ b/src/components/message/Message.js
@@ -15,7 +15,7 @@ class Message extends PureComponent {
     return (
       <Box data-teamleader-ui="message" className={classNames} {...others}>
         {image && <div className={theme['image']}>{image}</div>}
-        <div className={theme['content']}>
+        <Box flex="2">
           {children}
           {hasAction && (
             <ButtonGroup justifyContent={imagePositioning === 'center' ? 'center' : 'flex-end'} marginTop={4}>
@@ -23,7 +23,7 @@ class Message extends PureComponent {
               {button}
             </ButtonGroup>
           )}
-        </div>
+        </Box>
       </Box>
     );
   }

--- a/src/components/message/Message.js
+++ b/src/components/message/Message.js
@@ -18,7 +18,7 @@ class Message extends PureComponent {
         <div className={theme['content']}>
           {children}
           {hasAction && (
-            <ButtonGroup className={theme['actions']} marginTop={4}>
+            <ButtonGroup justifyContent={imagePositioning === 'center' ? 'center' : 'flex-end'} marginTop={4}>
               {link}
               {button && React.cloneElement(button, { className: theme['button'] })}
             </ButtonGroup>

--- a/src/components/message/theme.css
+++ b/src/components/message/theme.css
@@ -37,15 +37,6 @@
   margin-left: auto;
   margin-right: auto;
 
-  .actions {
-    flex-direction: column;
-
-    .button {
-      margin-bottom: var(--spacer-regular);
-      margin-right: 0;
-    }
-  }
-
   .image {
     margin-bottom: var(--spacer-regular);
   }

--- a/src/components/message/theme.css
+++ b/src/components/message/theme.css
@@ -6,10 +6,6 @@
   align-items: center;
 }
 
-.content {
-  flex: 2;
-}
-
 .image {
   flex: 1;
   display: flex;


### PR DESCRIPTION
### Description

This PR swaps the Link and the Button placement in our Message component. It also makes sure that they are always aligned on the right.

### Screenshot before this PR

**Without image**

![schermafdruk 2019-01-04 11 02 22](https://user-images.githubusercontent.com/5336831/50682788-4387b880-1010-11e9-8632-a861f6b5b8f5.png)

**With image left**

![schermafdruk 2019-01-04 11 01 29](https://user-images.githubusercontent.com/5336831/50682818-61551d80-1010-11e9-832f-7ff4fbcd95ab.png)

**With image centered**

![schermafdruk 2019-01-04 11 01 58](https://user-images.githubusercontent.com/5336831/50682825-65813b00-1010-11e9-9c53-354f1b311c96.png)

### Screenshot after this PR

**Without image**

![schermafdruk 2019-01-04 10 57 54](https://user-images.githubusercontent.com/5336831/50682858-7fbb1900-1010-11e9-91b4-3db1a3a78322.png)

**With image left**

![schermafdruk 2019-01-04 10 58 09](https://user-images.githubusercontent.com/5336831/50682864-86499080-1010-11e9-9b24-3db4632b1edf.png)

**With image centered**

![schermafdruk 2019-01-04 10 58 23](https://user-images.githubusercontent.com/5336831/50682876-8ba6db00-1010-11e9-911e-ac621ece2893.png)

### Breaking changes

None
