### PR TITLE
🚸 Make sure user can't enter invalid time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `TimeInput`: added time input validation. ([@mikeverf](https://github.com/mikeverf) in [#558](https://github.com/teamleadercrm/ui/pull/558))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/input/TimeInput.js
+++ b/src/components/input/TimeInput.js
@@ -4,10 +4,18 @@ import Icon from '../icon';
 import SingleLineInputBase from './SingleLineInputBase';
 import { IconTimerSmallOutline } from '@teamleader/ui-icons';
 
+const isValidTime = input => RegExp('([0-1][0-9]|[2][0-3]):([0-5][0-9])').test(input);
 class TimeInput extends PureComponent {
+  beforeMaskedValueChange = ({ value: newValue, selection }, { value: oldValue }) => {
+    if (!isValidTime(newValue)) {
+      return { value: oldValue, selection };
+    }
+    return { value: newValue, selection };
+  };
+
   render() {
     return (
-      <InputMask {...this.props} mask="99:99" maskChar="0">
+      <InputMask {...this.props} mask="99:99" maskChar="0" beforeMaskedValueChange={this.beforeMaskedValueChange}>
         {inputProps => (
           <SingleLineInputBase
             {...inputProps}


### PR DESCRIPTION
### Description

This PR makes sure the user can't enter an invalid time.
This means you can't enter `24:00`, `34:00` or `10:60` for example.
Below, you see me entering **2 3 5 6** and then **3 ← 3 4 6 0** (seems like some kind of cheat code, but it's way easier to understand if you actually use it :) )

#### Screenshot before this PR

![invalid](https://user-images.githubusercontent.com/19315705/54702921-19866280-4b38-11e9-9d4d-8fe5feabb58b.gif)

#### Screenshot after this PR

![valid](https://user-images.githubusercontent.com/19315705/54702915-17240880-4b38-11e9-8e68-a8b2c3d72578.gif)

### Breaking changes

none
