### PR TITLE
Counter: change font weight from 'black' to 'bold'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- `Counter`: changed the font weight from `black` to `bold`. ([@driesd](https://github.com/driesd) in [#612](https://github.com/teamleadercrm/ui/pull/612))
 - `Infrastructure`: changed the way this module is exported. CommonJS and ES modules are now available, which enables tree shaking. ([@duivvv](https://github.com/duivvv) in [#609](https://github.com/teamleadercrm/ui/pull/609))
 
 ### Deprecated

--- a/src/components/counter/theme.css
+++ b/src/components/counter/theme.css
@@ -10,7 +10,7 @@
   border-radius: var(--border-radius);
   color: var(--color-white);
   display: inline-block;
-  font-family: var(--font-family-black);
+  font-family: var(--font-family-bold);
   font-size: calc(1.2 * var(--unit));
   line-height: 1;
   vertical-align: middle;


### PR DESCRIPTION
### Description

This PR changes the font weight of our `Counter` component from `black` to `bold`.

#### Screenshot before this PR

![Screenshot 2019-06-19 16 35 40](https://user-images.githubusercontent.com/5336831/59774812-63562480-92b0-11e9-8c65-7206f5a7227c.png)

#### Screenshot after this PR

![Screenshot 2019-06-19 16 35 58](https://user-images.githubusercontent.com/5336831/59774828-6c46f600-92b0-11e9-97ea-3bf2fbf10ef5.png)

### Breaking changes

None.
