### PR TITLE
Label: merge child props with custom props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Label`: merged the props of the `children` with custom props that we also want to pass down. ([@driesd](https://github.com/driesd) in [#529](https://github.com/teamleadercrm/ui/pull/529))
+
 ## [0.21.2] - 2019-02-14
 
 ### Changed

--- a/src/components/label/Label.js
+++ b/src/components/label/Label.js
@@ -39,7 +39,7 @@ export default class Label extends PureComponent {
       <Box element="label" marginBottom={3} className={classNames} {...others}>
         {React.Children.map(children, child => {
           if (typeof child !== 'string') {
-            return React.cloneElement(child, childProps);
+            return React.cloneElement(child, { ...childProps, ...child.props });
           }
 
           return (

--- a/stories/playground.js
+++ b/stories/playground.js
@@ -19,8 +19,6 @@ import {
   Label,
   Link,
   Popover,
-  RadioButton,
-  RadioGroup,
   Select,
   StatusBullet,
   TextBody,
@@ -249,20 +247,5 @@ storiesOf('Playground', module)
           <Toast label="Your Toast is ready Sir!" />
         </ToastContainer>
       </Box>
-    );
-  })
-  .add('Z-Indexes', () => {
-    return (
-      <Label>
-        Customer
-        <RadioGroup display="flex" marginBottom={3} marginTop={3} value={1}>
-          <RadioButton marginRight={3} size="small" value={1}>
-            <TextBody color="teal">Companies</TextBody>
-          </RadioButton>
-          <RadioButton size="small" value={2}>
-            <TextBody color="teal">Contacts</TextBody>
-          </RadioButton>
-        </RadioGroup>
-      </Label>
     );
   });

--- a/stories/playground.js
+++ b/stories/playground.js
@@ -19,6 +19,8 @@ import {
   Label,
   Link,
   Popover,
+  RadioButton,
+  RadioGroup,
   Select,
   StatusBullet,
   TextBody,
@@ -247,5 +249,20 @@ storiesOf('Playground', module)
           <Toast label="Your Toast is ready Sir!" />
         </ToastContainer>
       </Box>
+    );
+  })
+  .add('Z-Indexes', () => {
+    return (
+      <Label>
+        Customer
+        <RadioGroup display="flex" marginBottom={3} marginTop={3} value={1}>
+          <RadioButton marginRight={3} size="small" value={1}>
+            <TextBody color="teal">Companies</TextBody>
+          </RadioButton>
+          <RadioButton size="small" value={2}>
+            <TextBody color="teal">Contacts</TextBody>
+          </RadioButton>
+        </RadioGroup>
+      </Label>
     );
   });


### PR DESCRIPTION
### Description

Before this PR it was not possible to override the margin top of the Label's children.

This PR merges the props of the `Label's children` with custom props that we also want to pass to the children. 

### Breaking changes

None.
