### PR TITLE
Remove dependency: url-loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Removed
 
+- `Dependency`: removed the `url-loader` dependency because we're not using it. ([@driesd](https://github.com/driesd) in [#638](https://github.com/teamleadercrm/ui/pull/638))
+
 ### Fixed
 
 ## [0.27.2] - 2019-07-09

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "proptypes": "^1.1.0",
     "rimraf": "^2.5.4",
     "style-loader": "^0.23.1",
-    "url-loader": "^0.6.2",
     "webpack": "^4.1.1"
   },
   "directories": {


### PR DESCRIPTION
### Description

This PR removes the `url-loader` dependency because we're not using it.

### Breaking changes

- None.