### PR TITLE
Maintenance: validation - clean up obsolete styles

### DIFF
--- a/src/components/datepicker/theme.css
+++ b/src/components/datepicker/theme.css
@@ -428,22 +428,12 @@
       border-color: var(--input-error-border) !important;
       box-shadow: 0 0 0 1px var(--input-error-border);
     }
-
-    .validation-icon,
-    .validation-text {
-      color: var(--color-ruby-dark);
-    }
   }
 
   &.is-inverse {
     .input-wrapper {
       border-color: var(--input-error-border-inverse) !important;
       box-shadow: 0 0 0 1px var(--input-error-border-inverse);
-    }
-
-    .validation-icon,
-    .validation-text {
-      color: var(--color-ruby-light);
     }
   }
 }

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -294,14 +294,6 @@
   }
 }
 
-.error {
-  color: var(--color-ruby-dark);
-}
-
-.validation-icon {
-  margin-top: -1px;
-}
-
 .textarea {
   height: 100%;
   overflow: auto;
@@ -390,10 +382,6 @@
       box-shadow: 0 0 0 1px var(--input-error-border);
       z-index: 2;
     }
-
-    .validation-text {
-      color: var(--color-ruby-dark);
-    }
   }
 
   &.is-inverse {
@@ -402,10 +390,6 @@
       border-color: var(--input-error-border-inverse);
       box-shadow: 0 0 0 1px var(--input-error-border-inverse);
       z-index: 2;
-    }
-
-    .validation-text {
-      color: var(--color-ruby-light);
     }
   }
 }

--- a/src/components/select/theme.css
+++ b/src/components/select/theme.css
@@ -16,17 +16,3 @@
 .is-large .dropdown-indicator {
   width: 36px;
 }
-
-.validation-icon {
-  margin-top: -1px;
-}
-
-.has-error {
-  &:not(.is-inverse) .validation-text {
-    color: var(--color-ruby-dark);
-  }
-
-  &.is-inverse .validation-text {
-    color: var(--color-ruby-light);
-  }
-}


### PR DESCRIPTION
### Description

This PR cleans up the css for `DatePicker`, `Input` & `Select` by removing the obsolete styles for validation text & icon (when error occured). We can do this safely since we extracted the validation (error & helpText) logic and styles to a separate component in an earlier PR.

### Breaking changes

None
