### PR TITLE
[TU-275] Select: directly provide width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Select`: added the `width` prop to override its full width default behavior. ([@driesd](https://github.com/driesd) in [#510](https://github.com/teamleadercrm/ui/pull/510))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -29,11 +29,12 @@ class Select extends PureComponent {
   };
 
   getControlStyles = (base, { isDisabled, isFocused }) => {
-    const { error, inverse, size, warning } = this.props;
+    const { error, inverse, size, warning, width } = this.props;
 
     const commonStyles = {
       ...base,
       minHeight: size === 'small' ? '30px' : size === 'medium' ? '36px' : '48px',
+      width,
     };
 
     if (inverse) {
@@ -123,11 +124,16 @@ class Select extends PureComponent {
     };
   };
 
-  getMenuStyles = base => ({
-    ...base,
-    backgroundColor: this.props.inverse ? COLOR.TEAL.NORMAL : COLOR.NEUTRAL.LIGHTEST,
-    zIndex: 300,
-  });
+  getMenuStyles = base => {
+    const { inverse, width } = this.props;
+
+    return {
+      ...base,
+      backgroundColor: inverse ? COLOR.TEAL.NORMAL : COLOR.NEUTRAL.LIGHTEST,
+      width,
+      zIndex: 300,
+    };
+  };
 
   getMultiValueStyles = base => {
     const { inverse } = this.props;

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -331,12 +331,15 @@ Select.propTypes = {
   value: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.func]),
   /** The text to use as warning message below the input. */
   warning: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  /** A custom width for the input field */
+  width: PropTypes.string,
 };
 
 Select.defaultProps = {
   creatable: false,
   inverse: false,
   size: 'medium',
+  width: '100%',
 };
 
 export default Select;

--- a/stories/select.js
+++ b/stories/select.js
@@ -48,6 +48,7 @@ storiesOf('Form elements/Select', module)
       error={text('error', '')}
       helpText={text('helpText', '')}
       warning={text('warning', '')}
+      width={text('width', undefined)}
     />
   ))
   .add('Grouped', () => (
@@ -66,6 +67,7 @@ storiesOf('Form elements/Select', module)
       error={text('error', '')}
       helpText={text('helpText', '')}
       warning={text('warning', '')}
+      width={text('width', undefined)}
     />
   ))
   .add('Custom Option', () => (
@@ -87,6 +89,7 @@ storiesOf('Form elements/Select', module)
       error={text('error', '')}
       helpText={text('helpText', '')}
       warning={text('warning', '')}
+      width={text('width', undefined)}
     />
   ))
   .add('With label', () => (
@@ -105,6 +108,7 @@ storiesOf('Form elements/Select', module)
         error={text('error', '')}
         helpText={text('helpText', '')}
         warning={text('warning', '')}
+        width={text('width', undefined)}
       />
     </Label>
   ))
@@ -144,6 +148,7 @@ storiesOf('Form elements/Select', module)
         error={text('error', '')}
         helpText={text('helpText', '')}
         warning={text('warning', '')}
+        width={text('width', undefined)}
       />
     );
   });


### PR DESCRIPTION
### Description

This PR makes it possible to override the default full width of our `Select` component with a custom value + unit. I've implemented the `width` prop which defaults to 100%.

#### Screenshot before this PR

![schermafdruk 2019-01-17 15 08 10](https://user-images.githubusercontent.com/5336831/51324278-99297f80-1a6a-11e9-8d11-c4b314ebc290.png)

#### Screenshot after this PR

![schermafdruk 2019-01-17 14 59 18](https://user-images.githubusercontent.com/5336831/51324291-9fb7f700-1a6a-11e9-9814-fe5588b87c99.png)

### Breaking changes

None.
