### PR TITLE
Fix: include postcss.config.js when installing as dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Publishing settings`: expose postcss.config.js in published dependency. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#660](https://github.com/teamleadercrm/ui/pull/660))
+
 ### Deprecated
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   ],
   "files": [
     "cjs",
-    "es"
+    "es",
+    "postcss.config.js"
   ],
   "dependencies": {
     "@babel/cli": "^7.4.4",


### PR DESCRIPTION
### Description

In order to use yarn plug'n play, we need the postcss config to be included, adding the postcss config file in the published dependency solves this.
This might also solve the fact that you need a postcss config to use our ui package, though I'm not sure about that.

### Breaking changes

- None.
