### PR TITLE
[TU-274 DatePickerInput & DatePickerInputRange: directly provide width

### DIFF
--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -93,7 +93,7 @@ class DatePickerInput extends PureComponent {
   };
 
   render() {
-    const { bold, disabled, error, helpText, inverse, readOnly, size, warning, ...others } = this.props;
+    const { bold, disabled, error, helpText, inverse, readOnly, size, warning, width, ...others } = this.props;
     const { inputHasFocus } = this.state;
 
     const boxProps = pickBoxProps(others);
@@ -110,7 +110,7 @@ class DatePickerInput extends PureComponent {
 
     return (
       <Box className={classNames} {...boxProps}>
-        <div className={theme['input-wrapper']}>
+        <div className={theme['input-wrapper']} style={{ width }}>
           {this.renderIcon()}
           {this.renderDayPickerInput()}
         </div>
@@ -141,6 +141,8 @@ DatePickerInput.propTypes = {
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   /** The text to use as warning message below the input. */
   warning: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  /** A custom width for the input field */
+  width: PropTypes.string,
 };
 
 DatePickerInput.defaultProps = {
@@ -149,6 +151,7 @@ DatePickerInput.defaultProps = {
   inverse: false,
   readOnly: false,
   size: 'medium',
+  width: '110px',
 };
 
 export default DatePickerInput;

--- a/src/components/datepicker/DatePickerInputRange.js
+++ b/src/components/datepicker/DatePickerInputRange.js
@@ -212,7 +212,7 @@ class DatePickerInputRange extends PureComponent {
   };
 
   render() {
-    const { bold, disabled, error, helpText, inverse, readOnly, size, warning, ...others } = this.props;
+    const { bold, disabled, error, helpText, inverse, readOnly, size, warning, width, ...others } = this.props;
 
     const boxProps = pickBoxProps(others);
 
@@ -228,7 +228,7 @@ class DatePickerInputRange extends PureComponent {
 
     return (
       <Box className={classNames} {...boxProps}>
-        <div className={theme['input-wrapper']}>
+        <div className={theme['input-wrapper']} style={{ width }}>
           {this.renderIcon()}
           {this.renderDayPickerInput()}
         </div>
@@ -271,6 +271,8 @@ DatePickerInputRange.propTypes = {
   inputEndDateValue: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
   /** The text to use as warning message below the input. */
   warning: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  /** A custom width for the input field */
+  width: PropTypes.string,
 };
 
 DatePickerInputRange.defaultProps = {
@@ -279,6 +281,7 @@ DatePickerInputRange.defaultProps = {
   inverse: false,
   readOnly: false,
   size: 'medium',
+  width: '210px',
 };
 
 export default DatePickerInputRange;

--- a/src/components/datepicker/theme.css
+++ b/src/components/datepicker/theme.css
@@ -13,8 +13,6 @@
   --input-height-small: calc(2.8 * var(--unit));
   --input-text-size: calc(1.4 * var(--unit));
   --input-text-size-large: calc(1.6 * var(--unit));
-  --input-width: calc(7.8 * var(--unit));
-  --input-width-large: calc(9 * var(--unit));
 }
 
 .date-picker {
@@ -359,10 +357,6 @@
   }
 }
 
-.date-picker-input-range input {
-  text-align: center;
-}
-
 .overlay {
   composes: box-shadow-200;
   background: var(--color-white);
@@ -388,9 +382,10 @@
 }
 
 .input-wrapper {
+  align-items: center;
   border: 1px solid;
   border-radius: var(--border-radius);
-  display: inline-block;
+  display: flex;
   transition: 0.3s ease-in-out border, 0.3s ease-in-out box-shadow;
   white-space: nowrap;
 
@@ -402,7 +397,7 @@
     font-size: var(--input-text-size);
     outline: 0;
     padding: 0;
-    width: var(--input-width);
+    width: 100%;
   }
 }
 
@@ -411,17 +406,29 @@
   top: -1px;
 }
 
-.container:not(.date-picker) {
-  display: inline-block;
-
-  &:last-child input {
-    padding: 0 5px 0 0;
+.date-picker-input,
+.date-picker-input-range {
+  .container {
+    flex: 1;
   }
 }
 
-.container:not(.date-picker) + .container:not(.date-picker)::before {
-  content: '-';
-  display: inline-block;
+.date-picker-input-range {
+  .container {
+    &:last-child {
+      padding-right: 24px;
+
+      input {
+        text-align: right;
+      }
+
+      &::before {
+        content: '-';
+        display: inline-block;
+        margin: 0 6px;
+      }
+    }
+  }
 }
 
 .has-warning {
@@ -566,7 +573,6 @@
     input {
       font-size: var(--input-text-size-large);
       height: var(--input-height-large);
-      width: var(--input-width-large);
     }
   }
 }

--- a/stories/datePicker.js
+++ b/stories/datePicker.js
@@ -75,6 +75,7 @@ storiesOf('Form elements/DatePicker', module)
         selectedDate={preSelectedDate}
         size={select('Size', sizes, 'medium')}
         value={preSelectedDate}
+        width={text('width', undefined)}
       />
     );
   })
@@ -130,6 +131,7 @@ storiesOf('Form elements/DatePicker', module)
         onChange={handleOnChange}
         selectedRange={preSelectedRange}
         size={select('Size', sizes, 'medium')}
+        width={text('width', undefined)}
       />
     );
   });


### PR DESCRIPTION
### Description

This PR implements a `width` prop in both `DatePickerInput` & `DatePickerInputRange` components. Different to the Input component, we set a default width to date input fields. In rare cases, you can always override with value `auto` if needed.

### Breaking changes

None
