### PR TITLE
Maintenance: change bordered prop DataGrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - `AvatarInitials`: center initials with `flexbox` instead of `padding` and `text-align`. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#577](https://github.com/teamleadercrm/ui/pull/577))
+- `DataGrid`: `bordered` prop so it only triggers a `border-bottom` and `border-top`. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#583](https://github.com/teamleadercrm/ui/pull/583))
 
 ### Deprecated
 

--- a/src/components/datagrid/theme.css
+++ b/src/components/datagrid/theme.css
@@ -12,7 +12,6 @@
   min-width: 100%;
   max-width: 100%;
   position: relative;
-  border-top: 1px solid var(--color-neutral);
 }
 
 .section-wrapper {
@@ -34,6 +33,12 @@
 
 .row {
   display: flex;
+
+  &:last-child {
+    .cell {
+      border-bottom: 0;
+    }
+  }
 }
 
 .cell {
@@ -72,36 +77,8 @@
 }
 
 .is-bordered {
-  border: 1px solid var(--color-neutral);
-  border-radius: 4px;
-
-  .section:first-child .row:first-child,
-  .section:first-child .row:first-child .cell:first-child {
-    border-top-left-radius: 4px;
-  }
-
-  .section:last-child .row:first-child,
-  .section:last-child .row:first-child .cell:last-child {
-    border-top-right-radius: 4px;
-  }
-
-  &:not(.is-overflowing) {
-    .section:first-child .row:last-child,
-    .section:first-child .row:last-child .cell:first-child {
-      border-bottom-left-radius: 4px;
-    }
-
-    .section:last-child .row:last-child,
-    .section:last-child .row:last-child .cell:last-child {
-      border-bottom-right-radius: 4px;
-    }
-
-    .row:last-child {
-      .cell {
-        border-bottom: 0;
-      }
-    }
-  }
+  border-bottom: 1px solid var(--color-neutral);
+  border-top: 1px solid var(--color-neutral);
 }
 
 .is-sticky-left {


### PR DESCRIPTION
### Description
- Changes to the css of the `DataGrid` so the `bordered` prop only triggers a top and bottom border.

#### Screenshot before this PR
![Screen Shot 2019-04-02 at 10 07 41](https://user-images.githubusercontent.com/33860269/55386188-3f940580-552f-11e9-9f98-4ecf637edaeb.png)

#### Screenshot after this PR
![Screen Shot 2019-04-02 at 10 08 10](https://user-images.githubusercontent.com/33860269/55386207-491d6d80-552f-11e9-88ea-4a65ba63849b.png)


### Breaking changes
- None