### PR TITLE
DatePickerInput: prevent activating Popover when Input is read only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `DatePickerInput`: prevent activating the `Popover` when `Input` field is `read-only`. ([@driesd](https://github.com/driesd) in [#564](https://github.com/teamleadercrm/ui/pull/564))
+
 ## [0.24.1] - 2019-03-22
 
 ### Changed

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -118,7 +118,7 @@ DatePickerInput.propTypes = {
   inputProps: PropTypes.object,
   /** If true, component will be rendered in inverse mode. */
   inverse: PropTypes.bool,
-  /** The language locale code ('en', 'nl', 'fr',...). */
+  /** The language ISO locale code ('en-GB', 'nl-BE', 'fr-FR',...). */
   locale: PropTypes.string,
   /** Callback function that is fired when the date has changed. */
   onChange: PropTypes.func,

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -131,8 +131,11 @@ DatePickerInput.propTypes = {
 };
 
 DatePickerInput.defaultProps = {
+  dayPickerProps: {},
+  inputProps: {},
   inverse: false,
   locale: 'en-GB',
+  popoverProps: {},
   size: 'medium',
 };
 

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -28,7 +28,11 @@ class DatePickerInput extends PureComponent {
   }
 
   handleInputFocus = event => {
-    const { onFocus } = this.props.inputProps;
+    const { onFocus, readOnly } = this.props.inputProps;
+
+    if (readOnly) {
+      return;
+    }
 
     this.setState(
       {


### PR DESCRIPTION
### Description

This PR prevents activating the `Popover` when the Input field is read-only.

### Breaking changes

None.