### PR TITLE
DatePicker: Add bordered prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - `Popover`: `minWidth` prop. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#579](https://github.com/teamleadercrm/ui/pull/579))
+- `DatePicker`: `bordered` prop. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#584](https://github.com/teamleadercrm/ui/pull/584))
 
 ### Changed
 

--- a/src/components/datepicker/DatePicker.js
+++ b/src/components/datepicker/DatePicker.js
@@ -34,12 +34,19 @@ class DatePicker extends PureComponent {
   };
 
   render() {
-    const { className, modifiers, size, ...others } = this.props;
+    const { bordered, className, modifiers, size, ...others } = this.props;
     const { selectedDate } = this.state;
-
     const boxProps = pickBoxProps(others);
     const restProps = omitBoxProps(others);
-    const classNames = cx(uiUtilities['reset-font-smoothing'], theme['date-picker'], theme[`is-${size}`], className);
+    const classNames = cx(
+      uiUtilities['reset-font-smoothing'],
+      theme['date-picker'],
+      theme[`is-${size}`],
+      {
+        [theme['is-bordered']]: bordered,
+      },
+      className
+    );
 
     return (
       <Box {...boxProps}>
@@ -59,6 +66,7 @@ class DatePicker extends PureComponent {
 }
 
 DatePicker.propTypes = {
+  bordered: PropTypes.bool,
   className: PropTypes.string,
   modifiers: PropTypes.object,
   onChange: PropTypes.func,
@@ -67,6 +75,7 @@ DatePicker.propTypes = {
 };
 
 DatePicker.defaultProps = {
+  bordered: false,
   size: 'medium',
 };
 

--- a/src/components/datepicker/DatePicker.js
+++ b/src/components/datepicker/DatePicker.js
@@ -81,7 +81,7 @@ DatePicker.propTypes = {
 };
 
 DatePicker.defaultProps = {
-  bordered: false,
+  bordered: true,
   size: 'medium',
 };
 

--- a/src/components/datepicker/DatePicker.js
+++ b/src/components/datepicker/DatePicker.js
@@ -66,11 +66,17 @@ class DatePicker extends PureComponent {
 }
 
 DatePicker.propTypes = {
+  /** If true we give a border to our wrapper. */
   bordered: PropTypes.bool,
+  /** A class name for the DatePicker to give custom styles. */
   className: PropTypes.string,
+  /** The modifiers of the DatePicker component. */
   modifiers: PropTypes.object,
+  /** Callback function that is fired when the date has changed. */
   onChange: PropTypes.func,
+  /** The current selected date. */
   selectedDate: PropTypes.instanceOf(Date),
+  /** Size of the DatePicker component. */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
 };
 

--- a/src/components/datepicker/DatePicker.js
+++ b/src/components/datepicker/DatePicker.js
@@ -45,7 +45,7 @@ class DatePicker extends PureComponent {
       {
         [theme['is-bordered']]: bordered,
       },
-      className
+      className,
     );
 
     return (

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -62,11 +62,22 @@ class DatePickerInput extends PureComponent {
   };
 
   render() {
-    const { className, dayPickerProps, inverse, inputProps, locale, popoverProps, size, ...others } = this.props;
+    const {
+      bordered,
+      className,
+      dayPickerProps,
+      inverse,
+      inputProps,
+      locale,
+      popoverProps,
+      size,
+      ...others
+    } = this.props;
     const { isPopoverActive, popoverAnchorEl, selectedDate } = this.state;
-
     const boxProps = pickBoxProps(others);
-    const datePickerClassNames = cx(theme['date-picker-input'], theme[`is-${size}`]);
+    const datePickerClassNames = cx(theme['date-picker-input'], theme[`is-${size}`], {
+      [theme['is-bordered']]: bordered,
+    });
     const formattedDate = this.props.formatDate
       ? this.props.formatDate(selectedDate, locale)
       : formatDate(selectedDate, locale);
@@ -112,6 +123,8 @@ class DatePickerInput extends PureComponent {
 }
 
 DatePickerInput.propTypes = {
+  /** If true we give a border to our wrapper. */
+  bordered: PropTypes.bool,
   /** A class name for the wrapper to give custom styles. */
   className: PropTypes.string,
   /** Object with props for the DatePicker component. */
@@ -135,6 +148,7 @@ DatePickerInput.propTypes = {
 };
 
 DatePickerInput.defaultProps = {
+  bordered: false,
   dayPickerProps: {},
   inputProps: {},
   inverse: false,

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -75,9 +75,7 @@ class DatePickerInput extends PureComponent {
     } = this.props;
     const { isPopoverActive, popoverAnchorEl, selectedDate } = this.state;
     const boxProps = pickBoxProps(others);
-    const datePickerClassNames = cx(theme['date-picker-input'], theme[`is-${size}`], {
-      [theme['is-bordered']]: bordered,
-    });
+    const datePickerClassNames = cx(theme['date-picker-input'], theme[`is-${size}`]);
     const formattedDate = this.props.formatDate
       ? this.props.formatDate(selectedDate, locale)
       : formatDate(selectedDate, locale);
@@ -107,6 +105,7 @@ class DatePickerInput extends PureComponent {
         >
           <Box overflowY="auto">
             <DatePicker
+              bordered={bordered}
               className={datePickerClassNames}
               locale={locale}
               localeUtils={LocaleUtils}

--- a/src/components/datepicker/DatePickerRange.js
+++ b/src/components/datepicker/DatePickerRange.js
@@ -66,7 +66,7 @@ class DatePickerRange extends PureComponent {
   };
 
   render() {
-    const { className, size, ...others } = this.props;
+    const { bordered, className, size, ...others } = this.props;
     const { selectedStartDate, mouseEnteredEndDate } = this.state;
     const modifiers = { from: selectedStartDate, to: mouseEnteredEndDate };
     const selectedDays = [selectedStartDate, { from: selectedStartDate, to: mouseEnteredEndDate }];
@@ -78,6 +78,9 @@ class DatePickerRange extends PureComponent {
       theme['date-picker'],
       theme['has-range'],
       theme[`is-${size}`],
+      {
+        [theme['is-bordered']]: bordered,
+      },
       className,
     );
 
@@ -100,6 +103,7 @@ class DatePickerRange extends PureComponent {
 }
 
 DatePickerRange.propTypes = {
+  bordered: PropTypes.bool,
   className: PropTypes.string,
   onChange: PropTypes.func,
   selectedRange: PropTypes.object,
@@ -107,6 +111,7 @@ DatePickerRange.propTypes = {
 };
 
 DatePickerRange.defaultProps = {
+  bordered: false,
   size: 'medium',
 };
 

--- a/src/components/datepicker/DatePickerRange.js
+++ b/src/components/datepicker/DatePickerRange.js
@@ -103,10 +103,15 @@ class DatePickerRange extends PureComponent {
 }
 
 DatePickerRange.propTypes = {
+  /** If true we give a border to our wrapper. */
   bordered: PropTypes.bool,
+  /** A class name for the DatePickerRange to give custom styles. */
   className: PropTypes.string,
+  /** Callback function that is fired when the date has changed. */
   onChange: PropTypes.func,
+  /** The current selected range. */
   selectedRange: PropTypes.object,
+  /** Size of the DatePickerRange component. */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
 };
 

--- a/src/components/datepicker/theme.css
+++ b/src/components/datepicker/theme.css
@@ -19,9 +19,14 @@
   display: inline-block;
 }
 
+.is-bordered {
+  .wrapper {
+    border: 1px solid var(--color-neutral);
+    border-radius: var(--border-radius);
+  }
+}
+
 .wrapper {
-  border: 1px solid var(--color-neutral);
-  border-radius: var(--border-radius);
   flex-direction: row;
   position: relative;
   user-select: none;

--- a/stories/datePicker.js
+++ b/stories/datePicker.js
@@ -55,6 +55,7 @@ storiesOf('Form elements/DatePicker', module)
 
     return (
       <DatePicker
+        bordered={boolean('bordered', true)}
         locale={select('Locale', languages, 'nl-BE')}
         localeUtils={CustomLocaleUtils}
         numberOfMonths={number('Number of months', 1)}
@@ -73,6 +74,7 @@ storiesOf('Form elements/DatePicker', module)
 
     return (
       <DatePickerInput
+        bordered={boolean('bordered', false)}
         dayPickerProps={{
           numberOfMonths: number('Number of months', 1),
           showOutsideDays: boolean('Show outside days', true),
@@ -104,6 +106,7 @@ storiesOf('Form elements/DatePicker', module)
 
     return (
       <DatePickerRange
+        bordered={boolean('bordered', true)}
         locale={select('Locale', languages, 'nl-BE')}
         localeUtils={CustomLocaleUtils}
         numberOfMonths={number('Number of months', 2)}


### PR DESCRIPTION
### Description
- Add a `bordered` prop to our DatePicker component.

#### Screenshot before this PR
![Screen Shot 2019-04-02 at 13 28 26](https://user-images.githubusercontent.com/33860269/55399408-57798280-554b-11e9-8681-3f611de79658.png)

#### Screenshot after this PR
![Screen Shot 2019-04-02 at 13 28 37](https://user-images.githubusercontent.com/33860269/55399426-5d6f6380-554b-11e9-9127-e24661559b7c.png)

### Breaking changes
- None
