### PR TITLE
Numeric input: disable tabindex for the spinner controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `NumericInput`: disabled the `tabindex` for the numeric input spinner controls. ([@driesd](https://github.com/driesd) in [#539](https://github.com/teamleadercrm/ui/pull/539))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -11,6 +11,7 @@ class SpinnerControls extends PureComponent {
     const iconProps = {
       color: inverse ? 'teal' : 'neutral',
       element: 'button',
+      tabindex: '-1',
       tint: inverse ? 'lightest' : 'darkest',
       type: 'button',
     };


### PR DESCRIPTION
### Description

Before this PR, when being focussed on a `NumericInput` field, you would hit the tab button on your keyboard and the first spinner button would gain focus. This is not intended behavior as you would expect the `next input field` to gain focus.

This PR disables the `tabindex` for the `numeric input spinner controls` and solves this weird behavior.

### Breaking changes

None.
