### PR TITLE
Avatar: change default color

### DIFF
--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -6,7 +6,9 @@ import AvatarOverlay from './AvatarOverlay';
 import Box, { pickBoxProps } from '../box';
 import cx from 'classnames';
 import theme from './theme.css';
-import { COLORS } from '../../constants';
+import { colorsWithout } from '../../constants';
+
+const colors = colorsWithout(['neutral']);
 
 const hashCode = str => {
   let hash = 0;
@@ -21,7 +23,7 @@ const hashCode = str => {
   return hash;
 };
 
-const getColor = id => (id ? COLORS[Math.abs(hashCode(id)) % COLORS.length] : COLORS[2]);
+const getColor = id => (id ? colors[Math.abs(hashCode(id)) % colors.length] : 'neutral');
 
 class Avatar extends PureComponent {
   render() {

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -21,7 +21,7 @@ const hashCode = str => {
   return hash;
 };
 
-const getColor = id => (id ? COLORS[Math.abs(hashCode(id)) % COLORS.length] : COLORS[0]);
+const getColor = id => (id ? COLORS[Math.abs(hashCode(id)) % COLORS.length] : COLORS[2]);
 
 class Avatar extends PureComponent {
   render() {

--- a/stories/avatars.js
+++ b/stories/avatars.js
@@ -20,7 +20,7 @@ storiesOf('Avatars', module)
     <Avatar
       editable={boolean('Editable', false)}
       fullName={text('Full name', 'John Doe')}
-      id="63227a3c-c80b-11e9-a32f-2a2ae2dbcce4"
+      id={text('Id', '63227a3c-c80b-11e9-a32f-2a2ae2dbcce4')}
       imageUrl={boolean('Image available', false) ? avatars[0].image : null}
       onImageChange={() => console.log('Change image')}
       size={select('Size', sizes, 'large')}


### PR DESCRIPTION
### Description

This PR changes the default color (from aqua to neutral) for the `AvavtarInitials` background. When an id (uuid) is present, it can be any color except `neutral`. When no id is present, it will be `neutral`.

#### Screenshot before this PR

![Screenshot 2019-09-24 10 23 40](https://user-images.githubusercontent.com/5336831/65495431-070a2e80-deb7-11e9-9d62-491ecab89092.png)


#### Screenshot after this PR

![Screenshot 2019-09-24 10 24 02](https://user-images.githubusercontent.com/5336831/65495438-0bcee280-deb7-11e9-86b5-c0571fd6e624.png)


### Breaking changes

None.
