### PR TITLE
[TU-261] Popover: cross browser height fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- `Popover`: fixed squashing of the `Popover`s body in Internet Explorer 10-11 ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#495](https://github.com/teamleadercrm/ui/pull/495))
+
 ## [0.19.4] - 2018-12-26
 
 ### Added

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -9,6 +9,7 @@ import ReactResizeDetector from 'react-resize-detector';
 import { events } from '../utils';
 import { calculatePositions } from './positionCalculation';
 import ScrollContainer from '../scrollContainer';
+import Box from '../box';
 import theme from './theme.css';
 
 const MAX_HEIGHT_DEFAULT = 240;
@@ -20,11 +21,11 @@ class Popover extends PureComponent {
 
   componentDidMount() {
     document.body.appendChild(this.popoverRoot);
-    events.addEventsToWindow({ scroll: this.setPlacementThrottled });
+    events.addEventsToWindow({ resize: this.setPlacementThrottled, scroll: this.setPlacementThrottled });
   }
 
   componentWillUnmount() {
-    events.removeEventsFromWindow({ scroll: this.setPlacementThrottled });
+    events.removeEventsFromWindow({ resize: this.setPlacementThrottled, scroll: this.setPlacementThrottled });
     document.body.removeChild(this.popoverRoot);
   }
 
@@ -47,6 +48,8 @@ class Popover extends PureComponent {
   getMaxHeight = () => {
     const { fullHeight } = this.props;
     const { maxHeight } = this.state.positioning;
+
+    console.log(maxHeight);
 
     if (!fullHeight && maxHeight > MAX_HEIGHT_DEFAULT) {
       return MAX_HEIGHT_DEFAULT;
@@ -111,13 +114,15 @@ class Popover extends PureComponent {
                 }}
               >
                 <div className={theme['arrow']} style={{ left: `${arrowLeft}px`, top: `${arrowTop}px` }} />
-                <ScrollContainer
-                  className={theme['inner']}
-                  header={header}
-                  body={children}
-                  footer={footer}
-                  style={{ maxHeight: this.getMaxHeight() }}
-                />
+                <Box display="flex">
+                  <ScrollContainer
+                    className={theme['inner']}
+                    header={header}
+                    body={children}
+                    footer={footer}
+                    style={{ maxHeight: this.getMaxHeight() }}
+                  />
+                </Box>
                 <ReactResizeDetector
                   handleHeight
                   handleWidth

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -49,8 +49,6 @@ class Popover extends PureComponent {
     const { fullHeight } = this.props;
     const { maxHeight } = this.state.positioning;
 
-    console.log(maxHeight);
-
     if (!fullHeight && maxHeight > MAX_HEIGHT_DEFAULT) {
       return MAX_HEIGHT_DEFAULT;
     }

--- a/src/components/scrollContainer/ScrollContainer.js
+++ b/src/components/scrollContainer/ScrollContainer.js
@@ -12,9 +12,9 @@ class ScrollContainer extends PureComponent {
 
     return (
       <Box className={classNames} display="flex" flexDirection="column" {...others}>
-        {header && <header>{header}</header>}
+        {header && <header className={theme['scroll-container-header']}>{header}</header>}
         {body && <div className={theme['scroll-container-body']}>{body}</div>}
-        {footer && <footer>{footer}</footer>}
+        {footer && <footer className={theme['scroll-container-footer']}>{footer}</footer>}
       </Box>
     );
   }

--- a/src/components/scrollContainer/theme.css
+++ b/src/components/scrollContainer/theme.css
@@ -3,6 +3,8 @@
 }
 
 .scroll-container-body {
-  flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: auto;
   overflow: auto;
 }


### PR DESCRIPTION
### Description

This PR aims to fix a bug in IE11(/10), where the `Popover`s body collapses.

The solution currently applied is based upon: a [flexbugs workaround](https://github.com/philipwalton/flexbugs#workaround-2) and [this JSFiddle](https://jsfiddle.net/gktpsyv5/).

One minor issue though, the `Popover` does not stretch itself fully anymore (a little bit of scrolling stays), once it has been squashed first (by resizing the window when the `Popover` is active and it would overflow the viewport, in IE only). But as this is a very detailed edge case, we've decided to skip it for now and get this solution through the door.

#### Screenshot before this PR
![screenshot 2019-01-02 at 17 53 33](https://user-images.githubusercontent.com/23736202/50647384-b3e2fb00-0f78-11e9-8280-c48aa55509f3.png)

#### Screenshot after this PR
![screenshot 2019-01-04 at 15 20 24](https://user-images.githubusercontent.com/23736202/50692472-498f9080-1034-11e9-813b-591886369df5.png)

### Breaking changes

None