### PR TITLE
Box: spread the style prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- `Box`: fixed the accidental `style` override when passing inline style prop. ([@driesd](https://github.com/driesd) in [#521](https://github.com/teamleadercrm/ui/pull/521))
 - `Select`: fixed `word break` behaviour for both Select `options` and `placeholder`. ([@driesd](https://github.com/driesd) in [#520](https://github.com/teamleadercrm/ui/pull/520))
 
 ## [0.21.0] - 2019-01-29

--- a/src/components/box/Box.js
+++ b/src/components/box/Box.js
@@ -46,6 +46,7 @@ class Box extends PureComponent {
       paddingLeft = paddingHorizontal,
       paddingRight = paddingHorizontal,
       paddingTop = paddingVertical,
+      style,
       ...others
     } = this.props;
 
@@ -71,7 +72,7 @@ class Box extends PureComponent {
       className,
     );
 
-    const style = {
+    const elementStyles = {
       ...(boxSizing && { boxSizing }),
       ...(flex && { flex }),
       ...(flexBasis && { flexBasis }),
@@ -81,6 +82,7 @@ class Box extends PureComponent {
       ...(overflow && { overflow }),
       ...(overflowX && { overflowX }),
       ...(overflowY && { overflowY }),
+      ...style,
     };
 
     const Element = element;
@@ -91,7 +93,7 @@ class Box extends PureComponent {
           this.node = node;
         }}
         className={classNames}
-        style={style}
+        style={elementStyles}
         {...others}
       >
         {children}
@@ -141,6 +143,7 @@ Box.propTypes = {
   paddingLeft: PropTypes.oneOf(spacings),
   paddingRight: PropTypes.oneOf(spacings),
   paddingTop: PropTypes.oneOf(spacings),
+  style: PropTypes.object,
 };
 
 Box.defaultProps = {


### PR DESCRIPTION
### Description

This PR spreads the `style` prop into the `elementStyles` to pass to our `Box` wrapper. This was the inline `style` prop was overriding the `flex` prop trough the {...others}.

### Breaking changes

None.
