### PR TITLE
Popover: drop header & footer, use children instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Removed
 
+- [BREAKING] `Popover`: removed `header` & `footer` prop, please use `children` instead. ([@driesd](https://github.com/driesd) in [#517](https://github.com/teamleadercrm/ui/pull/517))
+
 ### Fixed
 
 ## [0.20.1] - 2019-01-21

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -112,14 +112,14 @@ class Popover extends PureComponent {
                 }}
               >
                 <div className={theme['arrow']} style={{ left: `${arrowLeft}px`, top: `${arrowTop}px` }} />
-                <Box display="flex" flex="1" flexDirection="column">
-                  <ScrollContainer
-                    className={theme['inner']}
-                    header={header}
-                    body={children}
-                    footer={footer}
-                    style={{ maxHeight: this.getMaxHeight() }}
-                  />
+                <Box
+                  className={theme['inner']}
+                  display="flex"
+                  flex="1"
+                  flexDirection="column"
+                  style={{ maxHeight: this.getMaxHeight() }}
+                >
+                  {children}
                 </Box>
                 <ReactResizeDetector
                   handleHeight

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -68,7 +68,6 @@ class Popover extends PureComponent {
       className,
       color,
       footer,
-      header,
       lockScroll,
       onOverlayClick,
       onEscKeyDown,
@@ -156,8 +155,6 @@ Popover.propTypes = {
   direction: PropTypes.oneOf(['north', 'south', 'east', 'west']),
   /** Node to render as the footer */
   footer: PropTypes.node,
-  /** Node to render as the header */
-  header: PropTypes.node,
   /** If true, the Popover stretches to fit its content vertically */
   fullHeight: PropTypes.bool,
   /** The scroll state of the body, if true it will not be scrollable. */

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -67,7 +67,6 @@ class Popover extends PureComponent {
       children,
       className,
       color,
-      footer,
       lockScroll,
       onOverlayClick,
       onEscKeyDown,
@@ -153,8 +152,6 @@ Popover.propTypes = {
   color: PropTypes.oneOf(['aqua', 'gold', 'mint', 'neutral', 'ruby', 'teal', 'violet']),
   /** The direction in which the Popover is rendered, is overridden with the opposite direction if the Popover cannot be entirely displayed in the current direction. */
   direction: PropTypes.oneOf(['north', 'south', 'east', 'west']),
-  /** Node to render as the footer */
-  footer: PropTypes.node,
   /** If true, the Popover stretches to fit its content vertically */
   fullHeight: PropTypes.bool,
   /** The scroll state of the body, if true it will not be scrollable. */

--- a/stories/popover.js
+++ b/stories/popover.js
@@ -78,12 +78,10 @@ storiesOf('Popover', module)
           tint={select('Tint', tints, 'lightest')}
           lockScroll={boolean('Lock scroll', true)}
           offsetCorrection={number('Offset correction', 0)}
-          header={
-            <Banner fullWidth>
-              <Heading3>Popover Title</Heading3>
-            </Banner>
-          }
         >
+          <Banner fullWidth>
+            <Heading3>Popover Title</Heading3>
+          </Banner>
           {contentBoxWithSingleTextLine}
         </Popover>
       </State>
@@ -105,13 +103,11 @@ storiesOf('Popover', module)
           tint={select('Tint', tints, 'lightest')}
           lockScroll={boolean('Lock scroll', true)}
           offsetCorrection={number('Offset correction', 0)}
-          header={
-            <Banner color="neutral" fullWidth>
-              <Heading3>Popover Title</Heading3>
-              <TextSmall marginTop={1}>This is the popover content</TextSmall>
-            </Banner>
-          }
         >
+          <Banner color="neutral" fullWidth>
+            <Heading3>Popover Title</Heading3>
+            <TextSmall marginTop={1}>This is the popover content</TextSmall>
+          </Banner>
           {contentBoxWithSingleTextLine}
         </Popover>
       </State>
@@ -133,12 +129,10 @@ storiesOf('Popover', module)
           tint={select('Tint', tints, 'lightest')}
           lockScroll={boolean('Lock scroll', true)}
           offsetCorrection={number('Offset correction', 0)}
-          header={
-            <Banner onClose={handleCloseClick} fullWidth>
-              <Heading3>I am a heading 3</Heading3>
-            </Banner>
-          }
         >
+          <Banner onClose={handleCloseClick} fullWidth>
+            <Heading3>I am a heading 3</Heading3>
+          </Banner>
           {contentBoxWithSingleTextLine}
         </Popover>
       </State>
@@ -160,14 +154,42 @@ storiesOf('Popover', module)
           tint={select('Tint', tints, 'lightest')}
           lockScroll={boolean('Lock scroll', true)}
           offsetCorrection={number('Offset correction', 0)}
-          footer={
-            <ButtonGroup justifyContent="flex-end" padding={4}>
-              <Button label="Cancel" />
-              <Button level="primary" label="Confirm" />
-            </ButtonGroup>
-          }
         >
           {contentBoxWithSingleTextLine}
+          <ButtonGroup justifyContent="flex-end" padding={4}>
+            <Button label="Cancel" />
+            <Button level="primary" label="Confirm" />
+          </ButtonGroup>
+        </Popover>
+      </State>
+    </Box>
+  ))
+  .add('experiment 0', () => (
+    <Box display="flex" justifyContent="center">
+      <Button onClick={handleButtonClick} label="Open a experimental Popover" />
+      <State store={store}>
+        <Popover
+          active={false}
+          backdrop={select('Backdrop', backdrops, 'transparent')}
+          color={select('Color', colors, 'neutral')}
+          direction={select('Direction', directions, 'south')}
+          fullHeight={boolean('fullHeight', true)}
+          position={select('Position', positions, 'center')}
+          onEscKeyDown={handleCloseClick}
+          onOverlayClick={handleCloseClick}
+          tint={select('Tint', tints, 'lightest')}
+          lockScroll={boolean('Lock scroll', true)}
+          offsetCorrection={number('Offset correction', 0)}
+        >
+          <Box padding={4} overflow="auto">
+            <TextBody>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+              dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+              ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+              fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+              mollit anim id est laborum.
+            </TextBody>
+          </Box>
         </Popover>
       </State>
     </Box>
@@ -189,11 +211,17 @@ storiesOf('Popover', module)
           lockScroll={boolean('Lock scroll', true)}
           offsetCorrection={number('Offset correction', 0)}
         >
-          <Box padding={4}>
-            <Heading3>I am a heading 3</Heading3>
-            <TextBody marginTop={2}>
-              Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore
-              et dolore magna aliquyam erat, sed diam voluptua.
+          <Banner color="neutral" fullWidth>
+            <Heading3>Popover Title</Heading3>
+            <TextSmall marginTop={1}>This is the popover content</TextSmall>
+          </Banner>
+          <Box padding={4} overflow="auto">
+            <TextBody>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+              dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+              ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+              fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+              mollit anim id est laborum.
             </TextBody>
           </Box>
         </Popover>
@@ -217,7 +245,11 @@ storiesOf('Popover', module)
           lockScroll={boolean('Lock scroll', true)}
           offsetCorrection={number('Offset correction', 0)}
         >
-          <Box padding={4}>
+          <Banner color="neutral" fullWidth>
+            <Heading3>Popover Title</Heading3>
+            <TextSmall marginTop={1}>This is the popover content</TextSmall>
+          </Banner>
+          <Box padding={4} overflow="auto">
             <TextBody>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
               dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
@@ -226,6 +258,10 @@ storiesOf('Popover', module)
               mollit anim id est laborum.
             </TextBody>
           </Box>
+          <ButtonGroup justifyContent="flex-end" padding={4}>
+            <Button label="Cancel" />
+            <Button level="primary" label="Confirm" />
+          </ButtonGroup>
         </Popover>
       </State>
     </Box>


### PR DESCRIPTION
### Description

This PR gets rid of the `header` & `footer` prop in our Popover `component` This is because we faced some issues with this component, in some specific cases, once they're implemented in core.

Another reason for this is that some developers wanted to have `more control over the markup inside` this Popover.

As an alternative for the removed `ScrollContainer`, we [introduced](https://github.com/teamleadercrm/ui/pull/516) some `overflow` props in our `Box` component.

All this in place, we will have full control over the `Popover's content markup` and we can easily make `Box components scrollable`.

**Note:** Please don't merge before #516 has been merged.

### Breaking changes

After this PR, `header` & `footer` will be no valid props anymore in our `Popover` component. Please use `children` instead!