### PR TITLE
Link: `left` as the default value for `iconPlacement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - `Counter`: decreased horizontal padding from `6px` to `3px` for the `small` size variant. ([@driesd](https://github.com/driesd) in [#696](https://github.com/teamleadercrm/ui/pull/696))
+- `Link`: set `left` as the default value for the `iconPlacement` prop. ([@driesd](https://github.com/driesd) in [#698](https://github.com/teamleadercrm/ui/pull/698))
 
 ### Deprecated
 

--- a/src/components/link/Link.js
+++ b/src/components/link/Link.js
@@ -89,6 +89,7 @@ Link.defaultProps = {
   className: '',
   disabled: false,
   element: 'a',
+  iconPlacement: 'left',
   inherit: true,
   inverse: false,
 };


### PR DESCRIPTION
### Description

This PR sets `left` as the default value for the `iconPlacement` prop in our `Link` component.

### Breaking changes

None.