### PR TITLE
[TU-278] Select: selected option state should overrule hover state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Select`: fixed the option's `selected` state in that way the `focus` state does not overrule anymore. ([@driesd](https://github.com/driesd) in [#524](https://github.com/teamleadercrm/ui/pull/524))
+
 ## [0.21.1] - 2019-01-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Select`: changed `background & text color` for `hover & selected` options. ([@driesd](https://github.com/driesd) in [#524](https://github.com/teamleadercrm/ui/pull/524))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -208,11 +208,11 @@ class Select extends PureComponent {
 
     return {
       ...commonStyles,
-      color: isDisabled ? COLOR.NEUTRAL.DARK : isSelected ? COLOR.NEUTRAL.LIGHTEST : COLOR.TEAL.DARK,
-      backgroundColor: isSelected ? COLOR.NEUTRAL.DARKEST : isFocused ? COLOR.NEUTRAL.NORMAL : COLOR.NEUTRAL.LIGHTEST,
+      color: isDisabled ? COLOR.NEUTRAL.DARK : COLOR.TEAL.DARK,
+      backgroundColor: isSelected ? COLOR.AQUA.LIGHTEST : isFocused ? COLOR.NEUTRAL.LIGHT : COLOR.NEUTRAL.LIGHTEST,
       '&:active': {
-        backgroundColor: isDisabled ? COLOR.NEUTRAL.LIGHTEST : COLOR.NEUTRAL.DARKEST,
-        color: isDisabled ? COLOR.NEUTRAL.DARK : COLOR.NEUTRAL.LIGHTEST,
+        backgroundColor: isDisabled ? COLOR.NEUTRAL.LIGHTEST : COLOR.AQUA.LIGHTEST,
+        color: isDisabled ? COLOR.NEUTRAL.DARK : COLOR.TEAL.DARK,
       },
     };
   };

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -191,20 +191,28 @@ class Select extends PureComponent {
     if (this.props.inverse) {
       return {
         ...commonStyles,
-        color: isDisabled ? COLOR.TEAL.LIGHT : isFocused ? COLOR.TEAL.DARK : COLOR.NEUTRAL.LIGHTEST,
-        backgroundColor: isFocused ? COLOR.TEAL.LIGHT : isSelected ? COLOR.TEAL.DARK : COLOR.TEAL.NORMAL,
+        color: isDisabled
+          ? COLOR.TEAL.LIGHT
+          : isSelected
+            ? COLOR.NEUTRAL.LIGHTEST
+            : isFocused
+              ? COLOR.TEAL.DARK
+              : COLOR.NEUTRAL.LIGHTEST,
+        backgroundColor: isSelected ? COLOR.TEAL.DARK : isFocused ? COLOR.TEAL.LIGHT : COLOR.TEAL.NORMAL,
         '&:active': {
           backgroundColor: isDisabled ? COLOR.TEAL.NORMAL : COLOR.TEAL.DARK,
+          color: isDisabled ? COLOR.TEAL.LIGHT : COLOR.NEUTRAL.LIGHTEST,
         },
       };
     }
 
     return {
       ...commonStyles,
-      color: isDisabled ? COLOR.NEUTRAL.DARK : isSelected && !isFocused ? COLOR.NEUTRAL.LIGHTEST : COLOR.TEAL.DARK,
-      backgroundColor: isFocused ? COLOR.NEUTRAL.NORMAL : isSelected ? COLOR.NEUTRAL.DARKEST : COLOR.NEUTRAL.LIGHTEST,
+      color: isDisabled ? COLOR.NEUTRAL.DARK : isSelected ? COLOR.NEUTRAL.LIGHTEST : COLOR.TEAL.DARK,
+      backgroundColor: isSelected ? COLOR.NEUTRAL.DARKEST : isFocused ? COLOR.NEUTRAL.NORMAL : COLOR.NEUTRAL.LIGHTEST,
       '&:active': {
-        backgroundColor: isDisabled ? COLOR.NEUTRAL.LIGHTEST : COLOR.NEUTRAL.NORMAL,
+        backgroundColor: isDisabled ? COLOR.NEUTRAL.LIGHTEST : COLOR.NEUTRAL.DARKEST,
+        color: isDisabled ? COLOR.NEUTRAL.DARK : COLOR.NEUTRAL.LIGHTEST,
       },
     };
   };


### PR DESCRIPTION
### Description

Before this PR, the option's hover (isFocused) state was overruling its selected (isSelected) state. This PR fixes the issue by switching the if/else conditions from place.

**Edit:** Due to a design update, we changed the `background & text color` for `hover & selected` options (see screenshots).

### Screenshot before this PR

![schermafdruk 2019-02-01 15 48 42](https://user-images.githubusercontent.com/5336831/52129853-ee53bc80-2638-11e9-9de4-1ab959ccefaa.png)

### Screenshot after this PR

![schermafdruk 2019-02-01 15 48 07](https://user-images.githubusercontent.com/5336831/52129847-ea279f00-2638-11e9-8552-1861852a632f.png)

### Breaking changes

None.
