### PR TITLE
Maintenance: move disabled on link with text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Changed
 
-- `Link`: move `disabled` prop from `TextBody` to `Link` in Links with text. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#580](https://github.com/teamleadercrm/ui/pull/580))
-
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Link`: move `disabled` prop from `TextBody` to `Link` in Links with text. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#580](https://github.com/teamleadercrm/ui/pull/580))
+
 ### Deprecated
 
 ### Removed

--- a/stories/link.js
+++ b/stories/link.js
@@ -24,13 +24,14 @@ storiesOf('Links', module)
     </Link>
   ))
   .add('With text', () => (
-    <TextBody
-      disabled={boolean('disabled', false)}
-      color={select('color', COLORS, 'teal')}
-      tint={select('tint', TINTS, 'darkest')}
-    >
+    <TextBody color={select('color', COLORS, 'teal')} tint={select('tint', TINTS, 'darkest')}>
       Display text with a{' '}
-      <Link href="https://www.teamleader.be" target="_blank" inherit={boolean('inherit', false)}>
+      <Link
+        href="https://www.teamleader.be"
+        target="_blank"
+        inherit={boolean('inherit', false)}
+        disabled={boolean('disabled', false)}
+      >
         link
       </Link>{' '}
       inside


### PR DESCRIPTION
### Description
- Move the `disabled` prop from `TextBody` to `Link` in "With text".
 
#### Screenshot before this PR
![Screen Shot 2019-03-27 at 17 00 36](https://user-images.githubusercontent.com/33860269/55091909-e8ff7500-50b1-11e9-9a3f-c225c2839c08.png)

#### Screenshot after this PR
![Screen Shot 2019-03-27 at 17 00 51](https://user-images.githubusercontent.com/33860269/55091924-ee5cbf80-50b1-11e9-9a3a-0053758bb9fe.png)

### Breaking changes
- None