### PR TITLE
Labels: Change alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Checkbox` & `RadioButton` & `Toggle`: aligment label according to size. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#593](https://github.com/teamleadercrm/ui/pull/593))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/checkbox/theme.css
+++ b/src/components/checkbox/theme.css
@@ -17,10 +17,6 @@
   display: flex;
   user-select: none;
 
-  .label {
-    padding-top: 2px;
-  }
-
   .input {
     width: 0;
     height: 0;
@@ -119,6 +115,7 @@
   &.is-medium {
     .label {
       margin-left: var(--spacer-small);
+      padding-top: 2px;
     }
 
     .shape {
@@ -130,6 +127,7 @@
   &.is-large {
     .label {
       margin-left: var(--spacer-small);
+      padding-top: 4px;
     }
 
     .shape {

--- a/src/components/checkbox/theme.css
+++ b/src/components/checkbox/theme.css
@@ -13,9 +13,13 @@
 }
 
 .checkbox {
-  align-items: center;
+  align-items: flex-start;
   display: flex;
   user-select: none;
+
+  .label {
+    padding-top: 2px;
+  }
 
   .input {
     width: 0;

--- a/src/components/radio/theme.css
+++ b/src/components/radio/theme.css
@@ -19,10 +19,6 @@
   display: flex;
   user-select: none;
 
-  .label {
-    padding-top: 2px;
-  }
-
   .input {
     width: 0;
     height: 0;
@@ -133,6 +129,7 @@
   &.is-medium {
     .label {
       margin-left: var(--spacer-small);
+      padding-top: 2px;
     }
 
     .shape {
@@ -149,6 +146,7 @@
   &.is-large {
     .label {
       margin-left: var(--spacer-small);
+      padding-top: 4px;
     }
 
     .shape {

--- a/src/components/radio/theme.css
+++ b/src/components/radio/theme.css
@@ -15,9 +15,13 @@
 }
 
 .radiobutton {
-  align-items: center;
+  align-items: flex-start;
   display: flex;
   user-select: none;
+
+  .label {
+    padding-top: 2px;
+  }
 
   .input {
     width: 0;

--- a/src/components/toggle/theme.css
+++ b/src/components/toggle/theme.css
@@ -21,9 +21,13 @@
 }
 
 .toggle {
-  align-items: center;
+  align-items: flex-start;
   display: flex;
   user-select: none;
+
+  .label {
+    padding-top: 2px;
+  }
 
   .input {
     width: 0;

--- a/src/components/toggle/theme.css
+++ b/src/components/toggle/theme.css
@@ -25,10 +25,6 @@
   display: flex;
   user-select: none;
 
-  .label {
-    padding-top: 2px;
-  }
-
   .input {
     width: 0;
     height: 0;
@@ -154,6 +150,7 @@
   &.is-medium {
     .label {
       margin-left: var(--spacer-small);
+      padding-top: 2px;
     }
 
     .track {
@@ -183,6 +180,7 @@
   &.is-large {
     .label {
       margin-left: var(--spacer-small);
+      padding-top: 4px;
     }
 
     .track {


### PR DESCRIPTION
### Description
- Right now our labels will always be aligned in the center of a `Toggle`, `Checkbox` or `Radiobutton`. We don't want this when we have multiple lines in our label.

#### Screenshot before this PR
![Screenshot 2019-04-09 at 14 42 51](https://user-images.githubusercontent.com/33860269/55801210-d9325880-5ad5-11e9-9d3c-5cc9a03298a7.png)

#### Screenshot after this PR
![Screenshot 2019-04-09 at 14 43 12](https://user-images.githubusercontent.com/33860269/55801216-dc2d4900-5ad5-11e9-908b-c22f89da1b5a.png)

### Breaking changes
 - None
