### PR TITLE
Avatar: refactor & add an editable state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- `Avatar`: added `editable` boolean prop & `onImageChange` function prop. ([@driesd](https://github.com/driesd) in [#678](https://github.com/teamleadercrm/ui/pull/678))
 - `AvatarImage`, `AvatarInitials` & `AvatarStack`: added `hero` size variation. ([@driesd](https://github.com/driesd) in [#676](https://github.com/teamleadercrm/ui/pull/676))
 
 ### Changed
@@ -9,6 +10,8 @@
 ### Deprecated
 
 ### Removed
+
+- [BREAKING] `AvatarImage` & `AvatarInitials`: removed from export. `Avatar` should be used instead. ([@driesd](https://github.com/driesd) in [#678](https://github.com/teamleadercrm/ui/pull/678))
 
 ### Fixed
 

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -1,11 +1,12 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { AvatarImage, AvatarInitials } from '../avatar';
-import Box from '../box';
+import AvatarImage from './AvatarImage';
+import AvatarInitials from './AvatarInitials';
+import AvatarOverlay from './AvatarOverlay';
+import Box, { pickBoxProps } from '../box';
 import cx from 'classnames';
 import theme from './theme.css';
 import { COLORS } from '../../constants';
-import AvatarOverlay from './AvatarOverlay';
 
 const hashCode = str => {
   let hash = 0;
@@ -26,9 +27,10 @@ class Avatar extends PureComponent {
   render() {
     const { className, editable, imageUrl, fullName, id, onImageChange, size, shape, ...others } = this.props;
     const avatarClassNames = cx(theme['avatar'], theme[`is-${size}`], theme[`is-${shape}`], className);
+    const boxProps = pickBoxProps(others);
 
     return (
-      <Box className={avatarClassNames}>
+      <Box className={avatarClassNames} {...boxProps}>
         {imageUrl ? (
           <AvatarImage image={imageUrl} imageAlt={fullName} {...others} />
         ) : (

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -1,7 +1,11 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { AvatarImage, AvatarInitials } from '../avatar';
+import Box from '../box';
+import cx from 'classnames';
+import theme from './theme.css';
 import { COLORS } from '../../constants';
+import AvatarOverlay from './AvatarOverlay';
 
 const hashCode = str => {
   let hash = 0;
@@ -20,23 +24,42 @@ const getColor = id => (id ? COLORS[Math.abs(hashCode(id)) % COLORS.length] : CO
 
 class Avatar extends PureComponent {
   render() {
-    const { imageUrl, fullName, id, ...others } = this.props;
+    const { className, editable, imageUrl, fullName, id, onImageChange, size, shape, ...others } = this.props;
+    const avatarClassNames = cx(theme['avatar'], theme[`is-${size}`], theme[`is-${shape}`], className);
 
-    return imageUrl ? (
-      <AvatarImage image={imageUrl} imageAlt={fullName} {...others} />
-    ) : (
-      <AvatarInitials color={getColor(id)} name={fullName} {...others} />
+    return (
+      <Box className={avatarClassNames}>
+        {imageUrl ? (
+          <AvatarImage image={imageUrl} imageAlt={fullName} {...others} />
+        ) : (
+          <AvatarInitials color={getColor(id)} name={fullName} {...others} />
+        )}
+        {editable && (size === 'large' || size === 'hero') && <AvatarOverlay onClick={onImageChange} />}
+      </Box>
     );
   }
 }
 
 Avatar.propTypes = {
+  /** If true, an overlay will be shown with edit icon. */
+  editable: PropTypes.bool,
   /** The image url to show as an avatar. */
   imageUrl: PropTypes.string,
   /** When no image available, avatar initials will be based on this string. */
   fullName: PropTypes.string,
   /** Expects a uuid to determine the avatar initials background color. */
   id: PropTypes.string,
+  /** Callback function that is fired when user clicks the edit icon. */
+  onImageChange: PropTypes.func,
+  /** The shape of the avatar. */
+  shape: PropTypes.oneOf(['circle', 'rounded']),
+  /** The size of the avatar. */
+  size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'hero']),
+};
+
+Avatar.defaultProps = {
+  shape: 'circle',
+  size: 'medium',
 };
 
 export default Avatar;

--- a/src/components/avatar/AvatarImage.js
+++ b/src/components/avatar/AvatarImage.js
@@ -6,12 +6,10 @@ import theme from './theme.css';
 
 class AvatarImage extends PureComponent {
   render() {
-    const { children, className, image, imageAlt, imageClassName, shape, size, ...others } = this.props;
-
-    const avatarClassNames = cx(theme['avatar-image'], theme[`is-${shape}`], theme[`is-${size}`], className);
+    const { children, image, imageAlt, imageClassName, ...others } = this.props;
 
     return (
-      <Box className={avatarClassNames} {...others} data-teamleader-ui="avatar-image">
+      <Box className={theme['avatar-image']} {...others} data-teamleader-ui="avatar-image">
         <img alt={imageAlt} src={image} className={cx(theme['image'], imageClassName)} />
         {children && <div className={theme['children']}>{children}</div>}
       </Box>
@@ -22,23 +20,12 @@ class AvatarImage extends PureComponent {
 AvatarImage.propTypes = {
   /** Component that will be placed top right of the avatar image. */
   children: PropTypes.any,
-  /** A class name for the wrapper to give custom styles. */
-  className: PropTypes.string,
   /** An image source or an image element. */
   image: PropTypes.string,
   /** An alternative text for the image element. */
   imageAlt: PropTypes.string,
   /** A class name for the image to give custom styles. */
   imageClassName: PropTypes.string,
-  /** The shape of the avatar. */
-  shape: PropTypes.oneOf(['circle', 'rounded']),
-  /** The size of the avatar. */
-  size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'hero']),
-};
-
-AvatarImage.defaultProps = {
-  shape: 'circle',
-  size: 'medium',
 };
 
 export default AvatarImage;

--- a/src/components/avatar/AvatarImage.js
+++ b/src/components/avatar/AvatarImage.js
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Box from '../box';
 import cx from 'classnames';
 import theme from './theme.css';
 
@@ -9,10 +8,10 @@ class AvatarImage extends PureComponent {
     const { children, image, imageAlt, imageClassName, ...others } = this.props;
 
     return (
-      <Box className={theme['avatar-image']} {...others} data-teamleader-ui="avatar-image">
+      <div className={theme['avatar-image']} {...others} data-teamleader-ui="avatar-image">
         <img alt={imageAlt} src={image} className={cx(theme['image'], imageClassName)} />
         {children && <div className={theme['children']}>{children}</div>}
-      </Box>
+      </div>
     );
   }
 }

--- a/src/components/avatar/AvatarInitials.js
+++ b/src/components/avatar/AvatarInitials.js
@@ -18,40 +18,29 @@ class AvatarInitials extends PureComponent {
   };
 
   render() {
-    const { className, color, shape, size, ...others } = this.props;
-    const avatarClassNames = cx(
-      theme['avatar-initials'],
-      theme[`is-${size}`],
-      theme[`is-${shape}`],
-      theme[color],
-      className,
-    );
+    const { children, color, shape, ...others } = this.props;
+    const avatarClassNames = cx(theme['avatar-initials'], theme[color]);
 
     return (
       <Box className={avatarClassNames} {...others} data-teamleader-ui="avatar-initials">
         <Heading4 className={theme['initials']}>{this.getInitials()}</Heading4>
+        {children && <div className={theme['children']}>{children}</div>}
       </Box>
     );
   }
 }
 
 AvatarInitials.propTypes = {
-  /** A class name for the wrapper to give custom styles. */
-  className: PropTypes.string,
+  /** Component that will be placed top right of the avatar image. */
+  children: PropTypes.any,
   /** The color of the avatar. */
   color: PropTypes.oneOf(['neutral', 'mint', 'aqua', 'violet', 'teal', 'gold', 'ruby']),
-  /** The shape of the avatar. */
-  shape: PropTypes.oneOf(['circle', 'rounded']),
-  /** The size of the avatar. */
-  size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'hero']),
   /** The name for in the avatar. */
   name: PropTypes.string,
 };
 
 AvatarInitials.defaultProps = {
   color: 'neutral',
-  shape: 'circle',
-  size: 'medium',
   name: 'Michael Scott',
 };
 

--- a/src/components/avatar/AvatarInitials.js
+++ b/src/components/avatar/AvatarInitials.js
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Box from '../box';
 import cx from 'classnames';
 import theme from './theme.css';
 import { Heading4 } from '../typography';
@@ -22,10 +21,10 @@ class AvatarInitials extends PureComponent {
     const avatarClassNames = cx(theme['avatar-initials'], theme[color]);
 
     return (
-      <Box className={avatarClassNames} {...others} data-teamleader-ui="avatar-initials">
+      <div className={avatarClassNames} {...others} data-teamleader-ui="avatar-initials">
         <Heading4 className={theme['initials']}>{this.getInitials()}</Heading4>
         {children && <div className={theme['children']}>{children}</div>}
-      </Box>
+      </div>
     );
   }
 }

--- a/src/components/avatar/AvatarOverlay.js
+++ b/src/components/avatar/AvatarOverlay.js
@@ -7,11 +7,13 @@ import { IconEditSmallFilled } from '@teamleader/ui-icons';
 class AvatarOverlay extends PureComponent {
   render() {
     return (
-      <Box {...this.props} alignItems="flex-end" className={theme['overlay']} display="flex" justifyContent="center">
-        <Icon color="neutral" tint="lightest">
-          <IconEditSmallFilled />
-        </Icon>
-      </Box>
+      <div {...this.props} className={theme['overlay']}>
+        <Box className={theme['overlay-background']} display="flex" justifyContent="center">
+          <Icon color="neutral" tint="lightest">
+            <IconEditSmallFilled />
+          </Icon>
+        </Box>
+      </div>
     );
   }
 }

--- a/src/components/avatar/AvatarOverlay.js
+++ b/src/components/avatar/AvatarOverlay.js
@@ -1,0 +1,19 @@
+import React, { PureComponent } from 'react';
+import theme from './theme.css';
+import Box from '../box';
+import Icon from '../icon';
+import { IconEditSmallFilled } from '@teamleader/ui-icons';
+
+class AvatarOverlay extends PureComponent {
+  render() {
+    return (
+      <Box {...this.props} alignItems="flex-end" className={theme['overlay']} display="flex" justifyContent="center">
+        <Icon color="neutral" tint="lightest">
+          <IconEditSmallFilled />
+        </Icon>
+      </Box>
+    );
+  }
+}
+
+export default AvatarOverlay;

--- a/src/components/avatar/index.js
+++ b/src/components/avatar/index.js
@@ -1,7 +1,6 @@
 import Avatar from './Avatar';
 import AvatarImage from './AvatarImage';
-import AvatarInitials from './AvatarInitials';
 import AvatarStack from './AvatarStack';
 
 export default Avatar;
-export { Avatar, AvatarImage, AvatarInitials, AvatarStack };
+export { Avatar, AvatarImage, AvatarStack };

--- a/src/components/avatar/index.js
+++ b/src/components/avatar/index.js
@@ -1,6 +1,5 @@
 import Avatar from './Avatar';
-import AvatarImage from './AvatarImage';
 import AvatarStack from './AvatarStack';
 
 export default Avatar;
-export { Avatar, AvatarImage, AvatarStack };
+export { Avatar, AvatarStack };

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -177,7 +177,7 @@
     width: var(--large-size);
   }
 
-  .content {
+  .initials {
     font-size: 18px;
   }
 

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -61,6 +61,16 @@
   padding: 0 var(--overflow-padding-horizontal);
 }
 
+.overlay {
+  background-position: bottom center;
+  background-repeat: no-repeat;
+  bottom: 0;
+  cursor: pointer;
+  left: 0;
+  padding-bottom: 5px;
+  position: absolute;
+}
+
 .dark {
   .overflow {
     background: color(var(--color-teal-darkest) a(10%));
@@ -161,7 +171,8 @@
 .is-large {
   &.avatar-image,
   &.avatar-initials,
-  .image {
+  .image,
+  .overlay {
     height: var(--large-size);
     width: var(--large-size);
   }
@@ -181,12 +192,17 @@
     height: var(--large-size);
     min-width: calc(var(--large-size) - var(--overflow-padding-horizontal) * 2);
   }
+
+  .overlay {
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2OCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDY4IDI0Ij4gIDxwYXRoIGZpbGw9IiMzNDRCNjMiIGZpbGwtb3BhY2l0eT0iLjg1IiBkPSJNNjkuOTUxMjYyNCw0OC4wMDA2NDU1IEM2NS4wMDkwMTA1LDYxLjk4MjU1NjIgNTEuNjc0MzQxNCw3MS45OTk4ODQxIDM2LDcxLjk5OTg4NDEgQzIwLjMyNTY1ODYsNzEuOTk5ODg0MSA2Ljk5MDk4OTUxLDYxLjk4MjU1NjIgMi4wNDg3Mzc2Myw0OC4wMDA2NDU1IFoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yIC00OCkiLz48L3N2Zz4=);
+  }
 }
 
 .is-hero {
   &.avatar-image,
   &.avatar-initials,
-  .image {
+  .image,
+  .overlay {
     height: var(--hero-size);
     width: var(--hero-size);
   }
@@ -205,6 +221,10 @@
     font-size: calc(3.6 * var(--unit));
     height: var(--hero-size);
     min-width: calc(var(--hero-size) - var(--overflow-padding-horizontal) * 2);
+  }
+
+  .overlay {
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDgiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAxMDggMjQiPiAgPHBhdGggZmlsbD0iIzM0NEI2MyIgZmlsbC1vcGFjaXR5PSIuODUiIGQ9Ik0xMjUuNjY0NDY0LDEyMCBDMTEyLjQ4MDgzNiwxMzQuNzI4NjI4IDkzLjMyMjg2NzYsMTQzLjk5NzY2MyA3MiwxNDMuOTk3NjYzIEM1MC42NzcxMzI0LDE0My45OTc2NjMgMzEuNTE5MTYzOCwxMzQuNzI4NjI4IDE4LjMzNTUzNTgsMTIwIFoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xOCAtMTIwKSIvPjwvc3ZnPg==);
   }
 }
 

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -57,12 +57,22 @@
 }
 
 .overlay {
-  bottom: 0;
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  top: 0;
+  height: 100%;
+  width: 100%;
+}
+
+.overlay-background {
+  background-color: color(var(--color-teal-darkest) a(0.84));
   cursor: pointer;
   height: 24px;
   left: 0;
-  padding-bottom: 5px;
+  bottom: 0;
   position: absolute;
+  width: 100%;
 }
 
 .dark {
@@ -189,10 +199,6 @@
     height: var(--large-size);
     min-width: calc(var(--large-size) - var(--overflow-padding-horizontal) * 2);
   }
-
-  .overlay {
-    width: var(--large-size);
-  }
 }
 
 .is-hero {
@@ -219,29 +225,13 @@
     height: var(--hero-size);
     min-width: calc(var(--hero-size) - var(--overflow-padding-horizontal) * 2);
   }
-
-  .overlay {
-    width: var(--hero-size);
-  }
 }
 
 .is-circle {
   .avatar-image .image,
-  .avatar-initials {
-    border-radius: var(--shape-circle-image-border-radius);
-  }
-
+  .avatar-initials,
   .overlay {
-    background-position: bottom center;
-    background-repeat: no-repeat;
-  }
-
-  &.is-large .overlay {
-    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2OCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDY4IDI0Ij4gIDxwYXRoIGZpbGw9IiMzNDRCNjMiIGZpbGwtb3BhY2l0eT0iLjg1IiBkPSJNNjkuOTUxMjYyNCw0OC4wMDA2NDU1IEM2NS4wMDkwMTA1LDYxLjk4MjU1NjIgNTEuNjc0MzQxNCw3MS45OTk4ODQxIDM2LDcxLjk5OTg4NDEgQzIwLjMyNTY1ODYsNzEuOTk5ODg0MSA2Ljk5MDk4OTUxLDYxLjk4MjU1NjIgMi4wNDg3Mzc2Myw0OC4wMDA2NDU1IFoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yIC00OCkiLz48L3N2Zz4=);
-  }
-
-  &.is-hero .overlay {
-    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDgiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAxMDggMjQiPiAgPHBhdGggZmlsbD0iIzM0NEI2MyIgZmlsbC1vcGFjaXR5PSIuODUiIGQ9Ik0xMjUuNjY0NDY0LDEyMCBDMTEyLjQ4MDgzNiwxMzQuNzI4NjI4IDkzLjMyMjg2NzYsMTQzLjk5NzY2MyA3MiwxNDMuOTk3NjYzIEM1MC42NzcxMzI0LDE0My45OTc2NjMgMzEuNTE5MTYzOCwxMzQuNzI4NjI4IDE4LjMzNTUzNTgsMTIwIFoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xOCAtMTIwKSIvPjwvc3ZnPg==);
+    border-radius: var(--shape-circle-image-border-radius);
   }
 }
 
@@ -252,7 +242,6 @@
   }
 
   .overlay {
-    background-color: color(var(--color-teal-darkest) a(0.84));
     border-radius: 0 0 var(--shape-rounded-image-border-radius) var(--shape-rounded-image-border-radius);
   }
 }

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -16,18 +16,13 @@
   --shape-rounded-image-border-radius: 4px;
 }
 
+.avatar {
+  position: relative;
+}
+
 /* AvatarImage */
 .avatar-image {
   display: flex;
-  position: relative;
-
-  &.is-circle .image {
-    border-radius: var(--shape-circle-image-border-radius);
-  }
-
-  &.is-rounded .image {
-    border-radius: var(--shape-rounded-image-border-radius);
-  }
 }
 
 .children {
@@ -62,10 +57,9 @@
 }
 
 .overlay {
-  background-position: bottom center;
-  background-repeat: no-repeat;
   bottom: 0;
   cursor: pointer;
+  height: 24px;
   left: 0;
   padding-bottom: 5px;
   position: absolute;
@@ -102,8 +96,9 @@
 }
 
 .is-tiny {
-  &.avatar-image,
-  &.avatar-initials,
+  &.avatar,
+  .avatar-image,
+  .avatar-initials,
   .image {
     height: var(--tiny-size);
     width: var(--tiny-size);
@@ -127,8 +122,9 @@
 }
 
 .is-small {
-  &.avatar-image,
-  &.avatar-initials,
+  &.avatar,
+  .avatar-image,
+  .avatar-initials,
   .image {
     height: var(--small-size);
     width: var(--small-size);
@@ -148,8 +144,9 @@
 }
 
 .is-medium {
-  &.avatar-image,
-  &.avatar-initials,
+  &.avatar,
+  .avatar-image,
+  .avatar-initials,
   .image {
     height: var(--medium-size);
     width: var(--medium-size);
@@ -169,10 +166,10 @@
 }
 
 .is-large {
-  &.avatar-image,
-  &.avatar-initials,
-  .image,
-  .overlay {
+  &.avatar,
+  .avatar-image,
+  .avatar-initials,
+  .image {
     height: var(--large-size);
     width: var(--large-size);
   }
@@ -194,15 +191,15 @@
   }
 
   .overlay {
-    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2OCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDY4IDI0Ij4gIDxwYXRoIGZpbGw9IiMzNDRCNjMiIGZpbGwtb3BhY2l0eT0iLjg1IiBkPSJNNjkuOTUxMjYyNCw0OC4wMDA2NDU1IEM2NS4wMDkwMTA1LDYxLjk4MjU1NjIgNTEuNjc0MzQxNCw3MS45OTk4ODQxIDM2LDcxLjk5OTg4NDEgQzIwLjMyNTY1ODYsNzEuOTk5ODg0MSA2Ljk5MDk4OTUxLDYxLjk4MjU1NjIgMi4wNDg3Mzc2Myw0OC4wMDA2NDU1IFoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yIC00OCkiLz48L3N2Zz4=);
+    width: var(--large-size);
   }
 }
 
 .is-hero {
-  &.avatar-image,
-  &.avatar-initials,
-  .image,
-  .overlay {
+  &.avatar,
+  .avatar-image,
+  .avatar-initials,
+  .image {
     height: var(--hero-size);
     width: var(--hero-size);
   }
@@ -224,7 +221,39 @@
   }
 
   .overlay {
+    width: var(--hero-size);
+  }
+}
+
+.is-circle {
+  .avatar-image .image,
+  .avatar-initials {
+    border-radius: var(--shape-circle-image-border-radius);
+  }
+
+  .overlay {
+    background-position: bottom center;
+    background-repeat: no-repeat;
+  }
+
+  &.is-large .overlay {
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2OCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDY4IDI0Ij4gIDxwYXRoIGZpbGw9IiMzNDRCNjMiIGZpbGwtb3BhY2l0eT0iLjg1IiBkPSJNNjkuOTUxMjYyNCw0OC4wMDA2NDU1IEM2NS4wMDkwMTA1LDYxLjk4MjU1NjIgNTEuNjc0MzQxNCw3MS45OTk4ODQxIDM2LDcxLjk5OTg4NDEgQzIwLjMyNTY1ODYsNzEuOTk5ODg0MSA2Ljk5MDk4OTUxLDYxLjk4MjU1NjIgMi4wNDg3Mzc2Myw0OC4wMDA2NDU1IFoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yIC00OCkiLz48L3N2Zz4=);
+  }
+
+  &.is-hero .overlay {
     background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDgiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAxMDggMjQiPiAgPHBhdGggZmlsbD0iIzM0NEI2MyIgZmlsbC1vcGFjaXR5PSIuODUiIGQ9Ik0xMjUuNjY0NDY0LDEyMCBDMTEyLjQ4MDgzNiwxMzQuNzI4NjI4IDkzLjMyMjg2NzYsMTQzLjk5NzY2MyA3MiwxNDMuOTk3NjYzIEM1MC42NzcxMzI0LDE0My45OTc2NjMgMzEuNTE5MTYzOCwxMzQuNzI4NjI4IDE4LjMzNTUzNTgsMTIwIFoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xOCAtMTIwKSIvPjwvc3ZnPg==);
+  }
+}
+
+.is-rounded {
+  .avatar-image .image,
+  .avatar-initials {
+    border-radius: var(--shape-rounded-image-border-radius);
+  }
+
+  .overlay {
+    background-color: color(var(--color-teal-darkest) a(0.84));
+    border-radius: 0 0 var(--shape-rounded-image-border-radius) var(--shape-rounded-image-border-radius);
   }
 }
 
@@ -234,14 +263,6 @@
   align-items: center;
   justify-content: center;
   user-select: none;
-
-  &.is-circle {
-    border-radius: var(--shape-circle-image-border-radius);
-  }
-
-  &.is-rounded {
-    border-radius: var(--shape-rounded-image-border-radius);
-  }
 
   .initials {
     color: var(--color-neutral-lightest);

--- a/src/components/passport/EmptyPassport.js
+++ b/src/components/passport/EmptyPassport.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import theme from './theme.css';
-import AvatarImage from '../avatar';
+import Avatar from '../avatar';
 import Box from '../box';
 import Link from '../link';
 import Popover from '../popover';
@@ -16,7 +16,7 @@ class EmptyPassport extends PureComponent {
       <Popover {...others} backdrop="transparent" className={cx(theme['passport-empty'], className)}>
         <Box paddingHorizontal={4} paddingVertical={5}>
           <Box display="flex" flexDirection="column" alignItems="center">
-            {avatar && <AvatarImage {...avatar} size="small" marginBottom={4} />}
+            {avatar && <Avatar {...avatar} size="small" marginBottom={4} />}
             <Heading3 color="teal">{title}</Heading3>
             {description && (
               <TextBody color="neutral" marginTop={2}>

--- a/src/components/passport/Passport.js
+++ b/src/components/passport/Passport.js
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import theme from './theme.css';
-import AvatarImage from '../avatar';
+import Avatar from '../avatar';
 import Box from '../box';
 import Icon from '../icon';
 import Link from '../link';
@@ -50,7 +50,7 @@ class Passport extends PureComponent {
         <Box padding={3}>
           <Box display="flex">
             <Box flex="48px 0 0" paddingRight={3}>
-              <AvatarImage {...avatar} size="small" />
+              <Avatar {...avatar} size="small" />
             </Box>
             <Box className={theme['prevent-overflow']}>
               {this.renderTitle()}
@@ -89,7 +89,7 @@ class Passport extends PureComponent {
 }
 
 Passport.propTypes = {
-  /** Object containing the props of an AvatarImage. */
+  /** Object containing the props of an Avatar. */
   avatar: PropTypes.object.isRequired,
   /** The class names for the wrapper to apply custom styling. */
   className: PropTypes.string,

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import AdvancedCollapsible from './components/advancedCollapsible';
-import Avatar, { AvatarImage, AvatarStack } from './components/avatar';
+import Avatar, { AvatarStack } from './components/avatar';
 import Badge from './components/badge';
 import Banner from './components/banner';
 import Box from './components/box';
@@ -70,7 +70,6 @@ import {
 export {
   AdvancedCollapsible,
   Avatar,
-  AvatarImage,
   AvatarStack,
   AsyncSelect,
   Badge,

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import AdvancedCollapsible from './components/advancedCollapsible';
-import Avatar, { AvatarImage, AvatarInitials, AvatarStack } from './components/avatar';
+import Avatar, { AvatarImage, AvatarStack } from './components/avatar';
 import Badge from './components/badge';
 import Banner from './components/banner';
 import Box from './components/box';
@@ -71,7 +71,6 @@ export {
   AdvancedCollapsible,
   Avatar,
   AvatarImage,
-  AvatarInitials,
   AvatarStack,
   AsyncSelect,
   Badge,

--- a/stories/avatars.js
+++ b/stories/avatars.js
@@ -1,15 +1,14 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, number, select, text } from '@storybook/addon-knobs';
-import { Avatar, AvatarImage, AvatarInitials, AvatarStack, Bullet, Counter, TextBody, Tooltip } from '../src';
+import { Avatar, AvatarStack, Bullet, Counter, TextBody, Tooltip } from '../src';
 import avatars from './static/data/avatar';
 
 const directions = ['horizontal', 'vertical'];
 const sizes = ['tiny', 'small', 'medium', 'large', 'hero'];
-const shapes = [null, 'circle', 'rounded'];
-const colors = ['teal', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua'];
+const shapes = ['circle', 'rounded'];
 
-const TooltippedAvatarImage = Tooltip(AvatarImage);
+const TooltippedAvatar = Tooltip(Avatar);
 
 storiesOf('Avatars', module)
   .addParameters({
@@ -19,26 +18,13 @@ storiesOf('Avatars', module)
   })
   .add('Avatar', () => (
     <Avatar
+      editable={boolean('Editable', false)}
       fullName={text('Full name', 'John Doe')}
       id="63227a3c-c80b-11e9-a32f-2a2ae2dbcce4"
       imageUrl={boolean('Image available', false) ? avatars[0].image : null}
-      size={select('Size', sizes, 'medium')}
-      shape={select('Shape', shapes) || undefined}
-    />
-  ))
-  .add('AvatarImage', () => (
-    <AvatarImage
-      image={avatars[0].image}
-      size={select('Size', sizes, 'medium')}
-      shape={select('Shape', shapes) || undefined}
-    />
-  ))
-  .add('AvatarInitials', () => (
-    <AvatarInitials
-      color={select('Color', colors, 'neutral')}
-      size={select('Size', sizes, 'medium')}
-      shape={select('Shape', shapes) || undefined}
-      name={text('Name', undefined)}
+      onImageChange={() => console.log('Change image')}
+      size={select('Size', sizes, 'large')}
+      shape={select('Shape', shapes, 'circle')}
     />
   ))
   .add('AvatarStack', () => (
@@ -46,27 +32,48 @@ storiesOf('Avatars', module)
       direction={select('Direction', directions, 'horizontal')}
       displayMax={number('Display max', 5)}
       inverse={boolean('Inverse', false)}
-      size={select('Size', sizes, 'medium')}
+      size={select('Size', sizes, 'large')}
     >
       {avatars.map(({ image }, index) => (
-        <AvatarImage key={index} image={image} />
+        <Avatar key={index} imageUrl={image} />
       ))}
     </AvatarStack>
   ))
   .add('With bullet', () => (
-    <AvatarImage image={avatars[0].image} size={select('Size', sizes, 'medium')}>
+    <Avatar
+      editable={boolean('Editable', false)}
+      fullName={text('Full name', 'John Doe')}
+      id="63227a3c-c80b-11e9-a32f-2a2ae2dbcce4"
+      imageUrl={boolean('Image available', false) ? avatars[0].image : null}
+      onImageChange={() => console.log('Change image')}
+      size={select('Size', sizes, 'large')}
+      shape={select('Shape', shapes, 'circle')}
+    >
       <Bullet borderColor="neutral" borderTint="lightest" color="ruby" />
-    </AvatarImage>
+    </Avatar>
   ))
   .add('With counter', () => (
-    <AvatarImage image={avatars[0].image} size={select('Size', sizes, 'medium')}>
+    <Avatar
+      editable={boolean('Editable', false)}
+      fullName={text('Full name', 'John Doe')}
+      id="63227a3c-c80b-11e9-a32f-2a2ae2dbcce4"
+      imageUrl={boolean('Image available', false) ? avatars[0].image : null}
+      onImageChange={() => console.log('Change image')}
+      size={select('Size', sizes, 'large')}
+      shape={select('Shape', shapes, 'circle')}
+    >
       <Counter color="ruby" count={15} maxCount={6} borderColor="neutral" borderTint="lightest" />
-    </AvatarImage>
+    </Avatar>
   ))
   .add('With tooltip', () => (
-    <TooltippedAvatarImage
-      image={avatars[0].image}
-      size={select('Size', sizes, 'medium')}
+    <TooltippedAvatar
+      editable={boolean('Editable', false)}
+      fullName={text('Full name', 'John Doe')}
+      id="63227a3c-c80b-11e9-a32f-2a2ae2dbcce4"
+      imageUrl={boolean('Image available', false) ? avatars[0].image : null}
+      onImageChange={() => console.log('Change image')}
+      size={select('Size', sizes, 'large')}
+      shape={select('Shape', shapes, 'circle')}
       tooltip={<TextBody>I am the tooltip</TextBody>}
     />
   ));

--- a/stories/menu.js
+++ b/stories/menu.js
@@ -2,10 +2,10 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, select } from '@storybook/addon-knobs/react';
 import { IconClockSmallOutline, IconTrashSmallOutline } from '@teamleader/ui-icons';
-import { AvatarImage, IconMenu, Menu, MenuItem, MenuDivider, MenuTitle } from '../src';
+import { Avatar, IconMenu, Menu, MenuItem, MenuDivider, MenuTitle } from '../src';
 import avatars from './static/data/avatar';
 
-const avatar = <AvatarImage image={avatars[0].image} size="tiny" shape="circle" />;
+const avatar = <Avatar imageUrl={avatars[0].image} size="tiny" shape="circle" />;
 const positions = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
 
 storiesOf('Menus', module)

--- a/stories/passport.js
+++ b/stories/passport.js
@@ -70,7 +70,7 @@ storiesOf('Passport', module)
           description="Regional manager"
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
-          avatar={{ image: contactAvatar }}
+          avatar={{ imageUrl: contactAvatar, fullName: 'David Brent' }}
           lineItems={contactLineItems}
           title={{ children: 'David Brent', href: 'https://www.teamleader.eu' }}
         />
@@ -88,7 +88,7 @@ storiesOf('Passport', module)
           description={['1725 Slough Avenue', 'Sranton, PA 18540', 'United Kingdom']}
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
-          avatar={{ image: companyAvatar, shape: 'rounded' }}
+          avatar={{ imageUrl: companyAvatar, shape: 'rounded', fullName: 'Dunder Miflin' }}
           lineItems={companyLineItems}
           title="Dunder Miflin"
         />
@@ -107,7 +107,7 @@ storiesOf('Passport', module)
           description="It looks like you haven't added any contact information yet."
           onEscKeyDown={handleCloseClick}
           onOverlayClick={handleCloseClick}
-          avatar={{ image: emptyAvatar }}
+          avatar={{ imageUrl: emptyAvatar, fullName: 'No Information' }}
           title="No information to show"
         />
       </State>

--- a/stories/select.js
+++ b/stories/select.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { boolean, select, number, text } from '@storybook/addon-knobs/react';
-import { AvatarImage, Box, Label, Select, AsyncSelect, TextBody } from '../src';
+import { Avatar, Box, Label, Select, AsyncSelect, TextBody } from '../src';
 import { customOptions, groupedOptions, options } from './static/data/select';
 
 const sizes = ['small', 'medium', 'large'];
@@ -21,7 +21,7 @@ const CustomOption = ({ children, data, innerProps, isFocused, isSelected, isDis
 
   return (
     <Box paddingVertical={2} paddingHorizontal={2} display="flex" alignItems="center" {...innerProps} style={boxStyles}>
-      <AvatarImage image={data.avatar} size="tiny" marginRight={2} />
+      <Avatar imageUrl={data.avatar} size="tiny" marginRight={2} />
       <TextBody style={textStyles}>{children}</TextBody>
     </Box>
   );


### PR DESCRIPTION
### Description

This PR refactors our existing `Avatar` component. Basically all duplicate logic from `AvatarImage` & `AvatarInitials` has moved to `Avatar`.

I also added the `AvatarOverlay` component, which is rendered when the newly introduced `editable` prop is true.

#### Screenshots after this PR

![Screenshot 2019-09-04 17 35 13](https://user-images.githubusercontent.com/5336831/64270216-7c7b8280-cf3b-11e9-8b37-c4cd85490ab1.png)

![Screenshot 2019-09-04 17 35 23](https://user-images.githubusercontent.com/5336831/64270226-800f0980-cf3b-11e9-98aa-6ace2eb7eef1.png)

![Screenshot 2019-09-04 17 36 17](https://user-images.githubusercontent.com/5336831/64270243-8604ea80-cf3b-11e9-8c28-eada83535ea8.png)

![Screenshot 2019-09-04 17 36 07](https://user-images.githubusercontent.com/5336831/64270253-89987180-cf3b-11e9-9584-982cbcf4f62d.png)


### Breaking changes

`AvatarImage` & `AvatarInitials` have been removed from export. `Avatar` should be used instead.
