### PR TITLE
Remove dependency: imports-loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Removed
 
+- `Dependency`: removed the `imports-loader` dependency because we're not using it. ([@driesd](https://github.com/driesd) in [#617](https://github.com/teamleadercrm/ui/pull/617))
+
 ### Fixed
 
 ## [0.27.1] - 2019-06-24

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "html-webpack-plugin": "^4.0.0-alpha.2",
     "husky": "^0.14.3",
     "image-webpack-loader": "^4.1.0",
-    "imports-loader": "^0.7.1",
     "json-loader": "^0.5.4",
     "moment": "^2.22.2",
     "postcss": "^6.0.14",


### PR DESCRIPTION
### Description

This PR removes the `imports-loader` dependency because we're not using it.

### Breaking changes

- None.
