### PR TITLE
[AHOY-303] Input/Textarea: separate validation message from validation border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- `SingleLineInputBase` & `Textarea`: changed validation behavior to only show a border when passing a boolean value. ([@driesd](https://github.com/driesd) in [#601](https://github.com/teamleadercrm/ui/pull/601))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/input/SingleLineInputBase.js
+++ b/src/components/input/SingleLineInputBase.js
@@ -104,17 +104,17 @@ SingleLineInputBase.propTypes = {
   /** Element stuck to the right hand side of the component. */
   connectedRight: PropTypes.element,
   /** The text string/element to use as error message below the input. */
-  error: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  error: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
   /** The text string to use as help text below the input. */
   helpText: PropTypes.string,
   /** The text string/element to use as a prefix inside the input field */
   prefix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
   /** The text string/element to use as success message below the input. */
-  success: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  success: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
   /** The text string/element to use as a suffix inside the input field */
   suffix: PropTypes.oneOfType([PropTypes.array, PropTypes.element]),
   /** The text to use as warning message below the input. */
-  warning: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  warning: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
   /** A custom width for the input field */
   width: PropTypes.string,
 };

--- a/src/components/input/Textarea.js
+++ b/src/components/input/Textarea.js
@@ -40,15 +40,15 @@ Textarea.propTypes = {
   /** Sets a class name for the wrapper to give custom styles. */
   className: PropTypes.string,
   /** The text to use as error message below the input. */
-  error: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  error: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
   /** The text to use as help text below the input. */
   helpText: PropTypes.string,
   /** Boolean indicating whether the input should render as inverse. */
   inverse: PropTypes.bool,
   /** The text string/element to use as success message below the input. */
-  success: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  success: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
   /** The text to use as warning message below the input. */
-  warning: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  warning: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
 };
 
 Textarea.defaultProps = {

--- a/src/components/validationText/ValidationText.js
+++ b/src/components/validationText/ValidationText.js
@@ -10,15 +10,15 @@ class ValidationText extends PureComponent {
   render() {
     const { error, inverse, help, success, warning } = this.props;
 
-    if (error) {
+    if (error && typeof error !== 'boolean') {
       return <ErrorText inverse={inverse}>{error}</ErrorText>;
     }
 
-    if (warning) {
+    if (warning && typeof warning !== 'boolean') {
       return <WarningText inverse={inverse}>{warning}</WarningText>;
     }
 
-    if (success) {
+    if (success && typeof success !== 'boolean') {
       return <SuccessText inverse={inverse}>{success}</SuccessText>;
     }
 
@@ -31,11 +31,11 @@ class ValidationText extends PureComponent {
 }
 
 ValidationText.propTypes = {
-  error: PropTypes.node,
+  error: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
   help: PropTypes.node,
   inverse: PropTypes.bool,
-  success: PropTypes.node,
-  warning: PropTypes.node,
+  success: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
+  warning: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
 };
 
 export default ValidationText;


### PR DESCRIPTION
### Description

This PR makes it possible to show a `validation border color` on `Input` fields & `Textarea` without showing the message underneath.

If you now just pass a `boolean` as `error`, `warning` or `success` prop value, it will only show a border around the input/textarea.

### Breaking changes

None.