### PR TITLE
AvatarInitials: make sure the text is not selectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- `AvatarInitials`: changed so the text is not selectable anymore. ([@driesd](https://github.com/driesd) in [#669](https://github.com/teamleadercrm/ui/pull/669))
 - `DatePicker`: the `onChange` handler is no longer triggered when a disabled date has been selected. ([@Kemosabert](https://github.com/Kemosabert)) in [#664](https://github.com/teamleadercrm/ui/pull/664)
 - `Publishing settings`: expose postcss.config.js in published dependency. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#660](https://github.com/teamleadercrm/ui/pull/660))
 

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -185,6 +185,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  user-select: none;
 
   &.is-circle {
     border-radius: var(--shape-circle-image-border-radius);


### PR DESCRIPTION
### Description

This PR changes the styling of `AvatarInitials` in that way that the text is not selectable anymore.

### Breaking changes

None.
