### PR TITLE
[TU-261] Popover: set dimensions via CSS fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Popover`: fixed setting the dimensions of the `Popover`, via styling applied by passed down class names ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#498](https://github.com/teamleadercrm/ui/pull/498))
+
 ## [0.19.6] - 2018-01-07
 
 ### Changed

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -112,7 +112,7 @@ class Popover extends PureComponent {
                 }}
               >
                 <div className={theme['arrow']} style={{ left: `${arrowLeft}px`, top: `${arrowTop}px` }} />
-                <Box display="flex">
+                <Box display="flex" flexDirection="column">
                   <ScrollContainer
                     className={theme['inner']}
                     header={header}


### PR DESCRIPTION
### Description

In #495 I fixed the faulty rendering of the `Popover`.

Where I partially apply the solution suggested in: a [flexbugs workaround](https://github.com/philipwalton/flexbugs#workaround-2) and [this JSFiddle](https://jsfiddle.net/gktpsyv5/).

Initially I didn't set the `flex-direction` to `column` of the wrapper, as the issue was already resolved by leaving this part out.

But when updating this package in `core` I noticed some issues. Dimensions set via a custom passed class name did not have the desired effect anymore.

![screenshot 2019-01-08 at 19 41 58](https://user-images.githubusercontent.com/23736202/50852785-d615b800-1380-11e9-807e-f5ae1236356b.jpg)
![screenshot 2019-01-08 at 18 13 11](https://user-images.githubusercontent.com/23736202/50852841-f9406780-1380-11e9-839e-8909888d417d.jpg)
_The `Popover`s in core_

This is then resolved by - maybe you can guess it already - setting the `flex-direction` to `column`.

#### Screenshot before this PR
![screenshot 2019-01-08 at 20 10 12](https://user-images.githubusercontent.com/23736202/50853054-7b309080-1381-11e9-83e9-32bcf6c52b3b.png)

#### Screenshot after this PR
![screenshot 2019-01-08 at 20 10 35](https://user-images.githubusercontent.com/23736202/50853063-808ddb00-1381-11e9-8bf3-7b88ed262509.png)

_In these examples I pass a CSS classes that applies `min-width: 600px` to the `Popover`_

### Breaking changes

None