### PR TITLE
Banner: add size props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Banner`: `size` prop. ([@TaraldRotsaert](https://github.com/TaraldRotsaert) in [#604](https://github.com/teamleadercrm/ui/pull/604))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/banner/Banner.js
+++ b/src/components/banner/Banner.js
@@ -13,11 +13,11 @@ class Banner extends PureComponent {
   }
 
   render() {
-    const { children, className, icon, onClose, fullWidth, ...others } = this.props;
+    const { children, className, icon, onClose, fullWidth, size, ...others } = this.props;
     const Element = fullWidth ? Section : Island;
 
     return (
-      <Element data-teamleader-ui="banner" className={className} {...others}>
+      <Element data-teamleader-ui="banner" className={className} size={size} {...others}>
         <div className={theme['inner']}>
           {icon && <span className={theme['icon']}>{icon}</span>}
           <span className={theme['content']}>{children}</span>
@@ -48,10 +48,13 @@ Banner.propTypes = {
   onClose: PropTypes.func,
   /** If true, component will take the full width of it's container. */
   fullWidth: PropTypes.bool,
+  /** Size prop to add a padding to the Section or Island. */
+  size: PropTypes.string,
 };
 
 Banner.defaultProps = {
   color: 'white',
+  size: 'medium',
 };
 
 export default Banner;

--- a/stories/banners.js
+++ b/stories/banners.js
@@ -5,6 +5,7 @@ import { IconIdeaMediumOutline } from '@teamleader/ui-icons';
 import { Banner, Link, TextDisplay } from '../src';
 
 const colors = ['white', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua'];
+const sizes = ['small', 'medium', 'large'];
 
 storiesOf('Banner', module)
   .addParameters({
@@ -17,6 +18,7 @@ storiesOf('Banner', module)
       color={select('Color', colors, 'white')}
       fullWidth={boolean('Full width', false)}
       icon={<IconIdeaMediumOutline />}
+      size={select('Size', sizes, 'medium')}
     >
       <TextDisplay>
         {text(
@@ -31,6 +33,7 @@ storiesOf('Banner', module)
       color={select('Color', colors, 'white')}
       fullWidth={boolean('Full width', false)}
       icon={<IconIdeaMediumOutline />}
+      size={select('Size', sizes, 'medium')}
     >
       <TextDisplay>
         I am a banner with an <Link href="http://teamleader.eu">optional link</Link> inside.


### PR DESCRIPTION
### Description
- Add `size` prop to the `Banner` component

#### Screenshot before this PR
<img width="879" alt="Screenshot 2019-05-13 at 16 45 07" src="https://user-images.githubusercontent.com/33860269/57630805-9402ba00-759e-11e9-8ada-7ffdd64a4d4d.png">

#### Screenshot after this PR
<img width="893" alt="Screenshot 2019-05-13 at 16 45 38" src="https://user-images.githubusercontent.com/33860269/57630828-9a913180-759e-11e9-9d5e-4a7f1afeac36.png">

### Breaking changes
- None