### PR TITLE
🐛 Make display overwritable for Label

### DIFF
--- a/src/components/label/Label.js
+++ b/src/components/label/Label.js
@@ -26,7 +26,7 @@ export default class Label extends PureComponent {
     const Element = size === 'large' ? TextDisplay : TextBody;
 
     return (
-      <Box display="block" element="label" marginBottom={3} className={className} {...others}>
+      <Box display="block" element="label" marginBottom={3} {...others}>
         {React.Children.map(children, child => {
           if (typeof child !== 'string') {
             return React.cloneElement(child, { ...childProps, ...child.props });

--- a/src/components/label/Label.js
+++ b/src/components/label/Label.js
@@ -2,8 +2,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Box from '../box';
 import { TextBody, TextDisplay, TextSmall } from '../typography';
-import theme from './theme.css';
-import cx from 'classnames';
 
 export default class Label extends PureComponent {
   render() {
@@ -25,18 +23,10 @@ export default class Label extends PureComponent {
       size,
     };
 
-    const classNames = cx(
-      theme['label'],
-      {
-        [theme['is-inverse']]: inverse,
-      },
-      className,
-    );
-
     const Element = size === 'large' ? TextDisplay : TextBody;
 
     return (
-      <Box element="label" marginBottom={3} className={classNames} {...others}>
+      <Box display="block" element="label" marginBottom={3} className={className} {...others}>
         {React.Children.map(children, child => {
           if (typeof child !== 'string') {
             return React.cloneElement(child, { ...childProps, ...child.props });

--- a/src/components/label/Label.js
+++ b/src/components/label/Label.js
@@ -5,17 +5,7 @@ import { TextBody, TextDisplay, TextSmall } from '../typography';
 
 export default class Label extends PureComponent {
   render() {
-    const {
-      children,
-      connectedLeft,
-      connectedRight,
-      className,
-      inverse,
-      helpText,
-      required,
-      size,
-      ...others
-    } = this.props;
+    const { children, connectedLeft, connectedRight, inverse, helpText, required, size, ...others } = this.props;
 
     const childProps = {
       inverse,
@@ -66,7 +56,6 @@ export default class Label extends PureComponent {
 }
 
 Label.propTypes = {
-  className: PropTypes.string,
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.array]),
   connectedLeft: PropTypes.element,
   connectedRight: PropTypes.element,

--- a/src/components/label/theme.css
+++ b/src/components/label/theme.css
@@ -1,3 +1,0 @@
-.label {
-  display: block;
-}


### PR DESCRIPTION
### Description

When I added `display="flex"` to our Label component the changes weren't coming through. This was because there was a `theme` class overriding other classes which contained `display: block;`.

A fix for this is adding `display="block"` by default to the Box element and accept all `{...others}`. If we then pass `display="flex"` then we easily override the `block`.

#### Screenshot before this PR

![Screenshot 2019-08-07 11 45 05](https://user-images.githubusercontent.com/9056632/62612984-e38c2400-b908-11e9-8bf3-f51f6dbc5772.jpg)

#### Screenshot after this PR

![Screenshot 2019-08-07 11 45 19](https://user-images.githubusercontent.com/9056632/62613007-ea1a9b80-b908-11e9-9956-fc9c6b6d578a.jpg)

### Breaking changes

None

