### PR TITLE
Popover: add minWidth prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Popover`: `minWidth` prop. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#579](https://github.com/teamleadercrm/ui/pull/579))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -59,6 +59,7 @@ class Popover extends PureComponent {
       fullHeight,
       fullWidth,
       lockScroll,
+      minWidth,
       onOverlayClick,
       onEscKeyDown,
       onOverlayMouseDown,
@@ -97,7 +98,7 @@ class Popover extends PureComponent {
               <div
                 data-teamleader-ui={'popover'}
                 className={cx(uiUtilities['box-shadow-200'], theme['popover'], className)}
-                style={{ left: `${left}px`, top: `${top}px`, maxWidth: fullWidth ? '100vw' : '50vw' }}
+                style={{ left: `${left}px`, top: `${top}px`, maxWidth: fullWidth ? '100vw' : '50vw', minWidth }}
                 ref={this.popoverNode}
               >
                 <Box
@@ -148,6 +149,8 @@ Popover.propTypes = {
   fullWidth: PropTypes.bool,
   /** The scroll state of the body, if true it will not be scrollable. */
   lockScroll: PropTypes.bool,
+  /** The minimum width for the popover. */
+  minWidth: PropTypes.string,
   /** The amount of extra translation on the Popover (has no effect if position is "middle" or "center"). */
   offsetCorrection: PropTypes.number,
   /** The function executed, when the "ESC" key is down. */
@@ -177,6 +180,7 @@ Popover.defaultProps = {
   fullWidth: false,
   color: 'neutral',
   lockScroll: true,
+  minWidth: 'auto',
   offsetCorrection: 0,
   position: 'center',
   tint: 'lightest',

--- a/stories/popover.js
+++ b/stories/popover.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { select, boolean, number } from '@storybook/addon-knobs/react';
+import { select, boolean, number, text } from '@storybook/addon-knobs/react';
 import { Store, State } from '@sambego/storybook-state';
 import {
   IconChevronDownSmallOutline,
@@ -109,6 +109,7 @@ storiesOf('Popover', module)
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
           lockScroll={boolean('Lock scroll', true)}
+          minWidth={text('minWidth', undefined)}
           offsetCorrection={number('Offset correction', 0)}
         >
           {contentBoxWithSingleTextLine}
@@ -131,6 +132,7 @@ storiesOf('Popover', module)
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
           lockScroll={boolean('Lock scroll', true)}
+          minWidth={text('minWidth', undefined)}
           offsetCorrection={number('Offset correction', 0)}
         >
           <Banner fullWidth>
@@ -156,6 +158,7 @@ storiesOf('Popover', module)
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
           lockScroll={boolean('Lock scroll', true)}
+          minWidth={text('minWidth', undefined)}
           offsetCorrection={number('Offset correction', 0)}
         >
           <Banner color="neutral" fullWidth>
@@ -182,6 +185,7 @@ storiesOf('Popover', module)
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
           lockScroll={boolean('Lock scroll', true)}
+          minWidth={text('minWidth', undefined)}
           offsetCorrection={number('Offset correction', 0)}
         >
           <Banner onClose={handleCloseClick} fullWidth>
@@ -207,6 +211,7 @@ storiesOf('Popover', module)
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
           lockScroll={boolean('Lock scroll', true)}
+          minWidth={text('minWidth', undefined)}
           offsetCorrection={number('Offset correction', 0)}
         >
           {contentBoxWithSingleTextLine}
@@ -233,6 +238,7 @@ storiesOf('Popover', module)
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
           lockScroll={boolean('Lock scroll', true)}
+          minWidth={text('minWidth', undefined)}
           offsetCorrection={number('Offset correction', 0)}
         >
           <Box overflowY="auto">
@@ -306,6 +312,7 @@ storiesOf('Popover', module)
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
           lockScroll={boolean('Lock scroll', true)}
+          minWidth={text('minWidth', undefined)}
           offsetCorrection={number('Offset correction', 0)}
         >
           <Banner color="neutral" fullWidth>
@@ -340,6 +347,7 @@ storiesOf('Popover', module)
           onOverlayClick={handleCloseClick}
           tint={select('Tint', tints, 'lightest')}
           lockScroll={boolean('Lock scroll', true)}
+          minWidth={text('minWidth', undefined)}
           offsetCorrection={number('Offset correction', 0)}
         >
           <Banner color="neutral" fullWidth>


### PR DESCRIPTION
### Description
- Add a `minWidth` prop to our `Popover` component.

#### Screenshot before this PR
![Screen Shot 2019-03-27 at 16 17 29](https://user-images.githubusercontent.com/33860269/55088394-f3b70b80-50ab-11e9-9733-cbb18a8a372c.png)


#### Screenshot after this PR
![Screen Shot 2019-03-27 at 16 17 10](https://user-images.githubusercontent.com/33860269/55088351-e568ef80-50ab-11e9-9146-8fb218c064fb.png)


### Breaking changes
- None.
