### PR TITLE
Select: adjust alignment headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `Link`: change margin between link and icon to 6px. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#545](https://github.com/teamleadercrm/ui/pull/545))
 - `General`: eliminate `composes` in css files. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#542](https://github.com/teamleadercrm/ui/pull/542))
 - `General`: replace legacy ref with createRef. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#544](https://github.com/teamleadercrm/ui/pull/544))
+- `Select`: remove padding from headers in a grouped select. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#550](https://github.com/teamleadercrm/ui/pull/550))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 - `Link`: change margin between link and icon to 6px. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#545](https://github.com/teamleadercrm/ui/pull/545))
 - `General`: eliminate `composes` in css files. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#542](https://github.com/teamleadercrm/ui/pull/542))
 - `General`: replace legacy ref with createRef. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#544](https://github.com/teamleadercrm/ui/pull/544))
-- `Select`: remove padding from headers in a grouped select. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#550](https://github.com/teamleadercrm/ui/pull/550))
+- `Select`: use equal padding for headers and options. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#550](https://github.com/teamleadercrm/ui/pull/550))
 
 ### Removed
 

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -120,7 +120,6 @@ class Select extends PureComponent {
       fontSize: '12px',
       fontWeight: '700',
       letterSpacing: '0.6px',
-      padding: '0 6px',
     };
   };
 


### PR DESCRIPTION
### Description
- Remove the padding from headers in a grouped select for a better alignment.

#### Screenshot before this PR
![Screen Shot 2019-03-14 at 10 29 16](https://user-images.githubusercontent.com/33860269/54345803-183ecc80-4644-11e9-813a-4d9479e318e8.png)

#### Screenshot after this PR
![Screen Shot 2019-03-14 at 10 29 25](https://user-images.githubusercontent.com/33860269/54345829-212f9e00-4644-11e9-9a7e-808f8abcc65f.png)

### Breaking changes
- none