### PR TITLE
[TU-280] RadioButton: make sure it doesn't get squeezed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `RadioButton`: fixed the squeezed radio button shape. ([@driesd](https://github.com/driesd) in [#530](https://github.com/teamleadercrm/ui/pull/530))
+
 ## [0.21.2] - 2019-02-14
 
 ### Changed

--- a/src/components/radio/theme.css
+++ b/src/components/radio/theme.css
@@ -33,6 +33,7 @@
     border: var(--checkbox-border-width) solid var(--color-neutral-dark);
     border-radius: 100%;
     color: var(--color-white);
+    flex-shrink: 0;
     position: relative;
     cursor: pointer;
     transition: all 0.2s ease;


### PR DESCRIPTION
### Description

This PR fixes the squeezed `radio button` when it contains long label text.

#### Screenshot before this PR

![schermafdruk 2019-02-15 09 58 50](https://user-images.githubusercontent.com/5336831/52845802-5067f380-3108-11e9-89b4-e81d76398f71.png)

#### Screenshot after this PR

![schermafdruk 2019-02-15 09 48 21](https://user-images.githubusercontent.com/5336831/52845654-ef402000-3107-11e9-84c3-5af2cd323c5b.png)

### Breaking changes

None.
