### PR TITLE
Passport: rename the 'links' prop to 'lineItems'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Changed
 
-- `Checkbox` & `RadioButton` & `Toggle`: aligment label according to size. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#593](https://github.com/teamleadercrm/ui/pull/593))
+- `Checkbox` & `RadioButton` & `Toggle`: alignment label according to size. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#593](https://github.com/teamleadercrm/ui/pull/593))
+- [BREAKING] `Passport`: renamed the `links` prop to `lineItems`, so we could also render normal text. ([@driesd](https://github.com/driesd) in [#595](https://github.com/teamleadercrm/ui/pull/595))
 
 ### Deprecated
 

--- a/src/components/passport/Passport.js
+++ b/src/components/passport/Passport.js
@@ -43,7 +43,7 @@ class Passport extends PureComponent {
   };
 
   render() {
-    const { avatar, className, links, ...others } = this.props;
+    const { avatar, className, lineItems, ...others } = this.props;
 
     return (
       <Popover {...others} backdrop="transparent" className={cx(theme['passport'], className)}>
@@ -57,19 +57,26 @@ class Passport extends PureComponent {
               {this.renderDescription()}
             </Box>
           </Box>
-          {links && (
+          {lineItems && (
             <Box marginTop={3}>
-              {links.map(({ icon, ...link }, index) => (
+              {lineItems.map(({ icon, ...lineItem }, index) => (
                 <Box alignItems="flex-start" display="flex" key={index}>
                   <Box display="flex" flex="48px 0 0" justifyContent="center" paddingRight={3}>
                     {icon && (
-                      <Icon color="aqua" tint="dark" marginTop={1}>
+                      <Icon
+                        color={lineItem.href || lineItem.onClick ? 'aqua' : 'teal'}
+                        tint={lineItem.href || lineItem.onClick ? 'dark' : 'darkest'}
+                        marginTop={1}
+                      >
                         {icon}
                       </Icon>
                     )}
                   </Box>
-                  <TextBody className={cx(theme['prevent-overflow'], theme['prevent-wrap'], theme['show-ellipsis'])}>
-                    <Link {...link} inherit={false} />
+                  <TextBody
+                    className={cx(theme['prevent-overflow'], theme['prevent-wrap'], theme['show-ellipsis'])}
+                    color="teal"
+                  >
+                    {lineItem.href || lineItem.onClick ? <Link {...lineItem} inherit={false} /> : lineItem.children}
                   </TextBody>
                 </Box>
               ))}
@@ -89,7 +96,7 @@ Passport.propTypes = {
   /** The description of the Passport. */
   description: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
   /** Array of objects containing the props of a Link. */
-  links: PropTypes.array,
+  lineItems: PropTypes.array,
   /** The title of the Passport (can be a string of an object containing the props of a Link). */
   title: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
 };

--- a/stories/passport.js
+++ b/stories/passport.js
@@ -11,7 +11,7 @@ const store = new Store({
   active: false,
 });
 
-const contactLinks = [
+const contactLineItems = [
   {
     children: 'Dunder Miflin',
     icon: <IconBuildingSmallOutline />,
@@ -27,12 +27,10 @@ const contactLinks = [
   {
     children: 'david.brent@dundermiflin.com',
     icon: <IconMailSmallOutline />,
-    href: 'mailto:david.brent@dundermiflin.com',
-    title: 'Mail to david.brent@dundermiflin.com',
   },
 ];
 
-const companyLinks = [
+const companyLineItems = [
   {
     children: '+1 257 689 5454',
     icon: <IconPhoneSmallOutline />,
@@ -73,7 +71,7 @@ storiesOf('Passport', module)
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           avatar={{ image: contactAvatar }}
-          links={contactLinks}
+          lineItems={contactLineItems}
           title={{ children: 'David Brent', href: 'https://www.teamleader.eu' }}
         />
       </State>
@@ -91,7 +89,7 @@ storiesOf('Passport', module)
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
           avatar={{ image: companyAvatar, shape: 'rounded' }}
-          links={companyLinks}
+          lineItems={companyLineItems}
           title="Dunder Miflin"
         />
       </State>


### PR DESCRIPTION
### Description

This PR renames the `links` prop to `lineItems` so we could also render normal text. It also makes sure that the icon always has the correct color.

#### Screenshot before this PR
![Screenshot 2019-04-17 16 35 44](https://user-images.githubusercontent.com/5336831/56296504-f054f400-612e-11e9-8b3f-e31a4cce3331.png)

#### Screenshot after this PR
![Screenshot 2019-04-17 16 35 09](https://user-images.githubusercontent.com/5336831/56296488-ea5f1300-612e-11e9-8300-04f3f2ad4e7d.png)

### Breaking changes

- Renamed the `links` prop to `lineItems`
