### PR TITLE
[FIX] Merge passed inputProps with internal inputProps in DatePickerInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `DatePickerInput`: merged the passed inputProps with the internal inputProps. ([@duivvv](https://github.com/duivvv) in [#503](https://github.com/teamleadercrm/ui/pull/503))
+
 ## [0.19.8] - 2019-01-15
 
 ### Added

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -44,13 +44,13 @@ class DatePickerInput extends PureComponent {
   };
 
   renderDayPickerInput = () => {
-    const { className, dayPickerProps, disabled, modifiers, readOnly, size, ...others } = this.props;
+    const { className, dayPickerProps, disabled, inputProps, modifiers, readOnly, size, ...others } = this.props;
     const { selectedDate } = this.state;
 
     const dayPickerClassNames = cx(theme['date-picker'], theme[`is-${size}`], className);
 
     const propsWithoutBoxProps = omitBoxProps(others);
-    const restProps = omit(propsWithoutBoxProps, ['helpText', 'onBlur', 'onChange', 'onFocus']);
+    const restProps = omit(propsWithoutBoxProps, ['helpText', 'onBlur', 'onChange', 'onFocus', 'inputProps']);
 
     return (
       <DayPickerInput
@@ -70,6 +70,7 @@ class DatePickerInput extends PureComponent {
           disabled: disabled || readOnly,
           onBlur: this.handleBlur,
           onFocus: this.handleFocus,
+          ...inputProps,
         }}
         {...restProps}
       />
@@ -126,6 +127,7 @@ DatePickerInput.propTypes = {
   /** The text string/element to use as error message below the input. */
   error: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   helpText: PropTypes.string,
+  inputProps: PropTypes.object,
   inverse: PropTypes.bool,
   modifiers: PropTypes.object,
   /** Callback function that is fired when blurring the input field. */


### PR DESCRIPTION
### Description

- Added merging of `inputProps` in DatePickerInput (this caused some weird behaviour)

When passing custom InputProps like this

```js

<DatePickerInput
  value={value}
  onChange={onChange}
  inputProps={{ className: styles['wrapper'] }}
  onBlur={this.handleBlur}
  error={error}
/>

```

... the [internal ones](https://github.com/teamleadercrm/ui/pull/503/files#diff-cd03a1a42d98689a7cc6580ecb494a2aR69) were overwritten, causing onChange and onBlur to not trigger.