### PR TITLE
Release 0.27.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@
 
 ### Fixed
 
+## [0.27.5] - 2019-08-07
+
+### Changed
+
+- `Label`: changed the `css display rule` to use the `display prop` of our Box component.
+
+- `Dependencies`:
+  - `eslint-plugin-node` from `^6.0.0` to `^9.1.0`
+  - `eslint-config-standard` from `^11.0.0` to `^13.0.1`
+
 ## [0.27.4] - 2019-07-19
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.27.4",
+  "version": "0.27.5",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Changed

- `Label`: changed the `css display rule` to use the `display prop` of our Box component.

- `Dependencies`:
  - `eslint-plugin-node` from `^6.0.0` to `^9.1.0`
  - `eslint-config-standard` from `^11.0.0` to `^13.0.1`
