### PR TITLE
Center the icon better in the banners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+- `Banner`: fixed the centering of the icon. The centering was off by a few pixels. ([@lowiebenoot](https://github.com/lowiebenoot) in [#602](https://github.com/teamleadercrm/ui/pull/602))
+
 ## [0.25.0] - 2019-04-18
 
 ### Changed

--- a/src/components/banner/theme.css
+++ b/src/components/banner/theme.css
@@ -3,6 +3,7 @@
 
 .icon {
   margin-right: var(--spacer-small);
+  display: flex;
 }
 
 .inner {


### PR DESCRIPTION
### Description

When using a small icon in a banner, I noticed that the icon was not centered very well. It's quite subtle but noticeable. Somehow the `span` was getting extra height,

#### Screenshot before this PR (quite hard to see)

<img width="1177" alt="Screenshot 2019-05-07 at 16 13 52" src="https://user-images.githubusercontent.com/330765/57306753-aafb6500-70e3-11e9-9ccd-2da235f20877.png">


#### Screenshot after this PR

<img width="1163" alt="Screenshot 2019-05-07 at 16 13 39" src="https://user-images.githubusercontent.com/330765/57306738-a59e1a80-70e3-11e9-8079-c3cd1042d1f1.png">

