### PR TITLE
Fix: disabled and read-only on ie11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - `TimeInput`: added time input validation. ([@mikeverf](https://github.com/mikeverf) in [#558](https://github.com/teamleadercrm/ui/pull/558))
+- `Input`: fixed the css for the disabled and read-only props on ie11. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#561](https://github.com/teamleadercrm/ui/pull/561))
 
 ### Deprecated
 

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -76,16 +76,21 @@
   box-shadow: inset 0 1px 3px 0 rgba(130, 130, 140, 0.48);
 }
 
-/* Disabled and Read-only state */
+/* Read-only state */
 .wrapper.is-disabled .input-inner-wrapper,
-.wrapper.is-read-only .input-inner-wrapper,
+.wrapper.is-read-only .input-inner-wrapper {
+  background-color: var(--color-neutral);
+  border-color: var(--color-neutral);
+  box-shadow: none;
+}
+
+/* Disabled state */
 .input:disabled,
 .input:read-only {
   background-color: var(--color-neutral);
   border-color: var(--color-neutral);
   box-shadow: none;
 }
-
 /*
   Inverse styling
 */
@@ -118,7 +123,12 @@
 
 /* Disabled and Read-only state */
 .wrapper.is-inverse.is-disabled .input-inner-wrapper,
-.wrapper.is-inverse.is-read-only .input-inner-wrapper,
+.wrapper.is-inverse.is-read-only .input-inner-wrapper {
+  background-color: var(--color-teal-dark);
+  border-color: var(--color-teal-dark);
+  box-shadow: none;
+}
+
 .input.is-inverse:disabled,
 .input.is-inverse:read-only {
   background-color: var(--color-teal-dark);


### PR DESCRIPTION
### Description

- Separated the grouped css for the disabled and read-only props of input elements, otherwise, this code doesn't get executed on IE11.

#### Screenshot before this PR

![Schermafdruk 2019-03-22 09 45 27](https://user-images.githubusercontent.com/5336831/54811116-1ef2c280-4c88-11e9-875d-c5d2c022fabd.png)

#### Screenshot after this PR

![Schermafdruk 2019-03-22 09 45 42](https://user-images.githubusercontent.com/5336831/54811127-231ee000-4c88-11e9-9843-b1450890bbac.png)

### Breaking changes

None
