### PR TITLE
Avatar: AvatarImage or AvatarInitials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ### Added
 
+- `Avatar`: added new `Avatar` component which renders `AvatarInitials` or `AvatarImage`. ([@driesd](https://github.com/driesd) in [#670](https://github.com/teamleadercrm/ui/pull/670))
+
 ### Changed
 
+- [BREAKING] `Avatar`: renamed to `AvatarImage`. ([@driesd](https://github.com/driesd) in [#670](https://github.com/teamleadercrm/ui/pull/670))
 - `DatePicker`: the `onChange` handler is no longer triggered when a disabled date has been selected. ([@Kemosabert](https://github.com/Kemosabert)) in [#664](https://github.com/teamleadercrm/ui/pull/664)
 - `Publishing settings`: expose postcss.config.js in published dependency. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#660](https://github.com/teamleadercrm/ui/pull/660))
 

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -1,0 +1,42 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { AvatarImage, AvatarInitials } from '../avatar';
+import { COLORS } from '../../constants';
+
+const hashCode = str => {
+  let hash = 0;
+  if (!str || str.length === 0) {
+    return hash;
+  }
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash &= hash; // Convert to 32bit integer
+  }
+  return hash;
+};
+
+const getColor = id => (id ? COLORS[Math.abs(hashCode(id)) % COLORS.length] : COLORS[0]);
+
+class Avatar extends PureComponent {
+  render() {
+    const { imageUrl, fullName, id, ...others } = this.props;
+
+    return imageUrl ? (
+      <AvatarImage image={imageUrl} imageAlt={fullName} {...others} />
+    ) : (
+      <AvatarInitials color={getColor(id)} name={fullName} {...others} />
+    );
+  }
+}
+
+Avatar.propTypes = {
+  /** The image url to show as an avatar. */
+  imageUrl: PropTypes.string,
+  /** When no image available, avatar initials will be based on this string. */
+  fullName: PropTypes.string,
+  /** Expects a uuid to determine the avatar initials background color. */
+  id: PropTypes.string,
+};
+
+export default Avatar;

--- a/src/components/avatar/AvatarImage.js
+++ b/src/components/avatar/AvatarImage.js
@@ -4,14 +4,14 @@ import Box from '../box';
 import cx from 'classnames';
 import theme from './theme.css';
 
-class Avatar extends PureComponent {
+class AvatarImage extends PureComponent {
   render() {
     const { children, className, image, imageAlt, imageClassName, shape, size, ...others } = this.props;
 
-    const avatarClassNames = cx(theme['avatar'], theme[`is-${shape}`], theme[`is-${size}`], className);
+    const avatarClassNames = cx(theme['avatar-image'], theme[`is-${shape}`], theme[`is-${size}`], className);
 
     return (
-      <Box className={avatarClassNames} {...others} data-teamleader-ui="avatar">
+      <Box className={avatarClassNames} {...others} data-teamleader-ui="avatar-image">
         <img alt={imageAlt} src={image} className={cx(theme['image'], imageClassName)} />
         {children && <div className={theme['children']}>{children}</div>}
       </Box>
@@ -19,7 +19,7 @@ class Avatar extends PureComponent {
   }
 }
 
-Avatar.propTypes = {
+AvatarImage.propTypes = {
   /** Component that will be placed top right of the avatar image. */
   children: PropTypes.any,
   /** A class name for the wrapper to give custom styles. */
@@ -36,9 +36,9 @@ Avatar.propTypes = {
   size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large']),
 };
 
-Avatar.defaultProps = {
+AvatarImage.defaultProps = {
   shape: 'circle',
   size: 'medium',
 };
 
-export default Avatar;
+export default AvatarImage;

--- a/src/components/avatar/index.js
+++ b/src/components/avatar/index.js
@@ -1,6 +1,7 @@
+import Avatar from './Avatar';
 import AvatarImage from './AvatarImage';
 import AvatarInitials from './AvatarInitials';
 import AvatarStack from './AvatarStack';
 
-export default AvatarImage;
-export { AvatarImage, AvatarInitials, AvatarStack };
+export default Avatar;
+export { Avatar, AvatarImage, AvatarInitials, AvatarStack };

--- a/src/components/avatar/index.js
+++ b/src/components/avatar/index.js
@@ -1,6 +1,6 @@
-import Avatar from './Avatar';
+import AvatarImage from './AvatarImage';
 import AvatarInitials from './AvatarInitials';
 import AvatarStack from './AvatarStack';
 
-export default Avatar;
-export { Avatar, AvatarInitials, AvatarStack };
+export default AvatarImage;
+export { AvatarImage, AvatarInitials, AvatarStack };

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -15,8 +15,8 @@
   --shape-rounded-image-border-radius: 4px;
 }
 
-/* Avatar */
-.avatar {
+/* AvatarImage */
+.avatar-image {
   display: flex;
   position: relative;
 
@@ -87,7 +87,7 @@
 }
 
 .is-tiny {
-  &.avatar,
+  &.avatar-image,
   &.avatar-initials,
   .image {
     height: var(--tiny-size);
@@ -113,7 +113,7 @@
 }
 
 .is-small {
-  &.avatar,
+  &.avatar-image,
   &.avatar-initials,
   .image {
     height: var(--small-size);
@@ -134,7 +134,7 @@
 }
 
 .is-medium {
-  &.avatar,
+  &.avatar-image,
   &.avatar-initials,
   .image {
     height: var(--medium-size);
@@ -155,7 +155,7 @@
 }
 
 .is-large {
-  &.avatar,
+  &.avatar-image,
   &.avatar-initials,
   .image {
     height: var(--large-size);

--- a/src/components/passport/EmptyPassport.js
+++ b/src/components/passport/EmptyPassport.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import theme from './theme.css';
-import Avatar from '../avatar';
+import AvatarImage from '../avatar';
 import Box from '../box';
 import Link from '../link';
 import Popover from '../popover';
@@ -16,7 +16,7 @@ class EmptyPassport extends PureComponent {
       <Popover {...others} backdrop="transparent" className={cx(theme['passport-empty'], className)}>
         <Box paddingHorizontal={4} paddingVertical={5}>
           <Box display="flex" flexDirection="column" alignItems="center">
-            {avatar && <Avatar {...avatar} size="small" marginBottom={4} />}
+            {avatar && <AvatarImage {...avatar} size="small" marginBottom={4} />}
             <Heading3 color="teal">{title}</Heading3>
             {description && (
               <TextBody color="neutral" marginTop={2}>

--- a/src/components/passport/Passport.js
+++ b/src/components/passport/Passport.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import theme from './theme.css';
-import Avatar from '../avatar';
+import AvatarImage from '../avatar';
 import Box from '../box';
 import Icon from '../icon';
 import Link from '../link';
@@ -50,7 +50,7 @@ class Passport extends PureComponent {
         <Box padding={3}>
           <Box display="flex">
             <Box flex="48px 0 0" paddingRight={3}>
-              <Avatar {...avatar} size="small" />
+              <AvatarImage {...avatar} size="small" />
             </Box>
             <Box className={theme['prevent-overflow']}>
               {this.renderTitle()}
@@ -89,7 +89,7 @@ class Passport extends PureComponent {
 }
 
 Passport.propTypes = {
-  /** Object containing the props of an Avatar. */
+  /** Object containing the props of an AvatarImage. */
   avatar: PropTypes.object.isRequired,
   /** The class names for the wrapper to apply custom styling. */
   className: PropTypes.string,

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import AdvancedCollapsible from './components/advancedCollapsible';
-import Avatar, { AvatarInitials, AvatarStack } from './components/avatar';
+import AvatarImage, { AvatarInitials, AvatarStack } from './components/avatar';
 import Badge from './components/badge';
 import Banner from './components/banner';
 import Box from './components/box';
@@ -69,7 +69,7 @@ import {
 
 export {
   AdvancedCollapsible,
-  Avatar,
+  AvatarImage,
   AvatarInitials,
   AvatarStack,
   AsyncSelect,

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import AdvancedCollapsible from './components/advancedCollapsible';
-import AvatarImage, { AvatarInitials, AvatarStack } from './components/avatar';
+import Avatar, { AvatarImage, AvatarInitials, AvatarStack } from './components/avatar';
 import Badge from './components/badge';
 import Banner from './components/banner';
 import Box from './components/box';
@@ -69,6 +69,7 @@ import {
 
 export {
   AdvancedCollapsible,
+  Avatar,
   AvatarImage,
   AvatarInitials,
   AvatarStack,

--- a/stories/avatars.js
+++ b/stories/avatars.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, number, select, text } from '@storybook/addon-knobs';
-import { Avatar, AvatarInitials, AvatarStack, Bullet, Counter, TextBody, Tooltip } from '../src';
+import { AvatarImage, AvatarInitials, AvatarStack, Bullet, Counter, TextBody, Tooltip } from '../src';
 import avatars from './static/data/avatar';
 
 const directions = ['horizontal', 'vertical'];
@@ -9,7 +9,7 @@ const sizes = ['tiny', 'small', 'medium', 'large'];
 const shapes = [null, 'circle', 'rounded'];
 const colors = ['teal', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua'];
 
-const TooltippedAvatar = Tooltip(Avatar);
+const TooltippedAvatarImage = Tooltip(AvatarImage);
 
 storiesOf('Avatars', module)
   .addParameters({
@@ -17,14 +17,14 @@ storiesOf('Avatars', module)
       propTablesExclude: [Bullet, Counter],
     },
   })
-  .add('Sizes', () => (
-    <Avatar
+  .add('AvatarImage', () => (
+    <AvatarImage
       image={avatars[0].image}
       size={select('Size', sizes, 'medium')}
       shape={select('Shape', shapes) || undefined}
     />
   ))
-  .add('Initials', () => (
+  .add('AvatarInitials', () => (
     <AvatarInitials
       color={select('Color', colors, 'neutral')}
       size={select('Size', sizes, 'medium')}
@@ -32,7 +32,7 @@ storiesOf('Avatars', module)
       name={text('Name', undefined)}
     />
   ))
-  .add('Stacked', () => (
+  .add('AvatarStack', () => (
     <AvatarStack
       direction={select('Direction', directions, 'horizontal')}
       displayMax={number('Display max', 5)}
@@ -40,17 +40,17 @@ storiesOf('Avatars', module)
       size={select('Size', sizes, 'medium')}
     >
       {avatars.map(({ image }, index) => (
-        <Avatar key={index} image={image} />
+        <AvatarImage key={index} image={image} />
       ))}
     </AvatarStack>
   ))
   .add('With bullet', () => (
-    <Avatar image={avatars[0].image} size={select('Size', sizes, 'medium')}>
+    <AvatarImage image={avatars[0].image} size={select('Size', sizes, 'medium')}>
       <Bullet borderColor="neutral" borderTint="lightest" color="ruby" />
-    </Avatar>
+    </AvatarImage>
   ))
   .add('With counter', () => (
-    <Avatar image={avatars[0].image} size={select('Size', sizes, 'medium')}>
+    <AvatarImage image={avatars[0].image} size={select('Size', sizes, 'medium')}>
       <Counter
         color="ruby"
         count={avatars[0].count}
@@ -58,10 +58,10 @@ storiesOf('Avatars', module)
         borderColor="neutral"
         borderTint="lightest"
       />
-    </Avatar>
+    </AvatarImage>
   ))
   .add('With tooltip', () => (
-    <TooltippedAvatar
+    <TooltippedAvatarImage
       image={avatars[0].image}
       size={select('Size', sizes, 'medium')}
       tooltip={<TextBody>I am the tooltip</TextBody>}

--- a/stories/avatars.js
+++ b/stories/avatars.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, number, select, text } from '@storybook/addon-knobs';
-import { AvatarImage, AvatarInitials, AvatarStack, Bullet, Counter, TextBody, Tooltip } from '../src';
+import { Avatar, AvatarImage, AvatarInitials, AvatarStack, Bullet, Counter, TextBody, Tooltip } from '../src';
 import avatars from './static/data/avatar';
 
 const directions = ['horizontal', 'vertical'];
@@ -17,6 +17,15 @@ storiesOf('Avatars', module)
       propTablesExclude: [Bullet, Counter],
     },
   })
+  .add('Avatar', () => (
+    <Avatar
+      fullName={text('Full name', 'John Doe')}
+      id="63227a3c-c80b-11e9-a32f-2a2ae2dbcce4"
+      imageUrl={boolean('Image available', false) ? avatars[0].image : null}
+      size={select('Size', sizes, 'medium')}
+      shape={select('Shape', shapes) || undefined}
+    />
+  ))
   .add('AvatarImage', () => (
     <AvatarImage
       image={avatars[0].image}
@@ -51,13 +60,7 @@ storiesOf('Avatars', module)
   ))
   .add('With counter', () => (
     <AvatarImage image={avatars[0].image} size={select('Size', sizes, 'medium')}>
-      <Counter
-        color="ruby"
-        count={avatars[0].count}
-        maxCount={avatars[0].maxCount}
-        borderColor="neutral"
-        borderTint="lightest"
-      />
+      <Counter color="ruby" count={15} maxCount={6} borderColor="neutral" borderTint="lightest" />
     </AvatarImage>
   ))
   .add('With tooltip', () => (

--- a/stories/menu.js
+++ b/stories/menu.js
@@ -2,10 +2,10 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, select } from '@storybook/addon-knobs/react';
 import { IconClockSmallOutline, IconTrashSmallOutline } from '@teamleader/ui-icons';
-import { Avatar, IconMenu, Menu, MenuItem, MenuDivider, MenuTitle } from '../src';
+import { AvatarImage, IconMenu, Menu, MenuItem, MenuDivider, MenuTitle } from '../src';
 import avatars from './static/data/avatar';
 
-const avatar = <Avatar image={avatars[0].image} size="tiny" shape="circle" />;
+const avatar = <AvatarImage image={avatars[0].image} size="tiny" shape="circle" />;
 const positions = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
 
 storiesOf('Menus', module)

--- a/stories/select.js
+++ b/stories/select.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, select, number, text } from '@storybook/addon-knobs/react';
-import { Avatar, Box, Label, Select, AsyncSelect, TextBody } from '../src';
+import { AvatarImage, Box, Label, Select, AsyncSelect, TextBody } from '../src';
 import { customOptions, groupedOptions, options } from './static/data/select';
 
 const sizes = ['small', 'medium', 'large'];
@@ -21,7 +21,7 @@ const CustomOption = ({ children, data, innerProps, isFocused, isSelected, isDis
 
   return (
     <Box paddingVertical={2} paddingHorizontal={2} display="flex" alignItems="center" {...innerProps} style={boxStyles}>
-      <Avatar image={data.avatar} size="tiny" marginRight={2} />
+      <AvatarImage image={data.avatar} size="tiny" marginRight={2} />
       <TextBody style={textStyles}>{children}</TextBody>
     </Box>
   );

--- a/stories/static/data/avatar.js
+++ b/stories/static/data/avatar.js
@@ -8,14 +8,14 @@ import Image7 from '../avatars/7.png';
 import Image8 from '../avatars/8.png';
 
 const avatars = [
-  { image: Image1, count: 21, color: 'ruby', maxCount: 20 },
-  { image: Image2, count: 15, color: 'neutral', inactive: true },
-  { image: Image3, count: 5, color: 'neutral' },
-  { image: Image4, count: 3, color: 'ruby' },
-  { image: Image5, count: 0, color: 'ruby' },
-  { image: Image6, count: 4, color: 'ruby' },
-  { image: Image7, count: 5, color: 'neutral', inactive: true },
-  { image: Image8, count: 2, color: 'neutral', inactive: true },
+  { image: Image1 },
+  { image: Image2 },
+  { image: Image3 },
+  { image: Image4 },
+  { image: Image5 },
+  { image: Image6 },
+  { image: Image7 },
+  { image: Image8 },
 ];
 
 export default avatars;


### PR DESCRIPTION
### Description

This PR:
- renames the existing `Avatar` component to `AvatarImage`
- adds a new `Avatar` component which renders `AvatarInitials` or `AvatarImage` depending on the `imageUrl` prop


#### Screenshots
<img width="54" alt="Screenshot 2019-08-27 10 38 03" src="https://user-images.githubusercontent.com/5336831/63755399-dc788600-c8b6-11e9-9dfa-f2a78a6d0bf9.png">

<img width="54" alt="Screenshot 2019-08-27 10 38 22" src="https://user-images.githubusercontent.com/5336831/63755406-df737680-c8b6-11e9-80e7-3a64ee055c51.png">


### Breaking changes

⚠️  `Avatar` has been renamed to `AvatarImage`
