### PR TITLE
Checkbox: apply 'position: absolute;' to the input element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Checkbox`: added `position: absolute;` to the input element to fix alignment issue in Firefox on Linux. ([@driesd](https://github.com/driesd) in [#667](https://github.com/teamleadercrm/ui/pull/667))
+
 ### Changed
 
 - `DatePicker`: the `onChange` handler is no longer triggered when a disabled date has been selected. ([@Kemosabert](https://github.com/Kemosabert)) in [#664](https://github.com/teamleadercrm/ui/pull/664)

--- a/src/components/checkbox/theme.css
+++ b/src/components/checkbox/theme.css
@@ -22,6 +22,7 @@
     height: 0;
     overflow: hidden;
     opacity: 0;
+    position: absolute;
     margin: 0;
   }
 


### PR DESCRIPTION
### Description

This PR fixes a margin issue with our `Checkbox` component in `Firefox on Linux`.

### Breaking changes

None.