### PR TITLE
ProgressTracker: clickable status bullet only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- `ProgressStep`: changed the clickable area to only be the status bullet, instead of the whole wrapper. ([@driesd](https://github.com/driesd) in [#627](https://github.com/teamleadercrm/ui/pull/627))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/progressTracker/ProgressStep.js
+++ b/src/components/progressTracker/ProgressStep.js
@@ -15,9 +15,9 @@ class ProgressStep extends PureComponent {
       [theme['is-clickable']]: onClick,
     });
     return (
-      <Box className={classNames} onClick={onClick}>
+      <Box className={classNames}>
         <TextSmall className={theme['step-label']}>{label}</TextSmall>
-        <span className={theme['status-bullet']} />
+        <span className={theme['status-bullet']} onClick={onClick} />
       </Box>
     );
   }

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -135,13 +135,9 @@
     }
   }
 
-  &.is-clickable:hover {
-    cursor: pointer;
-
-    .step-label {
-      font-family: var(--font-family-bold);
-    }
-    .status-bullet {
+  &.is-clickable {
+    .status-bullet:hover {
+      cursor: pointer;
       transform: scale(1.5);
     }
   }


### PR DESCRIPTION
### Description

This PR changes the `clickable area` of our `ProgressStep` component, part of the `ProgressTracker`. After this PR, only the status bullet will be hoverable & clickable instead of its whole wrapper.

### Breaking changes

None.
