### PR TITLE
AvatarInitials: center initials with flexbox instead of paddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `AvatarInitials`: center initials with `flexbox` instead of `padding` and `text-align`. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#577](https://github.com/teamleadercrm/ui/pull/577))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -12,10 +12,6 @@
 
   --shape-circle-image-border-radius: 50%;
   --shape-rounded-image-border-radius: 4px;
-
-  --content-padding-tiny: 4px;
-  --content-padding-small: 9px;
-  --content-padding-medium: 15px;
 }
 
 /* Avatar */
@@ -94,7 +90,6 @@
   width: var(--tiny-size);
 
   .content {
-    padding-top: var(--content-padding-tiny);
     font-size: 8px;
     line-height: 16px;
   }
@@ -121,10 +116,6 @@
   height: var(--small-size);
   width: var(--small-size);
 
-  .content {
-    padding-top: var(--content-padding-small);
-  }
-
   .children {
     bottom: 60%;
     left: 76%;
@@ -147,10 +138,6 @@
   height: var(--medium-size);
   width: var(--medium-size);
 
-  .content {
-    padding-top: var(--content-padding-medium);
-  }
-
   .children {
     bottom: 65%;
     left: 80%;
@@ -171,6 +158,10 @@
 
 /*AvatarInitials*/
 .avatar-initials {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
   &.is-circle {
     border-radius: var(--shape-circle-image-border-radius);
   }
@@ -180,9 +171,7 @@
   }
 
   .content {
-    display: block;
     color: white;
-    text-align: center;
     text-transform: uppercase;
     letter-spacing: 0px;
   }


### PR DESCRIPTION
### Description
- In this PR the initials get centred with flexbox instead of paddings and text-align.

### Breaking changes
- None