### PR TITLE
Fix: AsyncSelect refetch options when handler changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - `Box`: fixed `flexGrow`, `flexShrink` & `order` with value `0` to apply the correct styles. ([@driesd](https://github.com/driesd) in [#523](https://github.com/teamleadercrm/ui/pull/523))
 - `Select`: fixed the option's `selected` state in that way the `focus` state does not overrule anymore. ([@driesd](https://github.com/driesd) in [#524](https://github.com/teamleadercrm/ui/pull/524))
+- `AsyncSelect`: refetch options when loadOptions handler changes ([@mikeverf](https://github.com/mikeverf) in [#527](https://github.com/teamleadercrm/ui/pull/527))
 
 ## [0.21.1] - 2019-01-30
 

--- a/src/components/select/AsyncSelect.js
+++ b/src/components/select/AsyncSelect.js
@@ -18,7 +18,7 @@ class AsyncSelect extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.pageSize !== prevProps.pageSize) {
+    if (this.props.pageSize !== prevProps.pageSize || this.props.loadOptions !== prevProps.loadOptions) {
       this.setState(
         state => ({
           ...state,


### PR DESCRIPTION
### Description

This PR fixes an issue where options aren't refetched when loadOptions handler has changed. This results in old options unexpectedly being shown instead of new ones.

### Breaking changes
none