### PR TITLE
💄 Remove padding on the right of banner content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `Button & IconButton`: use `Box` as the base component. ([@driesd](https://github.com/driesd) in [#697](https://github.com/teamleadercrm/ui/pull/697))
 - `Counter`: decreased horizontal padding from `6px` to `3px` for the `small` size variant. ([@driesd](https://github.com/driesd) in [#696](https://github.com/teamleadercrm/ui/pull/696))
 - `Link`: set `left` as the default value for the `iconPlacement` prop. ([@driesd](https://github.com/driesd) in [#698](https://github.com/teamleadercrm/ui/pull/698))
+- `Banner`: remove padding on the right side of the banner content. ([@rathesDot](https://github.com/rathesDot)) in [#699](https://github.com/teamleadercrm/ui/pull/699)
 
 ### Deprecated
 

--- a/src/components/banner/Banner.js
+++ b/src/components/banner/Banner.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import cx from 'classnames';
 
+import Box from '../box';
 import Island from '../island';
 import Section from '../section';
 import { IconButton } from '../button';
@@ -18,13 +18,13 @@ class Banner extends PureComponent {
     const { children, className, icon, onClose, fullWidth, ...others } = this.props;
     const Element = fullWidth ? Section : Island;
 
-    const contentClassNames = cx(theme['content'], { [theme['content--closable']]: onClose });
-
     return (
       <Element data-teamleader-ui="banner" className={className} {...others}>
         <div className={theme['inner']}>
           {icon && <span className={theme['icon']}>{icon}</span>}
-          <span className={contentClassNames}>{children}</span>
+          <Box flex={1} element="span" paddingRight={onClose && 7}>
+            {children}
+          </Box>
           {onClose && (
             <IconButton
               className={theme['close-button']}

--- a/src/components/banner/Banner.js
+++ b/src/components/banner/Banner.js
@@ -1,5 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
+
 import Island from '../island';
 import Section from '../section';
 import { IconButton } from '../button';
@@ -16,11 +18,13 @@ class Banner extends PureComponent {
     const { children, className, icon, onClose, fullWidth, ...others } = this.props;
     const Element = fullWidth ? Section : Island;
 
+    const contentClassNames = cx(theme['content'], { [theme['content--closable']]: onClose });
+
     return (
       <Element data-teamleader-ui="banner" className={className} {...others}>
         <div className={theme['inner']}>
           {icon && <span className={theme['icon']}>{icon}</span>}
-          <span className={theme['content']}>{children}</span>
+          <span className={contentClassNames}>{children}</span>
           {onClose && (
             <IconButton
               className={theme['close-button']}

--- a/src/components/banner/theme.css
+++ b/src/components/banner/theme.css
@@ -14,7 +14,6 @@
 
 .content {
   flex: 1;
-  padding-right: var(--spacer-big);
 }
 
 .close-button {

--- a/src/components/banner/theme.css
+++ b/src/components/banner/theme.css
@@ -16,6 +16,10 @@
   flex: 1;
 }
 
+.content--closable {
+  padding-right: var(--spacer-big);
+}
+
 .close-button {
   position: absolute;
   top: -3px;

--- a/src/components/banner/theme.css
+++ b/src/components/banner/theme.css
@@ -12,14 +12,6 @@
   position: relative;
 }
 
-.content {
-  flex: 1;
-}
-
-.content--closable {
-  padding-right: var(--spacer-big);
-}
-
 .close-button {
   position: absolute;
   top: -3px;

--- a/stories/banners.js
+++ b/stories/banners.js
@@ -38,4 +38,15 @@ storiesOf('Banner', module)
         I am a banner with an <Link href="http://teamleader.eu">optional link</Link> inside.
       </TextDisplay>
     </Banner>
+  ))
+  .add('Closable Banner', () => (
+    <Banner
+      color={select('Color', colors, 'white')}
+      fullWidth={boolean('Full width', false)}
+      icon={<IconIdeaMediumOutline />}
+      size={select('Size', [SMALL, MEDIUM, LARGE], MEDIUM)}
+      onClose={() => {}}
+    >
+      <TextDisplay>{text('Banner text', 'I am a banner that can be closed.')}</TextDisplay>
+    </Banner>
   ));


### PR DESCRIPTION
### Description

This PR removes some useless padding on the right of the banner which makes the spacing looking of when the content spans over multiple lines.

#### Screenshot before this PR

<img width="817" alt="Screen Shot 2019-10-03 at 11 15 46 AM" src="https://user-images.githubusercontent.com/6367520/66114560-5a732f80-e5cf-11e9-9e27-82f9cc073a84.png">


#### Screenshot after this PR

<img width="818" alt="Screen Shot 2019-10-03 at 11 16 05 AM" src="https://user-images.githubusercontent.com/6367520/66114572-62cb6a80-e5cf-11e9-9e58-3df8972bc741.png">

#### Note

This change has no impact on single-line banners (apart from that they can now have slightly more content in one line)

### Breaking changes

No breaking changes.