### PR TITLE
Counter: decrease horizontal padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Counter`: decreased horizontal padding from `6px` to `3px` for the `small` size variant. ([@driesd](https://github.com/driesd) in [#696](https://github.com/teamleadercrm/ui/pull/696))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/counter/theme.css
+++ b/src/components/counter/theme.css
@@ -24,7 +24,7 @@
 
 .small {
   min-width: calc(1.8 * var(--unit));
-  padding: var(--spacer-smallest) var(--spacer-smaller);
+  padding: var(--spacer-smallest);
 }
 
 .neutral {


### PR DESCRIPTION
### Description

This PR decreases the horizontal padding of our `small` sized `Counter` component from 6px to 3px.

#### Screenshot before this PR

![Screenshot 2019-09-27 12 29 53](https://user-images.githubusercontent.com/5336831/65763021-b8f96300-e122-11e9-9783-81838e551563.png)

#### Screenshot after this PR

![Screenshot 2019-09-27 12 28 54](https://user-images.githubusercontent.com/5336831/65763065-d0385080-e122-11e9-9452-3a0e4d666031.png)

### Breaking changes

None.
