### PR TITLE
[TU-187 & TU-189] Select: dropdown menu portal possibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Select`: added `usePortal` boolean prop. If true, the menu dropdown will be rendered inside a React Portal. ([@driesd](https://github.com/driesd) in [#531](https://github.com/teamleadercrm/ui/pull/531))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -135,6 +135,21 @@ class Select extends PureComponent {
     };
   };
 
+  getMenuPortalStyles = base => {
+    const { inverse } = this.props;
+
+    return {
+      ...base,
+      backgroundColor: inverse ? COLOR.TEAL.NORMAL : COLOR.NEUTRAL.LIGHTEST,
+      fontFamily: 'Inter-UI-Regular',
+      fontSize: '14px',
+      fontSmoothing: 'antialiased',
+      '-moz-osx-font-smoothing': 'grayscale',
+      '-webkit-font-smoothing': 'antialiased',
+      zIndex: 800,
+    };
+  };
+
   getMultiValueStyles = base => {
     const { inverse } = this.props;
 
@@ -262,6 +277,7 @@ class Select extends PureComponent {
     groupHeading: this.getGroupHeadingStyles,
     input: this.getInput,
     menu: this.getMenuStyles,
+    menuPortal: this.getMenuPortalStyles,
     multiValue: this.getMultiValueStyles,
     multiValueLabel: this.getMultiValueLabelStyles,
     multiValueRemove: this.getMultiValueRemoveStyles,

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -299,7 +299,7 @@ class Select extends PureComponent {
   };
 
   render() {
-    const { components, creatable, error, inverse, helpText, size, warning, ...otherProps } = this.props;
+    const { components, creatable, error, inverse, helpText, size, usePortal, warning, ...otherProps } = this.props;
 
     const boxProps = pickBoxProps(otherProps);
     const restProps = omitBoxProps(otherProps);
@@ -321,6 +321,7 @@ class Select extends PureComponent {
             IndicatorSeparator: null,
             ...components,
           }}
+          menuPortalTarget={usePortal && document.body}
           styles={this.getStyles()}
           {...restProps}
         />

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -343,6 +343,8 @@ Select.propTypes = {
   inverse: PropTypes.bool,
   /** Size of the input element. */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
+  /** If, true the dropdown menu will be rendered in a Portal */
+  usePortal: PropTypes.bool,
   /** Selected option value(s) */
   value: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.func]),
   /** The text to use as warning message below the input. */
@@ -355,6 +357,7 @@ Select.defaultProps = {
   creatable: false,
   inverse: false,
   size: 'medium',
+  usePortal: false,
   width: '100%',
 };
 

--- a/stories/playground.js
+++ b/stories/playground.js
@@ -19,6 +19,8 @@ import {
   Label,
   Link,
   Popover,
+  RadioButton,
+  RadioGroup,
   Select,
   StatusBullet,
   TextBody,
@@ -30,7 +32,7 @@ import {
 } from '../src';
 
 import { rows1 } from './static/data/datagrid';
-import options from './static/data/select';
+import options, { groupedOptions } from './static/data/select';
 
 const inputPlaceholderToday = DateTime.fromJSDate(new Date())
   .setLocale('nl')
@@ -210,7 +212,7 @@ storiesOf('Playground', module)
             <Heading3 color="teal">I am a Popover</Heading3>
             <Label marginTop={3} marginBottom={0} required>
               Select your flavourite
-              <Select helpText="Please select your favorite flavour" options={options} />
+              <Select helpText="Please select your favorite flavour" options={options} usePortal />
             </Label>
           </Box>
         </Popover>
@@ -223,7 +225,7 @@ storiesOf('Playground', module)
           <Box display="flex" marginTop={3}>
             <Label flex="1" marginBottom={0} marginRight={2} required>
               Select your flavourite
-              <Select helpText="Please select your favorite flavour" options={options} />
+              <Select helpText="Please select your favorite flavour" options={groupedOptions} usePortal />
             </Label>
             <Label required flex="1" marginLeft={2}>
               Pick a date
@@ -247,5 +249,26 @@ storiesOf('Playground', module)
           <Toast label="Your Toast is ready Sir!" />
         </ToastContainer>
       </Box>
+    );
+  })
+  .add('Forms', () => {
+    return (
+      <Label>
+        Customer
+        <RadioGroup display="flex" marginBottom={3} marginTop={3} value={1}>
+          <RadioButton marginRight={3} size="medium" value={1}>
+            <TextSmall color="teal">
+              Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore
+              et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.
+              Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit
+              amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna
+              aliquyam erat, sed diam voluptua.
+            </TextSmall>
+          </RadioButton>
+          <RadioButton size="medium" value={2}>
+            <TextSmall color="teal">Contacts</TextSmall>
+          </RadioButton>
+        </RadioGroup>
+      </Label>
     );
   });


### PR DESCRIPTION
### Description

This PR implements a `usePortal` boolean prop to our `Select` component. When `usePortal={true}` is passed as prop, the `Select dropdown menu` will be rendered in a `React portal`. This makes it possible to use a Select component inside a Popover or Dialog without overflow issues.

#### Screenshot before this PR

![schermafdruk 2019-02-15 14 48 37](https://user-images.githubusercontent.com/5336831/52860821-de57d480-3130-11e9-96bf-51aae1379aca.png)

#### Screenshot after this PR

![schermafdruk 2019-02-15 13 28 18](https://user-images.githubusercontent.com/5336831/52860776-b36d8080-3130-11e9-8385-7a6049adafbb.png)

### Breaking changes

None
