### PR TITLE
AvatarInitials: fix width and height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `AvatarInitials`: `size` prop on component. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#588](https://github.com/teamleadercrm/ui/pull/588))
+
 ## [0.24.5] - 2019-04-04
 
 ### Added

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -86,10 +86,12 @@
 }
 
 .is-tiny {
-  &.avatar {
+  &.avatar,
+  &.avatar-initials {
     height: var(--tiny-size);
     width: var(--tiny-size);
   }
+
   .content {
     font-size: 8px;
     line-height: 16px;
@@ -114,7 +116,8 @@
 }
 
 .is-small {
-  &.avatar {
+  &.avatar,
+  &.avatar-initials {
     height: var(--small-size);
     width: var(--small-size);
   }
@@ -138,7 +141,8 @@
 }
 
 .is-medium {
-  &.avatar {
+  &.avatar,
+  &.avatar-initials {
     height: var(--medium-size);
     width: var(--medium-size);
   }


### PR DESCRIPTION
### Description
- In the last release we fixed the size issue for our `AvatarStack`, but i forgot to make sure the size prop also worked on the `AvatarInitials` component.

#### Screenshot before this PR
![Screenshot 2019-04-05 at 10 15 22](https://user-images.githubusercontent.com/33860269/55613776-c6ddb500-578b-11e9-87e0-5f7c34454ad5.png)

#### Screenshot after this PR
![Screenshot 2019-04-05 at 10 15 27](https://user-images.githubusercontent.com/33860269/55613784-cb09d280-578b-11e9-9d15-59ed396fd5f9.png)

### Breaking changes
- None