### PR TITLE
Fix: AvatarInitials set letter-spacing to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `AvatarInitials`: set `letter-spacing` to zero to center the text. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#575](https://github.com/teamleadercrm/ui/pull/575))
+
 ## [0.24.4] - 2019-03-26
 
 ### Fixed

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -95,7 +95,6 @@
 
   .content {
     padding-top: var(--content-padding-tiny);
-    letter-spacing: 0.4px;
     font-size: 8px;
     line-height: 16px;
   }
@@ -185,6 +184,7 @@
     color: white;
     text-align: center;
     text-transform: uppercase;
+    letter-spacing: 0px;
   }
 }
 


### PR DESCRIPTION
### Description
- Set the `letter-spacing` of the initials to 0, otherwise the text jumps 1px to the right.

#### Screenshot before this PR
![Screen Shot 2019-03-26 at 13 47 58](https://user-images.githubusercontent.com/33860269/54998193-d14ec080-4fcd-11e9-9682-a850bc786dcc.png)

#### Screenshot after this PR
![Screen Shot 2019-03-26 at 13 47 38](https://user-images.githubusercontent.com/33860269/54998200-d449b100-4fcd-11e9-8497-ff795bcb4c94.png)

### Breaking changes
- None.
