### PR TITLE
Typography: overflow ellipsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Text`: added `ellipsis` prop which forces the text on one line and overflows with an ellipsis. ([@driesd](https://github.com/driesd) in [#687](https://github.com/teamleadercrm/ui/pull/687))
+
 ### Changed
 
 - `Select`: changed `Inter-UI` fonts to `Inter` since we updated `@teamleader/ui-typography`. ([@driesd](https://github.com/driesd) in [#686](https://github.com/teamleadercrm/ui/pull/686))

--- a/src/components/typography/Text.js
+++ b/src/components/typography/Text.js
@@ -8,9 +8,18 @@ import theme from './theme.css';
 const factory = (baseType, type, defaultElement) => {
   class Text extends PureComponent {
     render() {
-      const { children, className, color, element, tint, ...others } = this.props;
+      const { children, className, color, element, ellipsis, tint, ...others } = this.props;
 
-      const classNames = cx(theme[baseType], theme[type], theme[color], theme[tint], className);
+      const classNames = cx(
+        theme[baseType],
+        theme[type],
+        theme[color],
+        theme[tint],
+        {
+          [theme['overflow-ellipsis']]: ellipsis,
+        },
+        className,
+      );
 
       const Element = element || defaultElement;
 
@@ -27,11 +36,13 @@ const factory = (baseType, type, defaultElement) => {
     className: PropTypes.string,
     color: PropTypes.oneOf(COLORS),
     element: PropTypes.node,
+    ellipsis: PropTypes.bool,
     tint: PropTypes.oneOf(TINTS),
   };
 
   Text.defaultProps = {
     element: null,
+    ellipsis: false,
     tint: 'darkest',
   };
 

--- a/stories/typography.js
+++ b/stories/typography.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { select } from '@storybook/addon-knobs/react';
+import { boolean, select } from '@storybook/addon-knobs/react';
 import {
   COLORS,
   TINTS,
@@ -23,54 +23,121 @@ storiesOf('Typography', module)
   })
   .add('Headings', () => (
     <div>
-      <Heading1 color={select('Color', COLORS, 'teal')} tint={select('Tint', TINTS, 'darkest')}>
+      <Heading1
+        color={select('Color', COLORS, 'teal')}
+        ellipsis={boolean('Overflow ellipsis', false)}
+        tint={select('Tint', TINTS, 'darkest')}
+      >
         Heading 1 / font-size: 24px / line-height: 30px / weight: bold (700) / tracking: 0
       </Heading1>
-      <Heading2 color={select('Color', COLORS, 'teal')} tint={select('Tint', TINTS, 'darkest')} marginTop={4}>
+      <Heading2
+        color={select('Color', COLORS, 'teal')}
+        ellipsis={boolean('Overflow ellipsis', false)}
+        tint={select('Tint', TINTS, 'darkest')}
+        marginTop={4}
+      >
         Heading 2 / font-size: 18px / line-height: 24px / weight: medium (500) / tracking: 0
       </Heading2>
-      <Heading3 color={select('Color', COLORS, 'teal')} tint={select('Tint', TINTS, 'darkest')} marginTop={4}>
+      <Heading3
+        color={select('Color', COLORS, 'teal')}
+        ellipsis={boolean('Overflow ellipsis', false)}
+        tint={select('Tint', TINTS, 'darkest')}
+        marginTop={4}
+      >
         Heading 3 / font-size: 16px / line-height: 21px / weight: medium (500) / tracking: 0
       </Heading3>
-      <Heading4 color={select('Color', COLORS, 'teal')} tint={select('Tint', TINTS, 'darkest')} marginTop={4}>
+      <Heading4
+        color={select('Color', COLORS, 'teal')}
+        ellipsis={boolean('Overflow ellipsis', false)}
+        tint={select('Tint', TINTS, 'darkest')}
+        marginTop={4}
+      >
         Heading 4 / font-size: 12px / line-height: 18px / weight: bold (700) / tracking: 0.6px
       </Heading4>
     </div>
   ))
   .add('Text', () => (
-    <div>
-      <TextDisplay color={select('Color', COLORS, 'teal')} tint={select('Tint', TINTS, 'darkest')}>
+    <Box overflow="hidden">
+      <TextDisplay
+        color={select('Color', COLORS, 'teal')}
+        ellipsis={boolean('Overflow ellipsis', false)}
+        tint={select('Tint', TINTS, 'darkest')}
+      >
         Text display / font-size: 16px / line-height: 24px / weight: regular (400) / tracking: 0
       </TextDisplay>
-      <TextBody color={select('Color', COLORS, 'teal')} tint={select('Tint', TINTS, 'darkest')} marginTop={2}>
+      <TextBody
+        color={select('Color', COLORS, 'teal')}
+        ellipsis={boolean('Overflow ellipsis', false)}
+        tint={select('Tint', TINTS, 'darkest')}
+        marginTop={2}
+      >
         Text body / font-size: 14px / line-height: 21px / weight: regular (400) / tracking: 0
       </TextBody>
-      <TextSmall color={select('Color', COLORS, 'teal')} tint={select('Tint', TINTS, 'darkest')} marginTop={2}>
+      <TextSmall
+        color={select('Color', COLORS, 'teal')}
+        ellipsis={boolean('Overflow ellipsis', false)}
+        tint={select('Tint', TINTS, 'darkest')}
+        marginTop={2}
+      >
         Text small / font-size: 12px / line-height: 18px / weight: regular (400) / tracking: 0
       </TextSmall>
-    </div>
+    </Box>
   ))
   .add('Monospaced', () => (
     <Box padding={5}>
-      <Heading1 color={select('Color', COLORS, 'teal')} tint={select('Tint', TINTS, 'darkest')}>
+      <Heading1
+        color={select('Color', COLORS, 'teal')}
+        ellipsis={boolean('Overflow ellipsis', false)}
+        tint={select('Tint', TINTS, 'darkest')}
+      >
         <Monospaced>1234567890</Monospaced>
       </Heading1>
-      <Heading2 color={select('Color', COLORS, 'teal')} tint={select('Tint', TINTS, 'darkest')} marginTop={2}>
+      <Heading2
+        color={select('Color', COLORS, 'teal')}
+        ellipsis={boolean('Overflow ellipsis', false)}
+        tint={select('Tint', TINTS, 'darkest')}
+        marginTop={2}
+      >
         <Monospaced>1234567890</Monospaced>
       </Heading2>
-      <Heading3 color={select('Color', COLORS, 'teal')} tint={select('Tint', TINTS, 'darkest')} marginTop={2}>
+      <Heading3
+        color={select('Color', COLORS, 'teal')}
+        ellipsis={boolean('Overflow ellipsis', false)}
+        tint={select('Tint', TINTS, 'darkest')}
+        marginTop={2}
+      >
         <Monospaced>1234567890</Monospaced>
       </Heading3>
-      <Heading4 color={select('Color', COLORS, 'teal')} tint={select('Tint', TINTS, 'darkest')} marginTop={2}>
+      <Heading4
+        color={select('Color', COLORS, 'teal')}
+        ellipsis={boolean('Overflow ellipsis', false)}
+        tint={select('Tint', TINTS, 'darkest')}
+        marginTop={2}
+      >
         <Monospaced>1234567890</Monospaced>
       </Heading4>
-      <TextDisplay color={select('Color', COLORS, 'teal')} tint={select('Tint', TINTS, 'darkest')} marginTop={6}>
+      <TextDisplay
+        color={select('Color', COLORS, 'teal')}
+        ellipsis={boolean('Overflow ellipsis', false)}
+        tint={select('Tint', TINTS, 'darkest')}
+        marginTop={6}
+      >
         <Monospaced>1234567890</Monospaced>
       </TextDisplay>
-      <TextBody color={select('Color', COLORS, 'teal')} tint={select('Tint', TINTS, 'darkest')} marginTop={2}>
+      <TextBody
+        color={select('Color', COLORS, 'teal')}
+        ellipsis={boolean('Overflow ellipsis', false)}
+        tint={select('Tint', TINTS, 'darkest')}
+        marginTop={2}
+      >
         <Monospaced>1234567890</Monospaced>
       </TextBody>
-      <TextSmall color={select('Color', COLORS, 'teal')} tint={select('Tint', TINTS, 'darkest')} marginTop={2}>
+      <TextSmall
+        color={select('Color', COLORS, 'teal')}
+        ellipsis={boolean('Overflow ellipsis', false)}
+        tint={select('Tint', TINTS, 'darkest')}
+        marginTop={2}
+      >
         <Monospaced>1234567890</Monospaced>
       </TextSmall>
     </Box>


### PR DESCRIPTION
### Description

This PR adds the ability to force the text on one line and show an ellipsis at the end. This applies to all `Text` & `Heading` components.

#### Screenshot before this PR

![Screenshot 2019-09-19 13 38 11](https://user-images.githubusercontent.com/5336831/65241048-ede23600-dae2-11e9-90d9-709d14e2d7ca.png)

#### Screenshot after this PR

![Screenshot 2019-09-19 13 38 19](https://user-images.githubusercontent.com/5336831/65241059-f2a6ea00-dae2-11e9-9c71-aaf9d6b7f85e.png)

### Breaking changes
None.
