### PR TITLE
Release 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### Dependency updates
 
+## [0.30.0] - 2019-09-09
+
+### Dependency updates
+
 - [BREAKING] Removed deprecated `postcss-cssnext` and replaced it with the recommended package `postcss-preset-env`. ([@rathesDot](https://github.com/rathesDot) in [#680](https://github.com/teamleadercrm/ui/pull/680)). Install `postcss-preset-env` manually as a devDependecy if you enounter any issues in your build process. Alternatively, explicitly add your postcss config file's path to the postcss-loader option of your webpack.
   ```js
   {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Dependency updates

- [BREAKING] Removed deprecated `postcss-cssnext` and replaced it with the recommended package `postcss-preset-env`. ([@rathesDot](https://github.com/rathesDot) in [#680](https://github.com/teamleadercrm/ui/pull/680)). Install `postcss-preset-env` manually as a devDependecy if you enounter any issues in your build process. Alternatively, explicitly add your postcss config file's path to the postcss-loader option of your webpack.
  ```js
  {
    loader: 'postcss-loader',
    options: {
      config: {
        path: `${__dirname}/postcss.config.js`,
      },
    },
  },
  ```
