### PR TITLE
Storybook upgrade: follow up

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,2 +1,3 @@
+import '@storybook/addon-backgrounds/register';
 import '@storybook/addon-knobs/register';
 import '@storybook/addon-links/register';

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -2,27 +2,28 @@ import { centerStyles } from './styles';
 import { configure, addDecorator, addParameters } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { withKnobs } from '@storybook/addon-knobs';
-import pkg from '../package.json';
+import { COLOR } from '../src/constants';
 import PropTable from '../stories/components/propTable';
 import styles from '@sambego/storybook-styles';
+import teamleaderTheme from './teamleaderTheme';
 
 // global parameters
 addParameters({
   options: {
-    addonPanelInRight: true,
+    panelPosition: 'right',
     enableShortcuts: false,
-    name: `UI Version ${pkg.version}`,
+    theme: teamleaderTheme,
     url: 'https://teamleader.design',
   },
   backgrounds: [
-    { name: 'Aqua lightest', value: '#e6f2ff' },
-    { name: 'Neutral', value: '#f7f7fa' },
-    { name: 'Gold lightest', value: '#ffeecc' },
-    { name: 'Mint lightest', value: '#d3f2f2' },
-    { name: 'Ruby lightest', value: '#ffe2d9' },
-    { name: 'Teal lightest', value: '#e1ecfa' },
-    { name: 'Violet lightest', value: '#f0f0ff' },
-    { name: 'Teal darkest', value: '#2a3b4d' },
+    { name: 'Aqua lightest', value: COLOR.AQUA.LIGHTEST },
+    { name: 'Neutral', value: COLOR.NEUTRAL.NORMAL },
+    { name: 'Gold lightest', value: COLOR.GOLD.LIGHTEST },
+    { name: 'Mint lightest', value: COLOR.MINT.LIGHTEST },
+    { name: 'Ruby lightest', value: COLOR.RUBY.LIGHTEST },
+    { name: 'Teal lightest', value: COLOR.TEAL.LIGHTEST },
+    { name: 'Violet lightest', value: COLOR.VIOLET.LIGHTEST },
+    { name: 'Teal darkest', value: COLOR.TEAL.DARKEST },
   ],
 });
 
@@ -33,7 +34,7 @@ addDecorator(
     source: true,
     styles: stylesheet => {
       stylesheet.infoBody = {
-        color: '#2a3b4d',
+        color: COLOR.TEAL.DARKEST,
         fontFamily: 'Inter-UI-Regular',
         fontSize: '14px',
         margin: '48px 0',
@@ -49,7 +50,7 @@ addDecorator(
           margin: 0,
         },
         h2: {
-          color: '#82828c',
+          color: COLOR.NEUTRAL.DARKEST,
           fontFamily: 'Inter-UI-Medium',
           fontSize: '18px',
           fontWeight: 500,
@@ -57,7 +58,7 @@ addDecorator(
           margin: '24px 0 10px 0',
         },
         body: {
-          borderBottom: '1px solid #c0c0c4',
+          borderBottom: `1px solid ${COLOR.NEUTRAL.NORMAL}`,
           paddingTop: 10,
           marginBottom: 10,
         },
@@ -65,8 +66,8 @@ addDecorator(
 
       stylesheet.source = {
         h1: {
-          borderBottom: '1px solid #c0c0c4',
-          color: '#82828c',
+          borderBottom: `1px solid ${COLOR.NEUTRAL.NORMAL}`,
+          color: COLOR.NEUTRAL.DARKEST,
           fontFamily: 'Inter-UI-Medium',
           margin: '24px 0 10px 0',
           fontWeight: 500,
@@ -77,7 +78,7 @@ addDecorator(
       };
 
       stylesheet.propTableHead = {
-        color: '#344b63',
+        color: COLOR.TEAL.DARKEST,
         fontFamily: 'Inter-UI-Medium',
         fontWeight: 500,
         fontSize: '16px',

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -15,7 +15,6 @@ addParameters({
     url: 'https://teamleader.design',
   },
   backgrounds: [
-    { name: 'White', value: '#ffffff', default: true },
     { name: 'Aqua lightest', value: '#e6f2ff' },
     { name: 'Neutral', value: '#f7f7fa' },
     { name: 'Gold lightest', value: '#ffeecc' },

--- a/.storybook/teamleaderTheme.js
+++ b/.storybook/teamleaderTheme.js
@@ -1,0 +1,11 @@
+import { create } from '@storybook/theming';
+import { COLOR } from '../src/constants';
+import pkg from '../package.json';
+
+export default create({
+  base: 'light',
+  colorPrimary: COLOR.TEAL.DARKEST,
+  colorSecondary: COLOR.MINT.NORMAL,
+  textColor: COLOR.TEAL.DARKEST,
+  brandTitle: `UI Version ${pkg.version}`,
+});

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@babel/preset-react": "^7.0.0",
     "@sambego/storybook-state": "^1.0.7",
     "@sambego/storybook-styles": "^1.0.0",
+    "@storybook/addon-backgrounds": "^5.0.11",
     "@storybook/addon-info": "^5.0.11",
     "@storybook/addon-knobs": "^5.0.11",
     "@storybook/addon-links": "^5.0.11",

--- a/stories/banners.js
+++ b/stories/banners.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, select, text } from '@storybook/addon-knobs/react';
 import { IconIdeaMediumOutline } from '@teamleader/ui-icons';
-import { Banner, Link, TextDisplay } from '../src';
+import { Banner, Link, TextDisplay, SMALL, MEDIUM, LARGE } from '../src';
 
 const colors = ['white', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua'];
 
@@ -17,6 +17,7 @@ storiesOf('Banner', module)
       color={select('Color', colors, 'white')}
       fullWidth={boolean('Full width', false)}
       icon={<IconIdeaMediumOutline />}
+      size={select('Size', [SMALL, MEDIUM, LARGE], MEDIUM)}
     >
       <TextDisplay>
         {text(
@@ -31,6 +32,7 @@ storiesOf('Banner', module)
       color={select('Color', colors, 'white')}
       fullWidth={boolean('Full width', false)}
       icon={<IconIdeaMediumOutline />}
+      size={select('Size', [SMALL, MEDIUM, LARGE], MEDIUM)}
     >
       <TextDisplay>
         I am a banner with an <Link href="http://teamleader.eu">optional link</Link> inside.


### PR DESCRIPTION
### Description

In an [earlier PR](https://github.com/teamleadercrm/ui/pull/605), Storybook has been upgraded to 5.0.

This is a follow-up PR and contains:
- `background addon` fix
- a `custom theme` file
- update of the `options config` object
- use our `color constants` instead of hex color values
- and because it was just two extra lines, added the `size` Knob for our `Banner` component

### Breaking changes

None.

### Next up
Add our own brand component with the company logo and the version underneath.
In the current version, these brand settings are very limited.