### PR TITLE
Release 0.19.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,6 @@
 
 - `SingleLineInputBase`: added the `width` prop to override its full width default behavior. ([@driesd](https://github.com/driesd) in [#494](https://github.com/teamleadercrm/ui/pull/494))
 
-### Changed
-
-### Deprecated
-
-### Removed
-
 ### Fixed
 
 - Make the main entryfile in `package.json` explicit to avoid auto-importing issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+## [0.19.8] - 2019-01-15
+
+### Added
+
 - `SingleLineInputBase`: added the `width` prop to override its full width default behavior. ([@driesd](https://github.com/driesd) in [#494](https://github.com/teamleadercrm/ui/pull/494))
 
 ### Changed
@@ -14,13 +26,13 @@
 
 - Make the main entryfile in `package.json` explicit to avoid auto-importing issues.
 
-## [0.19.7] - 2018-01-09
+## [0.19.7] - 2019-01-09
 
 ### Fixed
 
 - `Popover`: fixed setting the dimensions of the `Popover`, via styling applied by passed down class names ([@LennertBlommaert](https://github.com/LennertBlommaert) in [#498](https://github.com/teamleadercrm/ui/pull/498))
 
-## [0.19.6] - 2018-01-07
+## [0.19.6] - 2019-01-07
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "author": "Teamleader <development@teamleader.eu>",
   "betterScripts": {
     "compile": {


### PR DESCRIPTION
## [0.19.8] - 2019-01-15

### Added

- `SingleLineInputBase`: added the `width` prop to override its full width default behavior. ([@driesd](https://github.com/driesd) in [#494](https://github.com/teamleadercrm/ui/pull/494))

### Fixed

- Make the main entryfile in `package.json` explicit to avoid auto-importing issues.