### PR TITLE
[TU-269] Select: word break options & placeholder

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -216,6 +216,7 @@ class Select extends PureComponent {
       ...base,
       marginLeft: isMulti && size !== 'large' ? '6px' : '2px',
       marginRight: isMulti && size !== 'large' ? '6px' : '2px',
+      whiteSpace: 'nowrap',
     };
 
     if (inverse) {

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -184,6 +184,7 @@ class Select extends PureComponent {
   getOptionStyles = (base, { isDisabled, isFocused, isSelected }) => {
     const commonStyles = {
       ...base,
+      wordBreak: 'break-all',
       padding: '8px 12px',
     };
 


### PR DESCRIPTION
### Description

This PR fixes the word break behaviour for both Select `options` and `placeholder`.

#### Screenshot before this PR

<img width="171" alt="schermafdruk 2019-01-30 11 12 36" src="https://user-images.githubusercontent.com/5336831/51974512-5dd27c00-2480-11e9-837a-eef1dbf61c7b.png">

#### Screenshot after this PR

<img width="172" alt="schermafdruk 2019-01-30 11 11 51" src="https://user-images.githubusercontent.com/5336831/51974525-662ab700-2480-11e9-8d04-a3443cc3ce70.png">

### Breaking changes

None (except for the breaking words 🙈).
