### PR TITLE
MenuItem: set background-image to none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `MenuItem`: added `background-image: none;` to the styles. ([@driesd](https://github.com/driesd) in [#647](https://github.com/teamleadercrm/ui/pull/647))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/menu/theme.css
+++ b/src/components/menu/theme.css
@@ -127,6 +127,7 @@
 }
 
 .menu-item {
+  background-image: none;
   height: var(--menu-item-height);
   overflow: hidden;
   position: relative;


### PR DESCRIPTION
### Description

This PR sets the `background-image` css rule to `none` in our `MenuItem` component. Before this PR, global styling in core would render a bullet background image to all `li` elements.

#### Screenshot before this PR
![Screenshot 2019-07-15 12 38 47](https://user-images.githubusercontent.com/5336831/61210762-cd21ec80-a6fd-11e9-8827-81988b096766.png)

#### Screenshot after this PR
![Screenshot 2019-07-15 12 39 09](https://user-images.githubusercontent.com/5336831/61210775-d4e19100-a6fd-11e9-86ba-2007e9bb0b94.png)

### Breaking changes

None.
