### PR TITLE
StatusLabel: padding adjustment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `StatusLabel`: decreased horizontal padding from 12px to 6px. ([@driesd](https://github.com/driesd) in [#690](https://github.com/teamleadercrm/ui/pull/690))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/statusLabel/StatusLabel.js
+++ b/src/components/statusLabel/StatusLabel.js
@@ -5,16 +5,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 import uiUtilities from '@teamleader/ui-utilities';
 
-const SIZES = {
-  medium: {
-    paddingHorizontal: 2,
-    paddingVertical: 1,
-  },
-  small: {
-    paddingHorizontal: 2,
-  },
-};
-
 class StatusLabel extends PureComponent {
   render() {
     const { children, className, color, size, ...others } = this.props;
@@ -22,7 +12,7 @@ class StatusLabel extends PureComponent {
     const classNames = cx(uiUtilities['reset-font-smoothing'], theme['label'], theme[color], theme[size], className);
 
     return (
-      <Box className={classNames} element="span" {...SIZES[size]} {...others} data-teamleader-ui="status-label">
+      <Box className={classNames} element="span" {...others} data-teamleader-ui="status-label">
         {children}
       </Box>
     );
@@ -37,7 +27,7 @@ StatusLabel.propTypes = {
   /** The name of the color them you want to give to the status label */
   color: PropTypes.oneOf(['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua']),
   /** Size of the button */
-  size: PropTypes.oneOf(Object.keys(SIZES)),
+  size: PropTypes.oneOf(['small', 'medium']),
 };
 
 StatusLabel.defaultProps = {

--- a/src/components/statusLabel/theme.css
+++ b/src/components/statusLabel/theme.css
@@ -29,14 +29,14 @@
   font-size: calc(1.4 * var(--unit));
   line-height: calc(1.8 * var(--unit));
   border-radius: 14px;
-  padding: 3px 12px;
+  padding: 3px 6px;
 }
 
 .small {
   font-size: calc(1.2 * var(--unit));
   line-height: calc(1.4 * var(--unit));
   border-radius: 11px;
-  padding: 2px 12px;
+  padding: 2px 6px;
 }
 
 h1,


### PR DESCRIPTION
### Description

This PR decreases the `horizontal padding` of our `StatusLabel` component from 12px to 6px.

#### Screenshot before this PR

![Screenshot 2019-09-23 10 14 40](https://user-images.githubusercontent.com/5336831/65410603-13c15080-ddeb-11e9-812f-a31cbc7a46a1.png)

#### Screenshot after this PR

![Screenshot 2019-09-23 10 14 51](https://user-images.githubusercontent.com/5336831/65410610-1754d780-ddeb-11e9-8045-864f44bfd6eb.png)

### Breaking changes

None.
