### PR TITLE
Maintenance: remove the react-hot-loader dependency

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,7 @@
   ],
   "env": {
     "development": {
-      "plugins": ["@babel/plugin-transform-react-jsx-source", "react-hot-loader/babel"]
+      "plugins": ["@babel/plugin-transform-react-jsx-source"]
     },
     "cjs": {
       "plugins": ["transform-react-remove-prop-types"]

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "prettier": "1.13.7",
     "pretty-quick": "1.6.0",
     "proptypes": "^1.1.0",
-    "react-hot-loader": "^3.0.0-beta.6",
     "rimraf": "^2.5.4",
     "style-loader": "^0.20.2",
     "url-loader": "^0.6.2",


### PR DESCRIPTION
### Description

This PR removes the `react-hot-loader` dependency because we're using the one from Storybook instead.

### Breaking changes

None.