### PR TITLE
Destructure other props in avatar initials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `AvatarInitials`: other props were not destructured onto the wrapping element.
+
 ## [0.27.5] - 2019-08-07
 
 ### Changed

--- a/src/components/avatar/AvatarInitials.js
+++ b/src/components/avatar/AvatarInitials.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Box, { pickBoxProps } from '../box';
+import Box from '../box';
 import cx from 'classnames';
 import theme from './theme.css';
 import { Heading4 } from '../typography';
@@ -27,10 +27,8 @@ class AvatarInitials extends PureComponent {
       className,
     );
 
-    const boxProps = pickBoxProps(others);
-
     return (
-      <Box className={avatarClassNames} {...boxProps} data-teamleader-ui="avatar-initials">
+      <Box className={avatarClassNames} {...others} data-teamleader-ui="avatar-initials">
         <Heading4 className={theme['content']}>{this.getInitials()}</Heading4>
       </Box>
     );


### PR DESCRIPTION
The "other" props were not destructured onto the wrapping element, which made it impossible to add custom props.