### PR TITLE
Use a div as the element for the toast label/children wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Toast`: changed the element for the `TextBody` that is wrapping the `label` and `children` of a toast to a `div` (instead of the default `p`). ([@driesd](https://github.com/lowiebenoot) in [#515](https://github.com/teamleadercrm/ui/pull/515))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/toast/Toast.js
+++ b/src/components/toast/Toast.js
@@ -91,7 +91,7 @@ class Toast extends PureComponent {
       <div data-teamleader-ui="toast" onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
         <div className={classNames}>
           {processing && <LoadingSpinner className={theme['spinner']} color="neutral" tint="lightest" />}
-          <TextBody className={theme['label']} color="neutral" tint="lightest">
+          <TextBody className={theme['label']} color="neutral" tint="lightest" element="div">
             {label}
             {children}
           </TextBody>


### PR DESCRIPTION
Changed the element for the `TextBody` that is wrapping the Toast content, because if you use some custom content in a Toast, React might complain that you shouldn't use (for example) a `<p>` inside a `<p>`.

```
Warning: validateDOMNesting(...): <p> cannot appear as a descendant of <p>.
```

