### PR TITLE
Release 0.27.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@
 
 ### Fixed
 
+## [0.27.4] - 2019-07-19
+
+### Changed
+
+- `Dependencies`:
+  - `react-select` from `^2.0.0` to `^3.0.4`
+  - `babel-eslint` from `^8.0.2` to `^10.0.2`
+  - `eslint-plugin-standard` from `^3.0.1` to `^4.0.0`
+  - `eslint-plugin-prettier` from `^2.1.2` to `^3.1.0`
+  - `eslint-config-standard-react` from `^6.0.0` to `^8.0.0`
+
+### Fixed
+
 - `Button`: fixed the loading spinner position. ([@driesd](https://github.com/driesd) in [#649](https://github.com/teamleadercrm/ui/pull/649))
 
 ## [0.27.3] - 2019-07-12

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.27.3",
+  "version": "0.27.4",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Changed

- `Dependencies`:
  - `react-select` from `^2.0.0` to `^3.0.4`
  - `babel-eslint` from `^8.0.2` to `^10.0.2`
  - `eslint-plugin-standard` from `^3.0.1` to `^4.0.0`
  - `eslint-plugin-prettier` from `^2.1.2` to `^3.1.0`
  - `eslint-config-standard-react` from `^6.0.0` to `^8.0.0`

### Fixed

- `Button`: fixed the loading spinner position. ([@driesd](https://github.com/driesd) in [#649](https://github.com/teamleadercrm/ui/pull/649))
