### PR TITLE
New component: YearPicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `YearPicker`: added `YearPicker` component. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#592](https://github.com/teamleadercrm/ui/pull/592))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/datepicker/FullNavigationBar.js
+++ b/src/components/datepicker/FullNavigationBar.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Box } from '../box';
-import { IconButton } from '../button';
+import { Button, ButtonGroup } from '../button';
 import {
   IconArrowLeftMediumOutline,
   IconArrowRightMediumOutline,
@@ -9,7 +8,7 @@ import {
   IconArrowRightSmallOutline,
 } from '@teamleader/ui-icons';
 
-class NavigationBar extends PureComponent {
+class FullNavigationBar extends PureComponent {
   handlePreviousClick = () => {
     this.props.onPreviousClick();
   };
@@ -18,38 +17,50 @@ class NavigationBar extends PureComponent {
     this.props.onNextClick();
   };
 
+  handleTodayClick = () => {
+    this.props.onTodayClick();
+  };
+
   render() {
     const { className, localeUtils, nextYear, previousYear, size } = this.props;
-
+    /*
     const years = localeUtils.getYears();
     const previousYearButtonLabel = years[previousYear.getMonth()];
     const nextYearButtonLabel = years[nextYear.getMonth()];
-
+    */
     return (
-      <Box className={className} display="flex" justifyContent="space-between">
-        <IconButton
+      <ButtonGroup segmented>
+        <Button
+          size={size}
+          active={false}
           icon={size === 'large' ? <IconArrowLeftMediumOutline /> : <IconArrowLeftSmallOutline />}
+          disabled={false}
           onClick={this.handlePreviousClick}
-          title={previousYearButtonLabel}
         />
-        <IconButton
+        <Button size={size} onClick={this.handleTodayClick}>
+          Today
+        </Button>
+        <Button
+          size={size}
+          active={false}
           icon={size === 'large' ? <IconArrowRightMediumOutline /> : <IconArrowRightSmallOutline />}
+          disabled={false}
           onClick={this.handleNextClick}
-          title={nextYearButtonLabel}
         />
-      </Box>
+      </ButtonGroup>
     );
   }
 }
 
-NavigationBar.propTypes = {
+FullNavigationBar.propTypes = {
   className: PropTypes.string,
   localeUtils: PropTypes.object,
   nextYear: PropTypes.instanceOf(Date),
   previousYear: PropTypes.instanceOf(Date),
   onNextClick: PropTypes.func,
   onPreviousClick: PropTypes.func,
+  onTodayClick: PropTypes.func,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
 };
 
-export default NavigationBar;
+export default FullNavigationBar;

--- a/src/components/datepicker/FullNavigationBar.js
+++ b/src/components/datepicker/FullNavigationBar.js
@@ -1,0 +1,55 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { Box } from '../box';
+import { IconButton } from '../button';
+import {
+  IconArrowLeftMediumOutline,
+  IconArrowRightMediumOutline,
+  IconArrowLeftSmallOutline,
+  IconArrowRightSmallOutline,
+} from '@teamleader/ui-icons';
+
+class NavigationBar extends PureComponent {
+  handlePreviousClick = () => {
+    this.props.onPreviousClick();
+  };
+
+  handleNextClick = () => {
+    this.props.onNextClick();
+  };
+
+  render() {
+    const { className, localeUtils, nextYear, previousYear, size } = this.props;
+
+    const years = localeUtils.getYears();
+    const previousYearButtonLabel = years[previousYear.getMonth()];
+    const nextYearButtonLabel = years[nextYear.getMonth()];
+
+    return (
+      <Box className={className} display="flex" justifyContent="space-between">
+        <IconButton
+          icon={size === 'large' ? <IconArrowLeftMediumOutline /> : <IconArrowLeftSmallOutline />}
+          onClick={this.handlePreviousClick}
+          title={previousYearButtonLabel}
+        />
+        <IconButton
+          icon={size === 'large' ? <IconArrowRightMediumOutline /> : <IconArrowRightSmallOutline />}
+          onClick={this.handleNextClick}
+          title={nextYearButtonLabel}
+        />
+      </Box>
+    );
+  }
+}
+
+NavigationBar.propTypes = {
+  className: PropTypes.string,
+  localeUtils: PropTypes.object,
+  nextYear: PropTypes.instanceOf(Date),
+  previousYear: PropTypes.instanceOf(Date),
+  onNextClick: PropTypes.func,
+  onPreviousClick: PropTypes.func,
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+};
+
+export default NavigationBar;

--- a/src/components/datepicker/FullNavigationBar.js
+++ b/src/components/datepicker/FullNavigationBar.js
@@ -8,7 +8,7 @@ import {
   IconArrowLeftSmallOutline,
   IconArrowRightSmallOutline,
 } from '@teamleader/ui-icons';
-import { Heading2, TextBody } from '../..';
+import { Section, Heading2 } from '../..';
 
 class FullNavigationBar extends PureComponent {
   handlePreviousClick = () => {

--- a/src/components/datepicker/FullNavigationBar.js
+++ b/src/components/datepicker/FullNavigationBar.js
@@ -19,14 +19,16 @@ const PADDINGS = {
 class FullNavigationBar extends PureComponent {
   handlePreviousClick = () => {
     this.props.onPreviousClick();
+    this.props.onClickPrevious();
   };
 
   handleNextClick = () => {
     this.props.onNextClick();
+    this.props.onClickNext();
   };
 
   handleTodayClick = () => {
-    this.props.handleClickToday();
+    this.props.onClickToday();
   };
 
   render() {

--- a/src/components/datepicker/FullNavigationBar.js
+++ b/src/components/datepicker/FullNavigationBar.js
@@ -2,13 +2,14 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Box } from '../box';
 import { Button, ButtonGroup } from '../button';
+import Section from '../section';
+import { Heading2 } from '../typography';
 import {
   IconArrowLeftMediumOutline,
   IconArrowRightMediumOutline,
   IconArrowLeftSmallOutline,
   IconArrowRightSmallOutline,
 } from '@teamleader/ui-icons';
-import { Section, Heading2 } from '../..';
 
 const PADDINGS = {
   small: 3,

--- a/src/components/datepicker/FullNavigationBar.js
+++ b/src/components/datepicker/FullNavigationBar.js
@@ -8,21 +8,19 @@ import {
   IconArrowLeftSmallOutline,
   IconArrowRightSmallOutline,
 } from '@teamleader/ui-icons';
-import { Section, Heading2 } from '../..';
+import { Heading2, TextBody } from '../..';
 
 class FullNavigationBar extends PureComponent {
   handlePreviousClick = () => {
     this.props.onPreviousClick();
-    this.props.onClickPrevious();
   };
 
   handleNextClick = () => {
-    this.props.onClickNext();
     this.props.onNextClick();
   };
 
   handleTodayClick = () => {
-    this.props.onClickToday();
+    this.props.handleClickToday();
   };
 
   render() {
@@ -30,8 +28,8 @@ class FullNavigationBar extends PureComponent {
     const year = month.getFullYear();
 
     return (
-      <Section marginBottom={3}>
-        <Box display="flex" alignItems="center">
+      <Box display="flex" alignItems="center" justifyContent="space-between">
+        <Box display="flex" alignItems="center" flex={1}>
           <ButtonGroup segmented marginRight={3}>
             <Button
               size={size}
@@ -51,18 +49,18 @@ class FullNavigationBar extends PureComponent {
           <Button size={size} onClick={this.handleTodayClick}>
             Today
           </Button>
-          <Box display="flex" flex={1} justifyContent="flex-end">
-            <Heading2>{year}</Heading2>
-          </Box>
         </Box>
-      </Section>
+        <Heading2 flex={1}>{year}</Heading2>
+        <Box>
+          <TextBody>Week 1</TextBody>
+        </Box>
+      </Box>
     );
   }
 }
 
 FullNavigationBar.propTypes = {
   className: PropTypes.string,
-  onClickToday: PropTypes.func,
   onNextClick: PropTypes.func,
   onPreviousClick: PropTypes.func,
   size: PropTypes.oneOf(['small', 'medium', 'large']),

--- a/src/components/datepicker/FullNavigationBar.js
+++ b/src/components/datepicker/FullNavigationBar.js
@@ -28,8 +28,8 @@ class FullNavigationBar extends PureComponent {
     const year = month.getFullYear();
 
     return (
-      <Box display="flex" alignItems="center" justifyContent="space-between">
-        <Box display="flex" alignItems="center" flex={1}>
+      <Section marginBottom={3}>
+        <Box display="flex" alignItems="center">
           <ButtonGroup segmented marginRight={3}>
             <Button
               size={size}
@@ -49,12 +49,11 @@ class FullNavigationBar extends PureComponent {
           <Button size={size} onClick={this.handleTodayClick}>
             Today
           </Button>
-        </Box>
-        <Heading2 flex={1}>{year}</Heading2>
-        <Box>
-          <TextBody>Week 1</TextBody>
+          <Box display="flex" flex={1} justifyContent="flex-end">
+            <Heading2>{year}</Heading2>
         </Box>
       </Box>
+      </Section>
     );
   }
 }

--- a/src/components/datepicker/FullNavigationBar.js
+++ b/src/components/datepicker/FullNavigationBar.js
@@ -10,6 +10,12 @@ import {
 } from '@teamleader/ui-icons';
 import { Section, Heading2 } from '../..';
 
+const PADDINGS = {
+  small: 3,
+  medium: 4,
+  large: 5,
+};
+
 class FullNavigationBar extends PureComponent {
   handlePreviousClick = () => {
     this.props.onPreviousClick();
@@ -24,11 +30,11 @@ class FullNavigationBar extends PureComponent {
   };
 
   render() {
-    const { className, month, size } = this.props;
+    const { month, size } = this.props;
     const year = month.getFullYear();
 
     return (
-      <Section marginBottom={3}>
+      <Section padding={PADDINGS[size]} marginBottom={3}>
         <Box display="flex" alignItems="center">
           <ButtonGroup segmented marginRight={3}>
             <Button
@@ -59,10 +65,24 @@ class FullNavigationBar extends PureComponent {
 }
 
 FullNavigationBar.propTypes = {
-  className: PropTypes.string,
+  /** The current active month. */
+  month: PropTypes.PropTypes.instanceOf(Date),
+  /** Callback function that is fired when there is clicked on a date. */
+  onClickToday: PropTypes.func,
+  /** Callback function that is fired when there is clicked on the next button. */
+  onClickNext: PropTypes.func,
+  /** Callback function that is fired when there is clicked on the previous button. */
+  onClickPrevious: PropTypes.func,
+  /** Callback function that is fired when there is clicked on the next button. */
   onNextClick: PropTypes.func,
+  /** Callback function that is fired when there is clicked on the previous button. */
   onPreviousClick: PropTypes.func,
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  /** The size wich controls the paddings. */
+  size: PropTypes.oneOf(Object.keys(PADDINGS)),
+};
+
+FullNavigationBar.defaultProps = {
+  size: 'medium',
 };
 
 export default FullNavigationBar;

--- a/src/components/datepicker/FullNavigationBar.js
+++ b/src/components/datepicker/FullNavigationBar.js
@@ -19,16 +19,25 @@ const PADDINGS = {
 
 class FullNavigationBar extends PureComponent {
   handlePreviousClick = () => {
-    this.props.onPreviousClick();
+    // Function to trigger the next button of our calendar
+    const { onPreviousClick: onDayPickerPreviousClick } = this.props;
+    onDayPickerPreviousClick();
+
+    // Function passed from our parent component to update our state
     this.props.onClickPrevious();
   };
 
   handleNextClick = () => {
-    this.props.onNextClick();
+    // Function to trigger the previous button of our calendar
+    const { onNextClick: onDayPickerNextClick } = this.props;
+    onDayPickerNextClick();
+
+    // Function passed from our parent component to update our state
     this.props.onClickNext();
   };
 
   handleTodayClick = () => {
+    // Function passed from our parent component that will reset the date
     this.props.onClickToday();
   };
 

--- a/src/components/datepicker/FullNavigationBar.js
+++ b/src/components/datepicker/FullNavigationBar.js
@@ -20,7 +20,7 @@ class FullNavigationBar extends PureComponent {
   };
 
   handleTodayClick = () => {
-    this.props.onTodayClick();
+    this.props.handleClickToday();
   };
 
   render() {
@@ -31,21 +31,21 @@ class FullNavigationBar extends PureComponent {
       <Box display="flex" alignItems="center" justifyContent="space-between">
         <Box display="flex" alignItems="center" flex={1}>
           <ButtonGroup segmented marginRight={3}>
-        <Button
-          size={size}
-          active={false}
-          icon={size === 'large' ? <IconArrowLeftMediumOutline /> : <IconArrowLeftSmallOutline />}
-          disabled={false}
-          onClick={this.handlePreviousClick}
-        />
-        <Button
-          size={size}
-          active={false}
-          icon={size === 'large' ? <IconArrowRightMediumOutline /> : <IconArrowRightSmallOutline />}
-          disabled={false}
-          onClick={this.handleNextClick}
-        />
-      </ButtonGroup>
+            <Button
+              size={size}
+              active={false}
+              icon={size === 'large' ? <IconArrowLeftMediumOutline /> : <IconArrowLeftSmallOutline />}
+              disabled={false}
+              onClick={this.handlePreviousClick}
+            />
+            <Button
+              size={size}
+              active={false}
+              icon={size === 'large' ? <IconArrowRightMediumOutline /> : <IconArrowRightSmallOutline />}
+              disabled={false}
+              onClick={this.handleNextClick}
+            />
+          </ButtonGroup>
           <Button size={size} onClick={this.handleTodayClick}>
             Today
           </Button>

--- a/src/components/datepicker/FullNavigationBar.js
+++ b/src/components/datepicker/FullNavigationBar.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { Box } from '../box';
 import { Button, ButtonGroup } from '../button';
 import {
   IconArrowLeftMediumOutline,
@@ -7,6 +8,7 @@ import {
   IconArrowLeftSmallOutline,
   IconArrowRightSmallOutline,
 } from '@teamleader/ui-icons';
+import { Heading2, TextBody } from '../..';
 
 class FullNavigationBar extends PureComponent {
   handlePreviousClick = () => {
@@ -26,7 +28,9 @@ class FullNavigationBar extends PureComponent {
     const year = month.getFullYear();
 
     return (
-      <ButtonGroup segmented>
+      <Box display="flex" alignItems="center" justifyContent="space-between">
+        <Box display="flex" alignItems="center" flex={1}>
+          <ButtonGroup segmented marginRight={3}>
         <Button
           size={size}
           active={false}
@@ -34,9 +38,6 @@ class FullNavigationBar extends PureComponent {
           disabled={false}
           onClick={this.handlePreviousClick}
         />
-        <Button size={size} onClick={this.handleTodayClick}>
-          Today
-        </Button>
         <Button
           size={size}
           active={false}
@@ -60,12 +61,8 @@ class FullNavigationBar extends PureComponent {
 
 FullNavigationBar.propTypes = {
   className: PropTypes.string,
-  localeUtils: PropTypes.object,
-  nextYear: PropTypes.instanceOf(Date),
-  previousYear: PropTypes.instanceOf(Date),
   onNextClick: PropTypes.func,
   onPreviousClick: PropTypes.func,
-  onTodayClick: PropTypes.func,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
 };
 

--- a/src/components/datepicker/FullNavigationBar.js
+++ b/src/components/datepicker/FullNavigationBar.js
@@ -59,8 +59,8 @@ class FullNavigationBar extends PureComponent {
           </Button>
           <Box display="flex" flex={1} justifyContent="flex-end">
             <Heading2>{year}</Heading2>
+          </Box>
         </Box>
-      </Box>
       </Section>
     );
   }

--- a/src/components/datepicker/FullNavigationBar.js
+++ b/src/components/datepicker/FullNavigationBar.js
@@ -8,19 +8,21 @@ import {
   IconArrowLeftSmallOutline,
   IconArrowRightSmallOutline,
 } from '@teamleader/ui-icons';
-import { Heading2, TextBody } from '../..';
+import { Section, Heading2 } from '../..';
 
 class FullNavigationBar extends PureComponent {
   handlePreviousClick = () => {
     this.props.onPreviousClick();
+    this.props.onClickPrevious();
   };
 
   handleNextClick = () => {
+    this.props.onClickNext();
     this.props.onNextClick();
   };
 
   handleTodayClick = () => {
-    this.props.handleClickToday();
+    this.props.onClickToday();
   };
 
   render() {
@@ -28,8 +30,8 @@ class FullNavigationBar extends PureComponent {
     const year = month.getFullYear();
 
     return (
-      <Box display="flex" alignItems="center" justifyContent="space-between">
-        <Box display="flex" alignItems="center" flex={1}>
+      <Section marginBottom={3}>
+        <Box display="flex" alignItems="center">
           <ButtonGroup segmented marginRight={3}>
             <Button
               size={size}
@@ -49,18 +51,18 @@ class FullNavigationBar extends PureComponent {
           <Button size={size} onClick={this.handleTodayClick}>
             Today
           </Button>
+          <Box display="flex" flex={1} justifyContent="flex-end">
+            <Heading2>{year}</Heading2>
+          </Box>
         </Box>
-        <Heading2 flex={1}>{year}</Heading2>
-        <Box>
-          <TextBody>Week 1</TextBody>
-        </Box>
-      </Box>
+      </Section>
     );
   }
 }
 
 FullNavigationBar.propTypes = {
   className: PropTypes.string,
+  onClickToday: PropTypes.func,
   onNextClick: PropTypes.func,
   onPreviousClick: PropTypes.func,
   size: PropTypes.oneOf(['small', 'medium', 'large']),

--- a/src/components/datepicker/FullNavigationBar.js
+++ b/src/components/datepicker/FullNavigationBar.js
@@ -22,12 +22,9 @@ class FullNavigationBar extends PureComponent {
   };
 
   render() {
-    const { className, localeUtils, nextYear, previousYear, size } = this.props;
-    /*
-    const years = localeUtils.getYears();
-    const previousYearButtonLabel = years[previousYear.getMonth()];
-    const nextYearButtonLabel = years[nextYear.getMonth()];
-    */
+    const { className, month, size } = this.props;
+    const year = month.getFullYear();
+
     return (
       <ButtonGroup segmented>
         <Button
@@ -48,6 +45,15 @@ class FullNavigationBar extends PureComponent {
           onClick={this.handleNextClick}
         />
       </ButtonGroup>
+          <Button size={size} onClick={this.handleTodayClick}>
+            Today
+          </Button>
+        </Box>
+        <Heading2 flex={1}>{year}</Heading2>
+        <Box>
+          <TextBody>Week 1</TextBody>
+        </Box>
+      </Box>
     );
   }
 }

--- a/src/components/datepicker/YearPicker.js
+++ b/src/components/datepicker/YearPicker.js
@@ -7,6 +7,7 @@ import WeekDay from './WeekDay';
 import cx from 'classnames';
 import theme from './theme.css';
 import uiUtilities from '@teamleader/ui-utilities';
+import LocaleUtils from './localeUtils';
 import { convertModifiersToClassnames, isSelectingFirstDay } from './utils';
 
 class YearPicker extends PureComponent {
@@ -98,20 +99,50 @@ class YearPicker extends PureComponent {
 
     return (
       <Box {...boxProps}>
-        <Box padding={5} className={theme['year-container']}>
+        {showNavigationBar ? (
           <DayPicker
             {...restProps}
-            month={new Date(new Date().getFullYear(), 0)}
+            month={displayedMonth}
             className={classNames}
             classNames={theme}
+            locale={locale}
+            localeUtils={LocaleUtils}
+            modifiers={convertModifiersToClassnames(modifiers, theme)}
             numberOfMonths={12}
             pagedNavigation
-            modifiers={convertModifiersToClassnames(modifiers, theme)}
-            navbarElement={<FullNavigationBar size={size} handleClickToday={this.handleClickToday} />}
+            navbarElement={
+              <FullNavigationBar
+                size={size}
+                onClickToday={this.handleClickToday}
+                onClickNext={this.handleClickNext}
+                onClickPrevious={this.handleClickPrevious}
+                month={displayedMonth}
+              />
+            }
+            onDayClick={this.handleDayClick}
+            onDayMouseEnter={this.handleDayMouseEnter}
+            selectedDays={selectedDays}
             weekdayElement={<WeekDay size={size} />}
             bordered={false}
           />
-        </Box>
+        ) : (
+          <DayPicker
+            {...restProps}
+            month={displayedMonth}
+            className={classNames}
+            classNames={theme}
+            locale={locale}
+            localeUtils={LocaleUtils}
+            modifiers={convertModifiersToClassnames(modifiers, theme)}
+            numberOfMonths={12}
+            pagedNavigation
+            onDayClick={this.handleDayClick}
+            onDayMouseEnter={this.handleDayMouseEnter}
+            selectedDays={selectedDays}
+            weekdayElement={<WeekDay size={size} />}
+            bordered={false}
+          />
+        )}
       </Box>
     );
   }
@@ -122,12 +153,14 @@ YearPicker.propTypes = {
   bordered: PropTypes.bool,
   /** A class name for the DatePicker to give custom styles. */
   className: PropTypes.string,
-  /** The modifiers of the DatePicker component. */
-  modifiers: PropTypes.object,
+  /** The language ISO locale code ('en-GB', 'nl-BE', 'fr-FR',...). */
+  locale: PropTypes.string,
   /** Callback function that is fired when the date has changed. */
   onChange: PropTypes.func,
   /** The current selected range. */
   selectedRange: PropTypes.object,
+  /** If true we render a navigation bar. */
+  showNavigationBar: PropTypes.bool,
   /** Size of the DatePicker component. */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
 };

--- a/src/components/datepicker/YearPicker.js
+++ b/src/components/datepicker/YearPicker.js
@@ -7,89 +7,20 @@ import WeekDay from './WeekDay';
 import cx from 'classnames';
 import theme from './theme.css';
 import uiUtilities from '@teamleader/ui-utilities';
-import LocaleUtils from './localeUtils';
-import { convertModifiersToClassnames, isSelectingFirstDay } from './utils';
+import { convertModifiersToClassnames } from './utils';
 
 class YearPicker extends PureComponent {
-  state = {
-    displayedMonth: new Date(new Date().getFullYear(), 0),
-    selectedStartDate: null,
-    selectedEndDate: null,
-    mouseEnteredEndDate: null,
-  };
-
-  static getDerivedStateFromProps(props, state) {
-    if (
-      props.selectedRange !== undefined &&
-      (props.selectedRange.selectedStartDate !== state.selectedStartDate ||
-        props.selectedRange.selectedEndDate !== state.selectedEndDate)
-    ) {
-      return {
-        selectedStartDate: props.selectedRange.selectedStartDate,
-        selectedEndDate: props.selectedRange.selectedEndDate,
-        mouseEnteredEndDate: props.selectedRange.selectedEndDate,
-      };
-    }
-
-    return null;
-  }
-
-  handleDayClick = day => {
-    const { selectedStartDate, selectedEndDate } = this.state;
-
-    if (isSelectingFirstDay(selectedStartDate, selectedEndDate, day)) {
-      this.setState({
-        selectedStartDate: day,
-        selectedEndDate: null,
-        mouseEnteredEndDate: null,
-      });
-    } else {
-      this.setState({
-        selectedEndDate: day,
-        mouseEnteredEndDate: day,
-      });
-    }
-  };
-
-  handleDayMouseEnter = day => {
-    const { selectedStartDate, selectedEndDate } = this.state;
-
-    if (!isSelectingFirstDay(selectedStartDate, selectedEndDate, day)) {
-      this.setState({
-        mouseEnteredEndDate: day,
-      });
-    }
-  };
-
   handleClickToday = () => {
-    this.setState({ displayedMonth: new Date(new Date().getFullYear(), 0) });
-  };
-
-  handleClickPrevious = () => {
-    const currentMonth = this.state.displayedMonth;
-    currentMonth.setMonth(currentMonth.getMonth() - 12);
-    this.setState({ displayedMonth: currentMonth });
-  };
-
-  handleClickNext = () => {
-    const currentMonth = this.state.displayedMonth;
-    currentMonth.setMonth(currentMonth.getMonth() + 12);
-    this.setState({ displayedMonth: currentMonth });
+    console.log('today');
   };
 
   render() {
-    const { bordered, className, locale, showNavigationBar, size, ...others } = this.props;
-    const { displayedMonth, mouseEnteredEndDate, selectedStartDate } = this.state;
-    const modifiers = { from: selectedStartDate, to: mouseEnteredEndDate };
-    const selectedDays = [selectedStartDate, { from: selectedStartDate, to: mouseEnteredEndDate }];
-
+    const { bordered, className, modifiers, size, ...others } = this.props;
     const boxProps = pickBoxProps(others);
     const restProps = omitBoxProps(others);
-
     const classNames = cx(
       uiUtilities['reset-font-smoothing'],
       theme['date-picker'],
-      theme['has-range'],
       theme[`is-${size}`],
       {
         [theme['is-bordered']]: bordered,
@@ -99,31 +30,20 @@ class YearPicker extends PureComponent {
 
     return (
       <Box {...boxProps}>
-        <DayPicker
-          {...restProps}
-          month={displayedMonth}
-          className={classNames}
-          classNames={theme}
-          locale={locale}
-          localeUtils={LocaleUtils}
-          modifiers={convertModifiersToClassnames(modifiers, theme)}
-          numberOfMonths={12}
-          pagedNavigation
-          navbarElement={
-            <FullNavigationBar
-              size={size}
-              onClickToday={this.handleClickToday}
-              onClickNext={this.handleClickNext}
-              onClickPrevious={this.handleClickPrevious}
-              month={displayedMonth}
-            />
-          }
-          onDayClick={this.handleDayClick}
-          onDayMouseEnter={this.handleDayMouseEnter}
-          selectedDays={selectedDays}
-          weekdayElement={<WeekDay size={size} />}
-          bordered={false}
-        />
+        <Box padding={5} className={theme['year-container']}>
+          <DayPicker
+            {...restProps}
+            month={new Date(new Date().getFullYear(), 0)}
+            className={classNames}
+            classNames={theme}
+            numberOfMonths={12}
+            pagedNavigation
+            modifiers={convertModifiersToClassnames(modifiers, theme)}
+            navbarElement={<FullNavigationBar size={size} handleClickToday={this.handleClickToday} />}
+            weekdayElement={<WeekDay size={size} />}
+            bordered={false}
+          />
+        </Box>
       </Box>
     );
   }
@@ -134,12 +54,12 @@ YearPicker.propTypes = {
   bordered: PropTypes.bool,
   /** A class name for the DatePicker to give custom styles. */
   className: PropTypes.string,
-  /** The language ISO locale code ('en-GB', 'nl-BE', 'fr-FR',...). */
-  locale: PropTypes.string,
+  /** The modifiers of the DatePicker component. */
+  modifiers: PropTypes.object,
   /** Callback function that is fired when the date has changed. */
   onChange: PropTypes.func,
-  /** The current selected range. */
-  selectedRange: PropTypes.object,
+  /** The current selected date. */
+  selectedDate: PropTypes.instanceOf(Date),
   /** Size of the DatePicker component. */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
 };

--- a/src/components/datepicker/YearPicker.js
+++ b/src/components/datepicker/YearPicker.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import DayPicker from 'react-day-picker';
 import Box, { omitBoxProps, pickBoxProps } from '../box';
-import NavigationBar from './NavigationBar';
+import FullNavigationBar from './FullNavigationBar';
 import WeekDay from './WeekDay';
 import cx from 'classnames';
 import theme from './theme.css';
@@ -40,7 +40,7 @@ class YearPicker extends PureComponent {
             pagedNavigation
             selectedDate={new Date(new Date().getFullYear(), 0, 1)}
             modifiers={convertModifiersToClassnames(modifiers, theme)}
-            navbarElement={<NavigationBar size={size} />}
+            navbarElement={<FullNavigationBar size={size} />}
             weekdayElement={<WeekDay size={size} />}
             bordered="false"
           />

--- a/src/components/datepicker/YearPicker.js
+++ b/src/components/datepicker/YearPicker.js
@@ -99,18 +99,18 @@ class YearPicker extends PureComponent {
 
     return (
       <Box {...boxProps}>
-        {showNavigationBar ? (
-          <DayPicker
-            {...restProps}
-            month={displayedMonth}
-            className={classNames}
-            classNames={theme}
-            locale={locale}
-            localeUtils={LocaleUtils}
-            modifiers={convertModifiersToClassnames(modifiers, theme)}
-            numberOfMonths={12}
-            pagedNavigation
-            navbarElement={
+        <DayPicker
+          {...restProps}
+          month={displayedMonth}
+          className={classNames}
+          classNames={theme}
+          locale={locale}
+          localeUtils={LocaleUtils}
+          modifiers={convertModifiersToClassnames(modifiers, theme)}
+          numberOfMonths={12}
+          pagedNavigation
+          navbarElement={
+            showNavigationBar ? (
               <FullNavigationBar
                 size={size}
                 onClickToday={this.handleClickToday}
@@ -118,31 +118,16 @@ class YearPicker extends PureComponent {
                 onClickPrevious={this.handleClickPrevious}
                 month={displayedMonth}
               />
-            }
-            onDayClick={this.handleDayClick}
-            onDayMouseEnter={this.handleDayMouseEnter}
-            selectedDays={selectedDays}
-            weekdayElement={<WeekDay size={size} />}
-            bordered={false}
-          />
-        ) : (
-          <DayPicker
-            {...restProps}
-            month={displayedMonth}
-            className={classNames}
-            classNames={theme}
-            locale={locale}
-            localeUtils={LocaleUtils}
-            modifiers={convertModifiersToClassnames(modifiers, theme)}
-            numberOfMonths={12}
-            pagedNavigation
-            onDayClick={this.handleDayClick}
-            onDayMouseEnter={this.handleDayMouseEnter}
-            selectedDays={selectedDays}
-            weekdayElement={<WeekDay size={size} />}
-            bordered={false}
-          />
-        )}
+            ) : (
+              undefined
+            )
+          }
+          onDayClick={this.handleDayClick}
+          onDayMouseEnter={this.handleDayMouseEnter}
+          selectedDays={selectedDays}
+          weekdayElement={<WeekDay size={size} />}
+          bordered={false}
+        />
       </Box>
     );
   }

--- a/src/components/datepicker/YearPicker.js
+++ b/src/components/datepicker/YearPicker.js
@@ -8,25 +8,29 @@ import cx from 'classnames';
 import theme from './theme.css';
 import uiUtilities from '@teamleader/ui-utilities';
 import { convertModifiersToClassnames } from './utils';
-import { Heading2 } from '../..';
 
 class YearPicker extends PureComponent {
-
   handleClickToday = () => {
     console.log('today');
-  }
+  };
 
   render() {
-    const { className, modifiers, size, ...others } = this.props;
-    const { currentYear, selectedDate } = this.state;
+    const { bordered, className, modifiers, size, ...others } = this.props;
     const boxProps = pickBoxProps(others);
     const restProps = omitBoxProps(others);
-    const classNames = cx(uiUtilities['reset-font-smoothing'], theme['date-picker'], theme[`is-${size}`], className);
+    const classNames = cx(
+      uiUtilities['reset-font-smoothing'],
+      theme['date-picker'],
+      theme[`is-${size}`],
+      {
+        [theme['is-bordered']]: bordered,
+      },
+      className,
+    );
 
     return (
       <Box {...boxProps}>
-        <Box padding={3} display="flex" alignItems="center" className={theme['year-container']}>
-          <Heading2 marginBottom={3}>{currentYear}</Heading2>
+        <Box padding={5} className={theme['year-container']}>
           <DayPicker
             {...restProps}
             month={new Date(new Date().getFullYear(), 0)}
@@ -34,7 +38,6 @@ class YearPicker extends PureComponent {
             classNames={theme}
             numberOfMonths={12}
             pagedNavigation
-            selectedDate={new Date(new Date().getFullYear(), 0, 1)}
             modifiers={convertModifiersToClassnames(modifiers, theme)}
             navbarElement={<FullNavigationBar size={size} handleClickToday={this.handleClickToday()} />}
             weekdayElement={<WeekDay size={size} />}
@@ -45,5 +48,25 @@ class YearPicker extends PureComponent {
     );
   }
 }
+
+YearPicker.propTypes = {
+  /** If true we give a border to our wrapper. */
+  bordered: PropTypes.bool,
+  /** A class name for the DatePicker to give custom styles. */
+  className: PropTypes.string,
+  /** The modifiers of the DatePicker component. */
+  modifiers: PropTypes.object,
+  /** Callback function that is fired when the date has changed. */
+  onChange: PropTypes.func,
+  /** The current selected date. */
+  selectedDate: PropTypes.instanceOf(Date),
+  /** Size of the DatePicker component. */
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+};
+
+YearPicker.defaultProps = {
+  bordered: false,
+  size: 'medium',
+};
 
 export default YearPicker;

--- a/src/components/datepicker/YearPicker.js
+++ b/src/components/datepicker/YearPicker.js
@@ -11,14 +11,9 @@ import { convertModifiersToClassnames } from './utils';
 import { Heading2 } from '../..';
 
 class YearPicker extends PureComponent {
-  state = {
-    currentYear: null,
-    selectedDate: null,
-  };
 
-  componentDidMount() {
-    const january = new Date(new Date().getFullYear(), 0, 1);
-    this.setState({ selectedDate: january });
+  handleClickToday = () => {
+    console.log('today');
   }
 
   render() {
@@ -34,15 +29,16 @@ class YearPicker extends PureComponent {
           <Heading2 marginBottom={3}>{currentYear}</Heading2>
           <DayPicker
             {...restProps}
+            month={new Date(new Date().getFullYear(), 0)}
             className={classNames}
             classNames={theme}
             numberOfMonths={12}
             pagedNavigation
             selectedDate={new Date(new Date().getFullYear(), 0, 1)}
             modifiers={convertModifiersToClassnames(modifiers, theme)}
-            navbarElement={<FullNavigationBar size={size} />}
+            navbarElement={<FullNavigationBar size={size} handleClickToday={this.handleClickToday()} />}
             weekdayElement={<WeekDay size={size} />}
-            bordered="false"
+            bordered={false}
           />
         </Box>
       </Box>

--- a/src/components/datepicker/YearPicker.js
+++ b/src/components/datepicker/YearPicker.js
@@ -7,20 +7,89 @@ import WeekDay from './WeekDay';
 import cx from 'classnames';
 import theme from './theme.css';
 import uiUtilities from '@teamleader/ui-utilities';
-import { convertModifiersToClassnames } from './utils';
+import LocaleUtils from './localeUtils';
+import { convertModifiersToClassnames, isSelectingFirstDay } from './utils';
 
 class YearPicker extends PureComponent {
+  state = {
+    displayedMonth: new Date(new Date().getFullYear(), 0),
+    selectedStartDate: null,
+    selectedEndDate: null,
+    mouseEnteredEndDate: null,
+  };
+
+  static getDerivedStateFromProps(props, state) {
+    if (
+      props.selectedRange !== undefined &&
+      (props.selectedRange.selectedStartDate !== state.selectedStartDate ||
+        props.selectedRange.selectedEndDate !== state.selectedEndDate)
+    ) {
+      return {
+        selectedStartDate: props.selectedRange.selectedStartDate,
+        selectedEndDate: props.selectedRange.selectedEndDate,
+        mouseEnteredEndDate: props.selectedRange.selectedEndDate,
+      };
+    }
+
+    return null;
+  }
+
+  handleDayClick = day => {
+    const { selectedStartDate, selectedEndDate } = this.state;
+
+    if (isSelectingFirstDay(selectedStartDate, selectedEndDate, day)) {
+      this.setState({
+        selectedStartDate: day,
+        selectedEndDate: null,
+        mouseEnteredEndDate: null,
+      });
+    } else {
+      this.setState({
+        selectedEndDate: day,
+        mouseEnteredEndDate: day,
+      });
+    }
+  };
+
+  handleDayMouseEnter = day => {
+    const { selectedStartDate, selectedEndDate } = this.state;
+
+    if (!isSelectingFirstDay(selectedStartDate, selectedEndDate, day)) {
+      this.setState({
+        mouseEnteredEndDate: day,
+      });
+    }
+  };
+
   handleClickToday = () => {
-    console.log('today');
+    this.setState({ displayedMonth: new Date(new Date().getFullYear(), 0) });
+  };
+
+  handleClickPrevious = () => {
+    const currentMonth = this.state.displayedMonth;
+    currentMonth.setMonth(currentMonth.getMonth() - 12);
+    this.setState({ displayedMonth: currentMonth });
+  };
+
+  handleClickNext = () => {
+    const currentMonth = this.state.displayedMonth;
+    currentMonth.setMonth(currentMonth.getMonth() + 12);
+    this.setState({ displayedMonth: currentMonth });
   };
 
   render() {
-    const { bordered, className, modifiers, size, ...others } = this.props;
+    const { bordered, className, locale, showNavigationBar, size, ...others } = this.props;
+    const { displayedMonth, mouseEnteredEndDate, selectedStartDate } = this.state;
+    const modifiers = { from: selectedStartDate, to: mouseEnteredEndDate };
+    const selectedDays = [selectedStartDate, { from: selectedStartDate, to: mouseEnteredEndDate }];
+
     const boxProps = pickBoxProps(others);
     const restProps = omitBoxProps(others);
+
     const classNames = cx(
       uiUtilities['reset-font-smoothing'],
       theme['date-picker'],
+      theme['has-range'],
       theme[`is-${size}`],
       {
         [theme['is-bordered']]: bordered,
@@ -30,20 +99,31 @@ class YearPicker extends PureComponent {
 
     return (
       <Box {...boxProps}>
-        <Box padding={5} className={theme['year-container']}>
-          <DayPicker
-            {...restProps}
-            month={new Date(new Date().getFullYear(), 0)}
-            className={classNames}
-            classNames={theme}
-            numberOfMonths={12}
-            pagedNavigation
-            modifiers={convertModifiersToClassnames(modifiers, theme)}
-            navbarElement={<FullNavigationBar size={size} handleClickToday={this.handleClickToday} />}
-            weekdayElement={<WeekDay size={size} />}
-            bordered={false}
-          />
-        </Box>
+        <DayPicker
+          {...restProps}
+          month={displayedMonth}
+          className={classNames}
+          classNames={theme}
+          locale={locale}
+          localeUtils={LocaleUtils}
+          modifiers={convertModifiersToClassnames(modifiers, theme)}
+          numberOfMonths={12}
+          pagedNavigation
+          navbarElement={
+            <FullNavigationBar
+              size={size}
+              onClickToday={this.handleClickToday}
+              onClickNext={this.handleClickNext}
+              onClickPrevious={this.handleClickPrevious}
+              month={displayedMonth}
+            />
+          }
+          onDayClick={this.handleDayClick}
+          onDayMouseEnter={this.handleDayMouseEnter}
+          selectedDays={selectedDays}
+          weekdayElement={<WeekDay size={size} />}
+          bordered={false}
+        />
       </Box>
     );
   }
@@ -54,12 +134,12 @@ YearPicker.propTypes = {
   bordered: PropTypes.bool,
   /** A class name for the DatePicker to give custom styles. */
   className: PropTypes.string,
-  /** The modifiers of the DatePicker component. */
-  modifiers: PropTypes.object,
+  /** The language ISO locale code ('en-GB', 'nl-BE', 'fr-FR',...). */
+  locale: PropTypes.string,
   /** Callback function that is fired when the date has changed. */
   onChange: PropTypes.func,
-  /** The current selected date. */
-  selectedDate: PropTypes.instanceOf(Date),
+  /** The current selected range. */
+  selectedRange: PropTypes.object,
   /** Size of the DatePicker component. */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
 };

--- a/src/components/datepicker/YearPicker.js
+++ b/src/components/datepicker/YearPicker.js
@@ -39,7 +39,7 @@ class YearPicker extends PureComponent {
             numberOfMonths={12}
             pagedNavigation
             modifiers={convertModifiersToClassnames(modifiers, theme)}
-            navbarElement={<FullNavigationBar size={size} handleClickToday={this.handleClickToday()} />}
+            navbarElement={<FullNavigationBar size={size} handleClickToday={this.handleClickToday} />}
             weekdayElement={<WeekDay size={size} />}
             bordered={false}
           />

--- a/src/components/datepicker/YearPicker.js
+++ b/src/components/datepicker/YearPicker.js
@@ -1,0 +1,53 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import DayPicker from 'react-day-picker';
+import Box, { omitBoxProps, pickBoxProps } from '../box';
+import NavigationBar from './NavigationBar';
+import WeekDay from './WeekDay';
+import cx from 'classnames';
+import theme from './theme.css';
+import uiUtilities from '@teamleader/ui-utilities';
+import { convertModifiersToClassnames } from './utils';
+import { Heading2 } from '../..';
+
+class YearPicker extends PureComponent {
+  state = {
+    currentYear: null,
+    selectedDate: null,
+  };
+
+  componentDidMount() {
+    const january = new Date(new Date().getFullYear(), 0, 1);
+    this.setState({ selectedDate: january });
+  }
+
+  render() {
+    const { className, modifiers, size, ...others } = this.props;
+    const { currentYear, selectedDate } = this.state;
+    const boxProps = pickBoxProps(others);
+    const restProps = omitBoxProps(others);
+    const classNames = cx(uiUtilities['reset-font-smoothing'], theme['date-picker'], theme[`is-${size}`], className);
+
+    return (
+      <Box {...boxProps}>
+        <Box padding={3} display="flex" alignItems="center" className={theme['year-container']}>
+          <Heading2 marginBottom={3}>{currentYear}</Heading2>
+          <DayPicker
+            {...restProps}
+            className={classNames}
+            classNames={theme}
+            numberOfMonths={12}
+            pagedNavigation
+            selectedDate={new Date(new Date().getFullYear(), 0, 1)}
+            modifiers={convertModifiersToClassnames(modifiers, theme)}
+            navbarElement={<NavigationBar size={size} />}
+            weekdayElement={<WeekDay size={size} />}
+            bordered="false"
+          />
+        </Box>
+      </Box>
+    );
+  }
+}
+
+export default YearPicker;

--- a/src/components/datepicker/index.js
+++ b/src/components/datepicker/index.js
@@ -2,6 +2,7 @@ import DatePicker from './DatePicker';
 import DatePickerInput from './DatePickerInput';
 import DatePickerRange from './DatePickerRange';
 import DatePickerInputRange from './DatePickerInputRange';
+import YearPicker from './YearPicker';
 
 export default DatePicker;
-export { DatePicker, DatePickerRange, DatePickerInput, DatePickerInputRange };
+export { DatePicker, DatePickerRange, DatePickerInput, DatePickerInputRange, YearPicker };

--- a/src/components/datepicker/theme.css
+++ b/src/components/datepicker/theme.css
@@ -422,6 +422,12 @@
   }
 }
 
+.year-container {
+  flex-flow: column;
+  border: 1px solid var(--color-neutral);
+  border-radius: var(--border-radius);
+}
+
 .has-warning {
   &:not(.has-focus) {
     &:not(.is-inverse) {

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,7 @@ import Tooltip from './components/tooltip';
 import QTip from './components/qTip';
 import ProgressTracker from './components/progressTracker';
 import Widget from './components/widget';
+import YearPicker from './components/datepicker/YearPicker';
 
 import {
   COLOR,
@@ -141,6 +142,7 @@ export {
   Tooltip,
   ValidationText,
   Widget,
+  YearPicker,
   QTip,
   COLOR,
   COLORS,

--- a/stories/datePicker.js
+++ b/stories/datePicker.js
@@ -157,17 +157,11 @@ storiesOf('Form elements/DatePicker', module)
     );
   })
   .add('Year picker', () => {
-    const handleOnChange = selectedDate => {
-      console.log('Selected date', selectedDate);
-    };
-
+    console.log(preSelectedDate);
     return (
       <YearPicker
-        bordered={boolean('bordered', false)}
         locale={select('Locale', languages, 'nl-BE')}
         localeUtils={CustomLocaleUtils}
-        onChange={handleOnChange}
-        showNavigationBar={boolean('showNavigationBar', true)}
         showOutsideDays={boolean('Show outside days', true)}
         showWeekNumbers={boolean('Show week numbers', true)}
         size={select('Size', sizes, 'medium')}

--- a/stories/datePicker.js
+++ b/stories/datePicker.js
@@ -162,6 +162,7 @@ storiesOf('Form elements/DatePicker', module)
       <YearPicker
         locale={select('Locale', languages, 'nl-BE')}
         localeUtils={CustomLocaleUtils}
+        showNavigationBar={boolean('Show navigationbar', true)}
         showOutsideDays={boolean('Show outside days', true)}
         showWeekNumbers={boolean('Show week numbers', true)}
         size={select('Size', sizes, 'medium')}

--- a/stories/datePicker.js
+++ b/stories/datePicker.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, number, select, text } from '@storybook/addon-knobs/react';
-import { DatePicker, DatePickerRange, DatePickerInput, DatePickerInputRange } from '../src';
+import { DatePicker, DatePickerRange, DatePickerInput, DatePickerInputRange, YearPicker } from '../src';
 import { DateTime } from 'luxon';
 import CustomLocaleUtils, { formatDate, parseDate } from '../src/components/datepicker/localeUtils';
 
@@ -150,6 +150,18 @@ storiesOf('Form elements/DatePicker', module)
         selectedRange={preSelectedRange}
         size={select('Size', sizes, 'medium')}
         width={text('width', undefined)}
+      />
+    );
+  })
+  .add('Year picker', () => {
+    console.log(preSelectedDate);
+    return (
+      <YearPicker
+        locale={select('Locale', languages, 'nl-BE')}
+        localeUtils={CustomLocaleUtils}
+        showOutsideDays={boolean('Show outside days', true)}
+        showWeekNumbers={boolean('Show week numbers', true)}
+        size={select('Size', sizes, 'medium')}
       />
     );
   });

--- a/stories/datePicker.js
+++ b/stories/datePicker.js
@@ -157,11 +157,16 @@ storiesOf('Form elements/DatePicker', module)
     );
   })
   .add('Year picker', () => {
-    console.log(preSelectedDate);
+    const handleOnChange = selectedDate => {
+      console.log('Selected date', selectedDate);
+    };
+
     return (
       <YearPicker
+        bordered={boolean('bordered', false)}
         locale={select('Locale', languages, 'nl-BE')}
         localeUtils={CustomLocaleUtils}
+        onChange={handleOnChange}
         showNavigationBar={boolean('Show navigationbar', true)}
         showOutsideDays={boolean('Show outside days', true)}
         showWeekNumbers={boolean('Show week numbers', true)}

--- a/stories/datePicker.js
+++ b/stories/datePicker.js
@@ -157,11 +157,17 @@ storiesOf('Form elements/DatePicker', module)
     );
   })
   .add('Year picker', () => {
-    console.log(preSelectedDate);
+    const handleOnChange = selectedDate => {
+      console.log('Selected date', selectedDate);
+    };
+
     return (
       <YearPicker
+        bordered={boolean('bordered', false)}
         locale={select('Locale', languages, 'nl-BE')}
         localeUtils={CustomLocaleUtils}
+        onChange={handleOnChange}
+        showNavigationBar={boolean('showNavigationBar', true)}
         showOutsideDays={boolean('Show outside days', true)}
         showWeekNumbers={boolean('Show week numbers', true)}
         size={select('Size', sizes, 'medium')}

--- a/stories/widget.js
+++ b/stories/widget.js
@@ -21,6 +21,7 @@ import {
   StatusLabel,
   MenuDivider,
   Bullet,
+  YearPicker,
 } from '../src';
 import { rows1 } from './static/data/datagrid';
 import IconEditMediumOutline from '@teamleader/ui-icons/cjs/IconEditMediumOutline';
@@ -142,13 +143,8 @@ storiesOf('Widget', module)
       <Widget.Header color={select('header color', colors, 'neutral')}>
         <Heading2>I am the widget header title</Heading2>
       </Widget.Header>
-      <Widget.Body>
-        <DatePicker
-          locale="nl-BE"
-          numberOfMonths={12}
-          onChange={() => console.log('Date changed')}
-          selectedDate={new Date()}
-        />
+      <Widget.Body padding={0}>
+        <YearPicker />
       </Widget.Body>
     </Widget>
   ))

--- a/stories/widget.js
+++ b/stories/widget.js
@@ -6,7 +6,6 @@ import {
   Button,
   ButtonGroup,
   DataGrid,
-  DatePicker,
   Heading3,
   IconButton,
   IconMenu,
@@ -21,11 +20,27 @@ import {
   StatusLabel,
   MenuDivider,
   Bullet,
+  YearPicker,
 } from '../src';
 import { rows1 } from './static/data/datagrid';
 import IconEditMediumOutline from '@teamleader/ui-icons/cjs/IconEditMediumOutline';
+import CustomLocaleUtils from '../src/components/datepicker/localeUtils';
 
 const colors = ['mint', 'violet', 'ruby', 'gold', 'aqua', 'white', 'neutral'];
+const languages = [
+  'da-DK',
+  'de-DE',
+  'fr-FR',
+  'en-GB',
+  'en-US',
+  'es-ES',
+  'fi-FI',
+  'it-IT',
+  'nl-BE',
+  'pt-PT',
+  'pl-PL',
+  'sv-SE',
+];
 const sizes = ['small', 'medium', 'large'];
 const TooltippedStatusBullet = Tooltip(StatusBullet);
 
@@ -142,12 +157,14 @@ storiesOf('Widget', module)
       <Widget.Header color={select('header color', colors, 'neutral')}>
         <Heading2>I am the widget header title</Heading2>
       </Widget.Header>
-      <Widget.Body>
-        <DatePicker
-          locale="nl-BE"
-          numberOfMonths={12}
-          onChange={() => console.log('Date changed')}
-          selectedDate={new Date()}
+      <Widget.Body padding={0}>
+        <YearPicker
+          locale={select('Locale', languages, 'nl-BE')}
+          localeUtils={CustomLocaleUtils}
+          showNavigationBar={boolean('Show navigationbar', true)}
+          showOutsideDays={boolean('Show outside days', true)}
+          showWeekNumbers={boolean('Show week numbers', true)}
+          size={select('Size', sizes, 'medium')}
         />
       </Widget.Body>
     </Widget>

--- a/stories/widget.js
+++ b/stories/widget.js
@@ -21,7 +21,6 @@ import {
   StatusLabel,
   MenuDivider,
   Bullet,
-  YearPicker,
 } from '../src';
 import { rows1 } from './static/data/datagrid';
 import IconEditMediumOutline from '@teamleader/ui-icons/cjs/IconEditMediumOutline';
@@ -143,8 +142,13 @@ storiesOf('Widget', module)
       <Widget.Header color={select('header color', colors, 'neutral')}>
         <Heading2>I am the widget header title</Heading2>
       </Widget.Header>
-      <Widget.Body padding={0}>
-        <YearPicker />
+      <Widget.Body>
+        <DatePicker
+          locale="nl-BE"
+          numberOfMonths={12}
+          onChange={() => console.log('Date changed')}
+          selectedDate={new Date()}
+        />
       </Widget.Body>
     </Widget>
   ))


### PR DESCRIPTION
### Description
- This PR adds a new component: the `YearPicker`. Our YearPicker can be used standalone or in a Widget.

### Screenshots

#### Standalone
![Screenshot 2019-04-08 at 16 48 16](https://user-images.githubusercontent.com/33860269/55733446-2652f380-5a1e-11e9-8e55-eba7d1420408.png)

#### Widget
![Screenshot 2019-04-08 at 16 47 58](https://user-images.githubusercontent.com/33860269/55733466-2ce16b00-5a1e-11e9-8182-c1a2441a8319.png)

### Breaking changes
- None
