### PR TITLE
Fix disabled and readOnly of TimeInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `TimeInput`: `disabled` and `readOnly` props. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#567](https://github.com/teamleadercrm/ui/pull/567))
+
 ## [0.24.2] - 2019-03-25
 
 ### Fixed

--- a/src/components/input/TimeInput.js
+++ b/src/components/input/TimeInput.js
@@ -14,12 +14,15 @@ class TimeInput extends PureComponent {
   };
 
   render() {
+    const { disabled, readOnly } = this.props;
     return (
       <InputMask {...this.props} mask="99:99" maskChar="0" beforeMaskedValueChange={this.beforeMaskedValueChange}>
         {inputProps => (
           <SingleLineInputBase
             {...inputProps}
             autoComplete="off"
+            readOnly={readOnly}
+            disabled={disabled}
             prefix={
               <Icon color="neutral" tint="darkest">
                 <IconTimerSmallOutline />


### PR DESCRIPTION
### Description
- Fix the disabled and readOnly props of the TimeInput component.

#### Screenshot before this PR
![Screen Shot 2019-03-25 at 10 56 42](https://user-images.githubusercontent.com/33860269/54910490-b7897c80-4eec-11e9-9ad6-4964b5db85aa.png)

#### Screenshot after this PR
![Screen Shot 2019-03-25 at 10 56 22](https://user-images.githubusercontent.com/33860269/54910496-b9534000-4eec-11e9-8c0b-9ea6edbf3843.png)


### Breaking changes
- None
