### PR TITLE
[AHOY-337] Radio button - change default background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `Button & IconButton`: use `Box` as the base component. ([@driesd](https://github.com/driesd) in [#697](https://github.com/teamleadercrm/ui/pull/697))
 - `Counter`: decreased horizontal padding from `6px` to `3px` for the `small` size variant. ([@driesd](https://github.com/driesd) in [#696](https://github.com/teamleadercrm/ui/pull/696))
 - `Link`: set `left` as the default value for the `iconPlacement` prop. ([@driesd](https://github.com/driesd) in [#698](https://github.com/teamleadercrm/ui/pull/698))
+- `Radio`: changed the default background color from neutral light to neutral lightest (white). ([@driesd](https://github.com/driesd) in [#700](https://github.com/teamleadercrm/ui/pull/700))
 - `Banner`: remove padding on the right side of the banner content. ([@rathesDot](https://github.com/rathesDot)) in [#699](https://github.com/teamleadercrm/ui/pull/699)
 
 ### Deprecated

--- a/src/components/radio/theme.css
+++ b/src/components/radio/theme.css
@@ -29,7 +29,7 @@
 
   .shape {
     box-sizing: border-box;
-    background: var(--color-neutral-light);
+    background: var(--color-neutral-lightest);
     border: var(--checkbox-border-width) solid var(--color-neutral-dark);
     border-radius: 100%;
     color: var(--color-white);


### PR DESCRIPTION
### Description

This PR changes the `default background-color` of our `Radio` component, from neutral light to neutral lightest.

#### Screenshot before this PR
![Screenshot 2019-10-04 11 29 03](https://user-images.githubusercontent.com/5336831/66197201-32043780-e69a-11e9-811c-d29439fece5a.png)

#### Screenshot after this PR
![Screenshot 2019-10-04 11 28 51](https://user-images.githubusercontent.com/5336831/66197212-37fa1880-e69a-11e9-831c-3f131d8a168e.png)

### Breaking changes

None.