### PR TITLE
AvatarStack: fix overflowAmount display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - `AvatarInitials`: set `letter-spacing` to zero to center the text. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#575](https://github.com/teamleadercrm/ui/pull/575))
+- `AvatarStack`: only show `overflowAmount` if the count of `Avatars` is higher than the `displayMax`. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#578](https://github.com/teamleadercrm/ui/pull/578))
 
 ## [0.24.4] - 2019-03-26
 

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -19,10 +19,9 @@ class AvatarStack extends PureComponent {
 
     const childrenToDisplay = displayMax > 0 ? children.slice(0, displayMax) : children;
     const overflowAmount = children.length - displayMax;
-
     return (
       <Box data-teamleader-ui="avatar-stack" className={classNames} {...others}>
-        {overflowAmount !== children.length && (
+        {overflowAmount > 0 && (
           <div
             className={cx(uiUtilities['reset-font-smoothing'], theme['overflow'])}
             onClick={onOverflowClick}


### PR DESCRIPTION
### Description
- Now the overflowAmount will only show if there are more `Avatars` then then the `displayMax`.

#### Screenshot before this PR
![Screen Shot 2019-03-27 at 15 04 50](https://user-images.githubusercontent.com/33860269/55082303-bbaacb00-50a1-11e9-8146-c63b2f1dcc5a.png)

#### Screenshot after this PR
![Screen Shot 2019-03-27 at 15 04 59](https://user-images.githubusercontent.com/33860269/55082383-df6e1100-50a1-11e9-8bef-554d00be46e8.png)
