### PR TITLE
Dialog: Remove resize magic and inner container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Removed
 
+- `Dialog`: wrapping `Box` of the body and all of the resize code. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#587](https://github.com/teamleadercrm/ui/pull/587))
+
 ### Fixed
 
 ## [0.24.5] - 2019-04-04

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -1,28 +1,14 @@
-import React, { PureComponent, createRef } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import omit from 'lodash.omit';
 import cx from 'classnames';
-import ReactResizeDetector from 'react-resize-detector';
 
 import theme from './theme.css';
 
-import { Banner, Box, Button, ButtonGroup, DialogBase, Heading2, Heading3, Link } from '../../index';
+import { Banner, Button, ButtonGroup, DialogBase, Heading2, Heading3, Link } from '../../index';
 import { COLORS } from '../../constants';
-import { isElementOverflowingY } from '../utils/utils';
 
 class Dialog extends PureComponent {
-  dialogNode = createRef();
-
-  state = {
-    isBodyOverFlowing: false,
-  };
-
-  componentDidUpdate(prevProps) {
-    if (this.props.active && !prevProps.active) {
-      this.setIsBodyOverflowing();
-    }
-  }
-
   getHeader = () => {
     const { headerColor, headerIcon, headingLevel, onCloseClick, title } = this.props;
 
@@ -35,25 +21,14 @@ class Dialog extends PureComponent {
 
   getFooter = () => {
     const { tertiaryAction, secondaryAction, primaryAction } = this.props;
-    const { isBodyOverFlowing } = this.state;
 
     return (
-      <ButtonGroup
-        className={isBodyOverFlowing ? theme['has-border'] : undefined}
-        justifyContent="flex-end"
-        padding={4}
-      >
+      <ButtonGroup justifyContent="flex-end" padding={4}>
         {tertiaryAction && <Link inherit={false} {...tertiaryAction} />}
         {secondaryAction && <Button {...secondaryAction} />}
         <Button level="primary" {...primaryAction} />
       </ButtonGroup>
     );
-  };
-
-  setIsBodyOverflowing = () => {
-    if (this.dialogNode.current) {
-      this.setState({ isBodyOverFlowing: isElementOverflowingY(this.dialogNode.current) });
-    }
   };
 
   render() {
@@ -72,11 +47,8 @@ class Dialog extends PureComponent {
     return (
       <DialogBase className={classNames} {...restProps}>
         {title && this.getHeader()}
-        <Box className={theme['dialog-body']} padding={4} ref={this.dialogNode}>
-          {children}
-        </Box>
+        {children}
         {this.getFooter()}
-        <ReactResizeDetector handleHeight onResize={this.setIsBodyOverflowing} />
       </DialogBase>
     );
   }

--- a/src/components/dialog/theme.css
+++ b/src/components/dialog/theme.css
@@ -81,7 +81,3 @@
   flex: 1;
   overflow: auto;
 }
-
-.has-border {
-  border-top: 1px solid var(--color-neutral);
-}

--- a/stories/dialogs.js
+++ b/stories/dialogs.js
@@ -71,7 +71,9 @@ storiesOf('Dialogs', module)
             onOverlayClick={handleActiveToggle}
             size={select('size', sizes, 'medium')}
           >
-            <TextBody>Here you can add arbitrary content.</TextBody>
+            <Box padding={4} overflowY="auto">
+              <TextBody>Here you can add arbitrary content.</TextBody>
+            </Box>
           </Dialog>
         </State>
       </Box>


### PR DESCRIPTION
### Description
- In this PR all the resize code and inner container of our Dialog body get removed.

### Screenshots
- No real visual changes.

### Breaking changes
- The body of the Dialog component is no longer wrapped in a Box (with padding).
- Removal of all the unnecessary rocketsciene that is written for a single border-top.