### PR TITLE
Avatar: use display flex instead of inline-block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Avatar`: changed the CSS `display: inline-block;` to `display: flex;` to fix the vertical alignment issue. ([@driesd](https://github.com/driesd) in [#625](https://github.com/teamleadercrm/ui/pull/625))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -17,7 +17,7 @@
 
 /* Avatar */
 .avatar {
-  display: inline-block;
+  display: flex;
   position: relative;
 
   &.is-circle .image {


### PR DESCRIPTION
### Description

This PR changed the CSS `display: inline-block;` to `display: flex;` of our `Avatar` component to fix the `vertical alignment` issue.

### Breaking changes

None.
