### PR TITLE
Box: add textAlign prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Box`: added `textAlign` prop. Possible values are `center`, `left` & `right`. ([@driesd](https://github.com/driesd) in [#673](https://github.com/teamleadercrm/ui/pull/673))
+
 ### Changed
 
 - `Select`: changed font smoothing css props from kebab-case to camelCase to fix emotion warnings. ([@driesd](https://github.com/driesd) in [#672](https://github.com/teamleadercrm/ui/pull/672))

--- a/src/components/box/Box.js
+++ b/src/components/box/Box.js
@@ -48,6 +48,7 @@ class Box extends PureComponent {
       paddingRight = paddingHorizontal,
       paddingTop = paddingVertical,
       style,
+      textAlign,
       ...others
     } = this.props;
 
@@ -72,6 +73,7 @@ class Box extends PureComponent {
         [theme[`padding-left-${paddingLeft}`]]: paddingLeft > 0,
         [theme[`padding-right-${paddingRight}`]]: paddingRight > 0,
         [theme[`padding-top-${paddingTop}`]]: paddingTop > 0,
+        [theme[`text-align-${textAlign}`]]: textAlign,
       },
       className,
     );
@@ -143,6 +145,7 @@ Box.propTypes = {
   paddingRight: PropTypes.oneOf(spacings),
   paddingTop: PropTypes.oneOf(spacings),
   style: PropTypes.object,
+  textAlign: PropTypes.oneOf(['center', 'left', 'right']),
 };
 
 Box.defaultProps = {

--- a/src/components/box/boxProps.js
+++ b/src/components/box/boxProps.js
@@ -35,6 +35,7 @@ const boxProps = [
   'paddingLeft',
   'paddingRight',
   'paddingTop',
+  'textAlign',
 ];
 
 const omitBoxProps = props => omit(props, boxProps);

--- a/src/components/box/theme.css
+++ b/src/components/box/theme.css
@@ -100,3 +100,9 @@
     }
   }
 }
+
+@each $text-alignment in (center, left, right) {
+  .text-align-$(text-alignment) {
+    text-align: $text-alignment;
+  }
+}

--- a/stories/box.js
+++ b/stories/box.js
@@ -5,6 +5,7 @@ import { Box, TextBody, COLORS, TINTS } from '../src';
 
 const displayValues = ['inline', 'inline-block', 'block', 'flex', 'inline-flex'];
 const justifyContentValues = ['center', 'flex-start', 'flex-end', 'space-around', 'space-between', 'space-evenly'];
+const textAlignValues = ['center', 'left', 'right'];
 
 const spacingOptions = {
   range: true,
@@ -27,6 +28,7 @@ storiesOf('Box', module)
       justifyContent={select('Justify Content', justifyContentValues, 'flex-start')}
       margin={number('Margin', 0, spacingOptions)}
       padding={number('Padding', 3, spacingOptions)}
+      textAlign={select('Text align', textAlignValues, 'left')}
     >
       <TextBody>I'm body text inside a Box component</TextBody>
     </Box>


### PR DESCRIPTION
### Description

This PR adds the `textAlign` prop in our `Box` component. Possible values are `center`, `left` & `right`.

#### Screenshots after this PR

![Screenshot 2019-09-02 10 08 42](https://user-images.githubusercontent.com/5336831/64099536-ce6cae80-cd69-11e9-9f8c-049685e30541.png)
![Screenshot 2019-09-02 10 09 05](https://user-images.githubusercontent.com/5336831/64099537-ce6cae80-cd69-11e9-95e1-4e9d896d4520.png)
![Screenshot 2019-09-02 10 09 12](https://user-images.githubusercontent.com/5336831/64099539-ce6cae80-cd69-11e9-8ac2-5907e8c03ba5.png)

### Breaking changes

None