### PR TITLE
ProgressTracker: adjust styling make clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ### Added
 
+- `ProgressStep`: added the `onClick` prop to make a `ProgressStep` interactional. ([@driesd](https://github.com/driesd) in [#607](https://github.com/teamleadercrm/ui/pull/607))
+
 ### Changed
 
 ### Deprecated
 
 ### Removed
+
+- [BREAKING] `ProgressStep`: removed the `color` prop. ([@driesd](https://github.com/driesd) in [#607](https://github.com/teamleadercrm/ui/pull/607))
 
 ### Fixed
 

--- a/src/components/progressTracker/ProgressStep.js
+++ b/src/components/progressTracker/ProgressStep.js
@@ -8,13 +8,14 @@ import { TextSmall } from '../typography';
 
 class ProgressStep extends PureComponent {
   render() {
-    const { label, active, completed } = this.props;
+    const { label, active, completed, onClick } = this.props;
     const classNames = cx(theme['step'], {
       [theme['is-active']]: active,
       [theme['is-completed']]: completed,
+      [theme['is-clickable']]: onClick,
     });
     return (
-      <Box className={classNames}>
+      <Box className={classNames} onClick={onClick}>
         <TextSmall className={theme['step-label']}>{label}</TextSmall>
         <span className={theme['status-bullet']} />
       </Box>
@@ -29,6 +30,8 @@ ProgressStep.propTypes = {
   active: PropTypes.bool.isRequired,
   /** Whether or not the step has been completed */
   completed: PropTypes.bool.isRequired,
+  /** Callback function that is fired when the progress step is clicked */
+  onClick: PropTypes.func,
 };
 
 ProgressStep.defaultProps = {

--- a/src/components/progressTracker/ProgressStep.js
+++ b/src/components/progressTracker/ProgressStep.js
@@ -8,8 +8,8 @@ import { TextSmall } from '../typography';
 
 class ProgressStep extends PureComponent {
   render() {
-    const { label, active, completed, color } = this.props;
-    const classNames = cx(theme['step'], theme[color], {
+    const { label, active, completed } = this.props;
+    const classNames = cx(theme['step'], {
       [theme['is-active']]: active,
       [theme['is-completed']]: completed,
     });
@@ -23,8 +23,6 @@ class ProgressStep extends PureComponent {
 }
 
 ProgressStep.propTypes = {
-  /** Color theme of the progress tracker. */
-  color: PropTypes.oneOf(['neutral', 'mint', 'aqua', 'violet', 'gold', 'ruby']),
   /** The label for the progress step */
   label: PropTypes.string.isRequired,
   /** Whether or not the step is active */
@@ -34,7 +32,6 @@ ProgressStep.propTypes = {
 };
 
 ProgressStep.defaultProps = {
-  color: 'neutral',
   active: false,
   completed: false,
 };

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -24,18 +24,20 @@
   max-width: 180px;
   position: relative;
 
-  &:before {
+  &:before,
+  &:after {
     content: '';
     height: 2px;
     position: absolute;
     bottom: 11px;
   }
 
+  &:before {
+    background-color: var(--color-neutral-dark);
+  }
+
   &:after {
-    content: '';
-    height: 4px;
-    position: absolute;
-    bottom: 10px;
+    background-color: var(--color-mint);
     left: 50%;
     transition: width var(--animation-duration) var(--animation-curve-default);
     width: 0;
@@ -71,7 +73,8 @@
 
   .status-bullet {
     background-color: transparent;
-    transition: background-color 0.1s var(--animation-curve-default) calc(var(--animation-duration) - 0.1s);
+    transition: background-color 0.1s var(--animation-curve-default) calc(var(--animation-duration) - 0.1s),
+      transform 0.1s var(--animation-curve-fast-out-slow-in);
     align-self: center;
     border-radius: 50%;
     display: block;
@@ -103,9 +106,18 @@
       opacity 0.1s var(--animation-curve-default) calc(var(--animation-duration) - 0.1s);
   }
 
+  &:not(.is-completed):not(.is-active) {
+    .status-bullet {
+      background-color: var(--color-neutral-dark);
+    }
+    .step-label {
+      color: var(--color-neutral-darkest);
+    }
+  }
+
   &.is-active {
     .step-label {
-      font-family: var(--font-family-medium);
+      font-family: var(--font-family-bold);
     }
     .status-bullet {
       &:before {
@@ -116,65 +128,23 @@
 
   &.is-completed,
   &.is-active {
+    .status-bullet {
+      background-color: var(--color-mint);
+    }
     .step-label {
+      color: var(--color-mint);
       opacity: 1;
     }
   }
-}
 
-@each $color in (mint, violet, gold, ruby, aqua) {
-  .$(color) {
+  &.is-clickable:hover {
+    cursor: pointer;
+
     .step-label {
-      color: var(--color-$(color)-darkest);
+      font-family: var(--font-family-bold);
     }
-
-    &.step {
-      &:before {
-        background-color: var(--color-$(color));
-      }
-      &:after {
-        background-color: var(--color-$(color)-dark);
-      }
-
-      &.is-completed,
-      &.is-active {
-        .status-bullet {
-          background-color: var(--color-$(color)-dark);
-        }
-      }
-
-      &:not(.is-completed):not(.is-active) {
-        .status-bullet {
-          background-color: var(--color-$(color));
-        }
-      }
-    }
-  }
-}
-
-.neutral {
-  .step-label {
-    color: var(--color-black);
-  }
-
-  &.step {
-    &:before {
-      background-color: var(--color-neutral);
-    }
-    &:after {
-      background-color: var(--color-neutral-darkest);
-    }
-
-    &.is-active,
-    &.is-completed {
-      .status-bullet {
-        background-color: var(--color-neutral-darkest);
-      }
-    }
-    &:not(.is-completed):not(.is-active) {
-      .status-bullet {
-        background-color: var(--color-neutral);
-      }
+    .status-bullet {
+      transform: scale(1.5);
     }
   }
 }

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -100,7 +100,6 @@
 
   .step-label {
     font-family: var(--font-family-regular);
-    opacity: 0.5;
     text-align: center;
     transition: font-family 0.1s var(--animation-curve-default) calc(var(--animation-duration) - 0.1s),
       opacity 0.1s var(--animation-curve-default) calc(var(--animation-duration) - 0.1s);
@@ -111,7 +110,7 @@
       background-color: var(--color-neutral-dark);
     }
     .step-label {
-      color: var(--color-neutral-darkest);
+      color: var(--color-neutral-dark);
     }
   }
 
@@ -133,7 +132,6 @@
     }
     .step-label {
       color: var(--color-mint);
-      opacity: 1;
     }
   }
 

--- a/stories/progressTracker.js
+++ b/stories/progressTracker.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { select, number, boolean } from '@storybook/addon-knobs/react';
+import { number, boolean } from '@storybook/addon-knobs/react';
 import { ProgressTracker, Island } from '../src';
 
 const steps = ['Draft', 'Book', 'Send invoices', 'Get paid'];
-const colors = ['neutral', 'mint', 'aqua', 'violet', 'gold', 'ruby'];
 const options = {
   range: true,
   min: 0,
@@ -19,13 +18,18 @@ storiesOf('ProgressTracker', module)
     },
   })
   .add('Basic', () => (
-    <Island color={select('Color', colors, 'neutral')} size="small">
-      <ProgressTracker
-        color={select('Color', colors, 'neutral')}
-        currentStep={number('Current step', 1, options)}
-        done={boolean('Completed', false)}
-      >
+    <Island size="small">
+      <ProgressTracker currentStep={number('Current step', 1, options)} done={boolean('Completed', false)}>
         {steps.map((step, index) => <ProgressTracker.ProgressStep label={step} key={index} />)}
+      </ProgressTracker>
+    </Island>
+  ))
+  .add('Interactional', () => (
+    <Island size="small">
+      <ProgressTracker currentStep={number('Current step', 1, options)} done={boolean('Completed', false)}>
+        {steps.map((step, index) => (
+          <ProgressTracker.ProgressStep label={step} key={index} onClick={() => console.log('step clicked')} />
+        ))}
       </ProgressTracker>
     </Island>
   ));


### PR DESCRIPTION
### Description

This PR adjusts the styling of our `ProgressTracker` component and makes a `ProgressStep` clickable when passing an `onClick` prop.

#### Screenshot before this PR

![Screenshot 2019-06-04 15 08 59](https://user-images.githubusercontent.com/5336831/58881596-c48bce80-86da-11e9-892e-176f2134352a.png)
![Screenshot 2019-06-04 15 09 12](https://user-images.githubusercontent.com/5336831/58881597-c5246500-86da-11e9-8bdc-d27d02fec3d8.png)

#### Screenshot after this PR

![Screenshot 2019-06-04 15 01 32](https://user-images.githubusercontent.com/5336831/58881604-c9e91900-86da-11e9-8be6-45fe3e708ee6.png)

### Breaking changes

- `ProgressStep`: the `color` prop has been removed
