### PR TITLE
Badge: refactor using our own Icon component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 
+- `Badge`: changed custom `span` to `Icon` component . ([@driesd](https://github.com/driesd) in [#553](https://github.com/teamleadercrm/ui/pull/553))
 - `General`: replace the `Luxon` package from devDependencies to dependencies. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#552](https://github.com/teamleadercrm/ui/pull/552))
 - `Menu & MenuItem`: restyled according to new design. ([@driesd](https://github.com/driesd) in [#551](https://github.com/teamleadercrm/ui/pull/551))
 

--- a/src/components/badge/Badge.js
+++ b/src/components/badge/Badge.js
@@ -1,6 +1,7 @@
 import React, { createRef, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Box from '../box';
+import Icon from '../icon';
 import { colorsWithout } from '../../constants';
 import { TextBody } from '../typography';
 import cx from 'classnames';
@@ -23,6 +24,20 @@ class Badge extends PureComponent {
     if (this.props.onMouseLeave) {
       this.props.onMouseLeave(event);
     }
+  };
+
+  renderIcon = () => {
+    const { color, icon, inverse } = this.props;
+
+    return (
+      <Icon
+        className={theme['icon']}
+        color={color === 'neutral' ? 'teal' : color}
+        tint={inverse ? 'lightest' : 'darkest'}
+      >
+        {icon}
+      </Icon>
+    );
   };
 
   render() {
@@ -62,7 +77,7 @@ class Badge extends PureComponent {
         paddingVertical={1}
         {...others}
       >
-        {icon && iconPlacement === 'left' && <span className={theme['icon']}>{icon}</span>}
+        {icon && iconPlacement === 'left' && this.renderIcon()}
         {inherit ? (
           <span className={theme['label']}>{children}</span>
         ) : (
@@ -70,7 +85,7 @@ class Badge extends PureComponent {
             {children}
           </TextBody>
         )}
-        {icon && iconPlacement === 'right' && <span className={theme['icon']}>{icon}</span>}
+        {icon && iconPlacement === 'right' && this.renderIcon()}
       </Box>
     );
   }

--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -120,10 +120,6 @@
             }
           }
         }
-
-        .icon {
-          color: var(--color-$(color)-darkest);
-        }
       }
     }
 


### PR DESCRIPTION
### Description

This PR refactors our `Badge` component to use our `Icon` component instead of a custom styled span.

### Breaking changes

None.
