### PR TITLE
[TU-256] QTip: overlay event handler props & closed becomes active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@
 ### Added
 
 - `SingleLineInputBase`: added the `width` prop to override its full width default behavior. ([@driesd](https://github.com/driesd) in [#494](https://github.com/teamleadercrm/ui/pull/494))
+- `QTip`: added the `onEscKeyDown`, `onOverlayClick`, `onOverlayMouseDown`, `onOverlayMouseMove` & `onOverlayMouseUp` props. ([@driesd](https://github.com/driesd) in [#500](https://github.com/teamleadercrm/ui/pull/500))
 
 ### Changed
+
+- [BREAKING] `QTip`: `closed` prop has been renamed to `active`, logic & styling have been inverted. ([@driesd](https://github.com/driesd) in [#500](https://github.com/teamleadercrm/ui/pull/500))
+- [BREAKING] `QTip`: `onEscKeyDown` prop has to be explicitly passed instead of reusing the `onChange` prop internally. ([@driesd](https://github.com/driesd) in [#500](https://github.com/teamleadercrm/ui/pull/500))
 
 ### Deprecated
 

--- a/src/components/qTip/QTip.js
+++ b/src/components/qTip/QTip.js
@@ -9,10 +9,10 @@ import Box from '../box';
 
 class QTip extends PureComponent {
   render() {
-    const { children, closed, highlighted, icon, onChange, ...others } = this.props;
+    const { active, children, highlighted, icon, onChange, ...others } = this.props;
 
     const classNames = cx(theme['container'], {
-      [theme['is-closed']]: closed,
+      [theme['is-active']]: active,
       [theme['is-highlighted']]: highlighted,
     });
 
@@ -20,7 +20,7 @@ class QTip extends PureComponent {
 
     return (
       <Box className={classNames} {...others}>
-        <Overlay active={!closed} onEscKeyDown={onChange} />
+        <Overlay active={active} onEscKeyDown={onChange} />
         <div className={theme['qtip']}>
           <Button className={theme['icon']} level={level} onClick={onChange} icon={icon} />
           <div className={theme['inner-container']}>
@@ -39,11 +39,15 @@ class QTip extends PureComponent {
 }
 
 QTip.propTypes = {
+  active: PropTypes.bool,
   children: PropTypes.node.isRequired,
-  closed: PropTypes.bool,
   highlighted: PropTypes.bool,
   icon: PropTypes.element.isRequired,
   onChange: PropTypes.func.isRequired,
+};
+
+QTip.defaultProps = {
+  active: false,
 };
 
 export default QTip;

--- a/src/components/qTip/QTip.js
+++ b/src/components/qTip/QTip.js
@@ -39,10 +39,15 @@ class QTip extends PureComponent {
 }
 
 QTip.propTypes = {
+  /** If true, the QTip becomes fully visible on screen. */
   active: PropTypes.bool,
+  /** The content to display inside the QTip. */
   children: PropTypes.node.isRequired,
+  /** If true, the toggle button's color changes to mint instead of neutral. */
   highlighted: PropTypes.bool,
+  /** The icon displayed inside the toggle button. */
   icon: PropTypes.element.isRequired,
+  /** Callback function that is fired when the active prop has changed. */
   onChange: PropTypes.func.isRequired,
 };
 

--- a/src/components/qTip/QTip.js
+++ b/src/components/qTip/QTip.js
@@ -9,7 +9,19 @@ import Box from '../box';
 
 class QTip extends PureComponent {
   render() {
-    const { active, children, highlighted, icon, onChange, ...others } = this.props;
+    const {
+      active,
+      children,
+      highlighted,
+      icon,
+      onChange,
+      onEscKeyDown,
+      onOverlayClick,
+      onOverlayMouseDown,
+      onOverlayMouseMove,
+      onOverlayMouseUp,
+      ...others
+    } = this.props;
 
     const classNames = cx(theme['container'], {
       [theme['is-active']]: active,
@@ -20,7 +32,14 @@ class QTip extends PureComponent {
 
     return (
       <Box className={classNames} {...others}>
-        <Overlay active={active} onEscKeyDown={onChange} />
+        <Overlay
+          active={active}
+          onClick={onOverlayClick}
+          onEscKeyDown={onEscKeyDown}
+          onMouseDown={onOverlayMouseDown}
+          onMouseMove={onOverlayMouseMove}
+          onMouseUp={onOverlayMouseUp}
+        />
         <div className={theme['qtip']}>
           <Button className={theme['icon']} level={level} onClick={onChange} icon={icon} />
           <div className={theme['inner-container']}>
@@ -47,8 +66,18 @@ QTip.propTypes = {
   highlighted: PropTypes.bool,
   /** The icon displayed inside the toggle button. */
   icon: PropTypes.element.isRequired,
-  /** Callback function that is fired when the active prop has changed. */
+  /** The function executed, when the active prop has changed. */
   onChange: PropTypes.func.isRequired,
+  /** The function executed, when the "ESC" key is down. */
+  onEscKeyDown: PropTypes.func,
+  /** The function executed, when the Overlay is clicked. */
+  onOverlayClick: PropTypes.func,
+  /** The function executed, when the mouse is down on the Overlay. */
+  onOverlayMouseDown: PropTypes.func,
+  /** The function executed, when the mouse is being moved over the Overlay. */
+  onOverlayMouseMove: PropTypes.func,
+  /** The function executed, when the mouse is up on the Overlay. */
+  onOverlayMouseUp: PropTypes.func,
 };
 
 QTip.defaultProps = {

--- a/src/components/qTip/theme.css
+++ b/src/components/qTip/theme.css
@@ -11,7 +11,7 @@
   overflow: hidden;
   pointer-events: none;
 
-  &:not(.is-closed) {
+  &:not(.is-active) {
     z-index: 600;
   }
 }
@@ -23,11 +23,12 @@
   border-right: 0;
   border-top-left-radius: 4px;
   border-bottom-left-radius: 4px;
+  transform: translateX(100%) translateX(calc(-1 * var(--tip-width) + 1px)); /* split into 2 separete translate, otherwise IE can't handle it */
   transition: all var(--animation-duration) var(--animation-curve-default);
   pointer-events: all;
 
-  .is-closed & {
-    transform: translateX(100%) translateX(calc(-1 * var(--tip-width) + 1px)); /* split into 2 separete translate, otherwise IE can't handle it */
+  .is-active & {
+    transform: translateX(0);
   }
 }
 

--- a/src/components/qTip/theme.css
+++ b/src/components/qTip/theme.css
@@ -23,7 +23,7 @@
   border-right: 0;
   border-top-left-radius: 4px;
   border-bottom-left-radius: 4px;
-  transform: translateX(100%) translateX(calc(-1 * var(--tip-width) + 1px)); /* split into 2 separete translate, otherwise IE can't handle it */
+  transform: translate3d(100%, 0, 0) translate3d(calc(-1 * var(--tip-width) + 1px), 0, 0); /* split into 2 separete translate, otherwise IE can't handle it */
   transition: all var(--animation-duration) var(--animation-curve-default);
   pointer-events: all;
 

--- a/src/components/qTip/theme.css
+++ b/src/components/qTip/theme.css
@@ -28,7 +28,7 @@
   pointer-events: all;
 
   .is-active & {
-    transform: translateX(0);
+    transform: translate3d(0, 0, 0);
   }
 }
 

--- a/stories/qTip.js
+++ b/stories/qTip.js
@@ -22,7 +22,13 @@ storiesOf('Q-tip', module)
   .add('Default', () => (
     <Island paddingHorizontal={0} paddingVertical={6} style={{ width: '500px' }}>
       <State store={store}>
-        <QTip highlighted={boolean('Highlighted', false)} onChange={updateState} icon={<IconIdeaMediumOutline />}>
+        <QTip
+          highlighted={boolean('Highlighted', false)}
+          onChange={updateState}
+          onEscKeyDown={updateState}
+          onOverlayClick={updateState}
+          icon={<IconIdeaMediumOutline />}
+        >
           <TextBody color="teal">
             Lorem ipsum dolor sit amet, consectetur{' '}
             <Link href="#" inherit={false}>

--- a/stories/qTip.js
+++ b/stories/qTip.js
@@ -6,11 +6,11 @@ import { IconIdeaMediumOutline } from '@teamleader/ui-icons';
 import { Island, Link, QTip, TextBody } from '../src';
 
 const store = new Store({
-  closed: true,
+  active: false,
 });
 
 const updateState = () => {
-  store.set({ closed: !store.get('closed') });
+  store.set({ active: !store.get('active') });
 };
 
 storiesOf('Q-tip', module)


### PR DESCRIPTION
### Description

This PR renames the `closed` prop to `active` and inverts the according logic & styles. It also implements the missing `overlay event handler props` to be consistent with Popover & Dialog.

#### Screenshot of the QTip

![schermafdruk 2019-01-15 09 19 08](https://user-images.githubusercontent.com/5336831/51167353-aeee4780-18a6-11e9-9bb8-7905c29fad9b.png)

### Breaking changes

- `closed` prop has been renamed to `active`, logic & styling have been inverted
- `onEscKeyDown` prop has to be explicitly passed instead of reusing the `onChange` prop
