### PR TITLE
Fix resize checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `CheckBox`: added a flex-shrink to the checkbox so it doesn't resize on long texts. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#562](https://github.com/teamleadercrm/ui/pull/562))
+
 ### Changed
 
 - `TimeInput`: added time input validation. ([@mikeverf](https://github.com/mikeverf) in [#558](https://github.com/teamleadercrm/ui/pull/558))

--- a/src/components/checkbox/theme.css
+++ b/src/components/checkbox/theme.css
@@ -31,6 +31,7 @@
     border: var(--checkbox-border-width) solid var(--color-neutral-dark);
     border-radius: 4px;
     color: var(--color-white);
+    flex-shrink: 0;
     position: relative;
     display: inline-flex;
     justify-content: center;


### PR DESCRIPTION
### Description
- Add a `flex-shrink: 0` to our checkbox component so it doesn't resize on long texts.

#### Screenshot before this PR
![Screen Shot 2019-03-22 at 11 35 16](https://user-images.githubusercontent.com/33860269/54817195-992a4380-4c96-11e9-9ccb-5202c14a8c63.png)


#### Screenshot after this PR
![Screen Shot 2019-03-22 at 11 34 59](https://user-images.githubusercontent.com/33860269/54817199-9b8c9d80-4c96-11e9-8972-289a57be11c3.png)


### Breaking changes
- None
