### PR TITLE
[TU-191] Input: directly provide width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `SingleLineInputBase`: added the `width` prop to override its full width default behavior. ([@driesd](https://github.com/driesd) in [#494](https://github.com/teamleadercrm/ui/pull/494))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/input/SingleLineInputBase.js
+++ b/src/components/input/SingleLineInputBase.js
@@ -82,10 +82,7 @@ class SingleLineInputBase extends PureComponent {
       <Box className={classNames} {...boxProps}>
         <div className={theme['input-wrapper']}>
           {connectedLeft}
-          <div
-            className={theme['input-inner-wrapper']}
-            style={{ width: width && `${width}px`, flex: width && '0 0 auto' }}
-          >
+          <div className={theme['input-inner-wrapper']} style={{ width, flex: width && '0 0 auto' }}>
             {prefix && <div className={theme['prefix-wrapper']}>{this.renderOneOrMultipleElements(prefix)}</div>}
             <InputBase {...inputProps} />
             {suffix && <div className={theme['suffix-wrapper']}>{this.renderOneOrMultipleElements(suffix)}</div>}
@@ -107,8 +104,8 @@ SingleLineInputBase.propTypes = {
   prefix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
   /** The text string/element to use as a suffix inside the input field */
   suffix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
-  /** A custom width (in pixels) for the input field */
-  width: PropTypes.number,
+  /** A custom width for the input field */
+  width: PropTypes.string,
 };
 
 export default SingleLineInputBase;

--- a/src/components/input/SingleLineInputBase.js
+++ b/src/components/input/SingleLineInputBase.js
@@ -49,6 +49,7 @@ class SingleLineInputBase extends PureComponent {
       inverse,
       readOnly,
       suffix,
+      width,
       ...others
     } = this.props;
 
@@ -81,7 +82,10 @@ class SingleLineInputBase extends PureComponent {
       <Box className={classNames} {...boxProps}>
         <div className={theme['input-wrapper']}>
           {connectedLeft}
-          <div className={theme['input-inner-wrapper']}>
+          <div
+            className={theme['input-inner-wrapper']}
+            style={{ width: width && `${width}px`, flex: width && '0 0 auto' }}
+          >
             {prefix && <div className={theme['prefix-wrapper']}>{this.renderOneOrMultipleElements(prefix)}</div>}
             <InputBase {...inputProps} />
             {suffix && <div className={theme['suffix-wrapper']}>{this.renderOneOrMultipleElements(suffix)}</div>}
@@ -103,6 +107,8 @@ SingleLineInputBase.propTypes = {
   prefix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
   /** The text string/element to use as a suffix inside the input field */
   suffix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
+  /** A custom width (in pixels) for the input field */
+  width: PropTypes.number,
 };
 
 export default SingleLineInputBase;

--- a/stories/input.js
+++ b/stories/input.js
@@ -82,6 +82,7 @@ storiesOf('Form elements/Input', module)
       }
       prefix={boolean('Toggle prefix', false) ? prefix : undefined}
       suffix={boolean('Toggle suffix', false) ? suffix : undefined}
+      width={number('width', undefined)}
     />
   ))
   .add('NumericInput', () => (
@@ -113,6 +114,7 @@ storiesOf('Form elements/Input', module)
       }
       prefix={boolean('Toggle prefix', false) ? prefix : undefined}
       suffix={boolean('Toggle suffix', false) ? suffix : undefined}
+      width={number('width', undefined)}
     />
   ))
   .add('Textarea', () => (

--- a/stories/input.js
+++ b/stories/input.js
@@ -82,7 +82,7 @@ storiesOf('Form elements/Input', module)
       }
       prefix={boolean('Toggle prefix', false) ? prefix : undefined}
       suffix={boolean('Toggle suffix', false) ? suffix : undefined}
-      width={number('width', undefined)}
+      width={text('width', undefined)}
     />
   ))
   .add('NumericInput', () => (
@@ -114,7 +114,7 @@ storiesOf('Form elements/Input', module)
       }
       prefix={boolean('Toggle prefix', false) ? prefix : undefined}
       suffix={boolean('Toggle suffix', false) ? suffix : undefined}
-      width={number('width', undefined)}
+      width={text('width', undefined)}
     />
   ))
   .add('Textarea', () => (


### PR DESCRIPTION
### Description

This PR makes it possible to override the default full width of an `single line input field` with a custom `value + unit`. I've implemented the `width` prop. Not implemented for our Textarea component for now.

#### Screenshot before this PR

![schermafdruk 2019-01-04 14 57 54](https://user-images.githubusercontent.com/5336831/50691504-34653280-1031-11e9-8351-30d6c4ed17b2.png)

![schermafdruk 2019-01-04 14 58 19](https://user-images.githubusercontent.com/5336831/50691507-3929e680-1031-11e9-9e85-1d2c56c273b4.png)

#### Screenshot after this PR

![schermafdruk 2019-01-04 14 44 21](https://user-images.githubusercontent.com/5336831/50691269-7e99e400-1030-11e9-8094-17c13285323e.png)

![schermafdruk 2019-01-04 14 46 09](https://user-images.githubusercontent.com/5336831/50691274-82c60180-1030-11e9-97dd-0f771cbef4ba.png)

### Breaking changes

None.
