### PR TITLE
AvatarStack: fix sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - `AvatarInitials`: set `letter-spacing` to zero to center the text. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#575](https://github.com/teamleadercrm/ui/pull/575))
+- `AvatarStack`: remove `size` prop of `AvatarStack` wrapper. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#576](https://github.com/teamleadercrm/ui/pull/576))
 
 ## [0.24.4] - 2019-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Fixed
 
 - `AvatarInitials`: set `letter-spacing` to zero to center the text. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#575](https://github.com/teamleadercrm/ui/pull/575))
-- `AvatarStack`: pass `size` prop of `AvatarStack` to children. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#576](https://github.com/teamleadercrm/ui/pull/576))
+- `AvatarStack`: pass `size` prop to children. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#576](https://github.com/teamleadercrm/ui/pull/576))
 
 ## [0.24.4] - 2019-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Fixed
 
 - `AvatarInitials`: set `letter-spacing` to zero to center the text. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#575](https://github.com/teamleadercrm/ui/pull/575))
-- `AvatarStack`: remove `size` prop of `AvatarStack` wrapper. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#576](https://github.com/teamleadercrm/ui/pull/576))
+- `AvatarStack`: pass `size` prop of `AvatarStack` to children. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#576](https://github.com/teamleadercrm/ui/pull/576))
 
 ## [0.24.4] - 2019-03-26
 

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { cloneElement, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Box from '../box';
 import cx from 'classnames';
@@ -28,7 +28,7 @@ class AvatarStack extends PureComponent {
             onClick={onOverflowClick}
           >{`+${overflowAmount}`}</div>
         )}
-        {childrenToDisplay.map((child, index) => React.cloneElement(child, { ...child.props, size }))}
+        {childrenToDisplay.map((child, index) => cloneElement(child, { ...child.props, size }))}
       </Box>
     );
   }

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -28,7 +28,7 @@ class AvatarStack extends PureComponent {
             onClick={onOverflowClick}
           >{`+${overflowAmount}`}</div>
         )}
-        {childrenToDisplay.map((child, index) => cloneElement(child, { ...child.props, size }))}
+        {childrenToDisplay.map((child, index) => cloneElement(child, { key: index, ...child.props, size }))}
       </Box>
     );
   }

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -28,7 +28,7 @@ class AvatarStack extends PureComponent {
             onClick={onOverflowClick}
           >{`+${overflowAmount}`}</div>
         )}
-        {childrenToDisplay}
+        {childrenToDisplay.map((child, index) => React.cloneElement(child, { ...child.props, size }))}
       </Box>
     );
   }

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -90,9 +90,10 @@
 }
 
 .is-tiny {
-  height: var(--tiny-size);
-  width: var(--tiny-size);
-
+  &.avatar {
+    height: var(--tiny-size);
+    width: var(--tiny-size);
+  }
   .content {
     padding-top: var(--content-padding-tiny);
     font-size: 8px;
@@ -118,8 +119,10 @@
 }
 
 .is-small {
-  height: var(--small-size);
-  width: var(--small-size);
+  &.avatar {
+    height: var(--small-size);
+    width: var(--small-size);
+  }
 
   .content {
     padding-top: var(--content-padding-small);
@@ -144,8 +147,10 @@
 }
 
 .is-medium {
-  height: var(--medium-size);
-  width: var(--medium-size);
+  &.avatar {
+    height: var(--medium-size);
+    width: var(--medium-size);
+  }
 
   .content {
     padding-top: var(--content-padding-medium);

--- a/stories/avatars.js
+++ b/stories/avatars.js
@@ -39,7 +39,7 @@ storiesOf('Avatars', module)
       inverse={boolean('Inverse', false)}
       size={select('Size', sizes, 'medium')}
     >
-      {avatars.map(({ image }, index) => <Avatar key={index} image={image} size={select('Size', sizes, 'medium')} />)}
+      {avatars.map(({ image }, index) => <Avatar key={index} image={image} />)}
     </AvatarStack>
   ))
   .add('with bullet', () => (


### PR DESCRIPTION
### Description
- Right now the AvatarStack get affected by the sizes prop, while only the Avatar(Initials) components may be affected.

#### Screenshot before this PR
![Screen Shot 2019-03-27 at 14 00 09](https://user-images.githubusercontent.com/33860269/55077698-ada47c80-5098-11e9-968e-483b5d1ac901.png)

#### Screenshot after this PR
![Screen Shot 2019-03-27 at 14 00 15](https://user-images.githubusercontent.com/33860269/55077701-b006d680-5098-11e9-9156-ae3013b8448e.png)

### Breaking changes
- None
