### PR TITLE
[AHOY-286] Input elements: innerRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- `InputBase`: added `innerRef` prop to directly target the `html input element` of an `Input`, `NumericInput` or `Textarea` component. ([@driesd](https://github.com/driesd) in [#537](https://github.com/teamleadercrm/ui/pull/537))
 - `Popover`: added `zIndex` prop (defaults to `300`). ([@driesd](https://github.com/driesd) in [#534](https://github.com/teamleadercrm/ui/pull/534))
 - `Select`: added `menuPortalTarget` prop (defaults to `document.body`) to specify where the portal should be rendered. ([@driesd](https://github.com/driesd) in [#534](https://github.com/teamleadercrm/ui/pull/534))
 

--- a/src/components/input/InputBase.js
+++ b/src/components/input/InputBase.js
@@ -7,7 +7,7 @@ import theme from './theme.css';
 
 class InputBase extends PureComponent {
   render() {
-    const { bold, className, element, inverse, size, ...otherProps } = this.props;
+    const { bold, className, element, innerRef, inverse, size, ...otherProps } = this.props;
 
     const classNames = cx(
       theme['input'],
@@ -23,6 +23,7 @@ class InputBase extends PureComponent {
 
     const props = {
       className: classNames,
+      ref: innerRef,
       ...restProps,
     };
 
@@ -39,6 +40,8 @@ InputBase.propTypes = {
   disabled: PropTypes.bool,
   /** The element to render. */
   element: PropTypes.oneOf(['input', 'textarea']),
+  /** The reference to the inner html element */
+  innerRef: PropTypes.object,
   /** Boolean indicating whether the input should render as inverse. */
   inverse: PropTypes.bool,
   /** Callback function that is fired when blurring the input field. */

--- a/stories/playground.js
+++ b/stories/playground.js
@@ -17,14 +17,15 @@ import {
   Heading4,
   Icon,
   IconMenu,
+  Input,
   MenuItem,
+  NumericInput,
   Label,
   Link,
   Popover,
-  RadioButton,
-  RadioGroup,
   Select,
   StatusBullet,
+  Textarea,
   TextBody,
   TextSmall,
   Toast,
@@ -337,23 +338,43 @@ storiesOf('Playground', module)
     </Box>
   ))
   .add('Forms', () => {
+    const inputRef = React.createRef();
+    const numericInputRef = React.createRef();
+    const textareaRef = React.createRef();
+
+    const focusOnInput = () => {
+      inputRef.current.focus();
+    };
+
+    const focusOnNumericInput = () => {
+      numericInputRef.current.focus();
+    };
+
+    const focusOnTextarea = () => {
+      textareaRef.current.focus();
+    };
+
     return (
-      <Label>
-        Customer
-        <RadioGroup display="flex" marginBottom={3} marginTop={3} value={1}>
-          <RadioButton marginRight={3} size="medium" value={1}>
-            <TextSmall color="teal">
-              Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore
-              et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.
-              Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit
-              amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna
-              aliquyam erat, sed diam voluptua.
-            </TextSmall>
-          </RadioButton>
-          <RadioButton size="medium" value={2}>
-            <TextSmall color="teal">Contacts</TextSmall>
-          </RadioButton>
-        </RadioGroup>
-      </Label>
+      <Box>
+        <ButtonGroup>
+          <Button label="Focus the Input" onClick={focusOnInput} />
+          <Button label="Focus the NumericInput" onClick={focusOnNumericInput} />
+          <Button label="Focus the Textarea" onClick={focusOnTextarea} />
+        </ButtonGroup>
+        <Box display="flex" marginTop={4}>
+          <Label flex={1} marginRight={2}>
+            Input
+            <Input innerRef={inputRef} />
+          </Label>
+          <Label flex={1} marginLeft={2}>
+            NumericInput
+            <NumericInput innerRef={numericInputRef} />
+          </Label>
+        </Box>
+        <Label marginTop={4}>
+          Textarea
+          <Textarea innerRef={textareaRef} />
+        </Label>
+      </Box>
     );
   });


### PR DESCRIPTION
### Description

This PR implements the `innerRef` prop in our `InputBase` component. The `innerRef` prop is passed down to the actual `html input` element as `ref`.

This makes it possible to directly target the `html input element` of an `Input`, `NumericInput` or `Textarea` component.

#### Screenshot after this PR

![schermafdruk 2019-03-05 14 21 19](https://user-images.githubusercontent.com/5336831/53808492-a931eb80-3f52-11e9-96bd-115957ff0108.png)

### Breaking changes

None.
