### PR TITLE
[AHOY-335] Radio button - increase spacing between radio and label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `Button & IconButton`: use `Box` as the base component. ([@driesd](https://github.com/driesd) in [#697](https://github.com/teamleadercrm/ui/pull/697))
 - `Counter`: decreased horizontal padding from `6px` to `3px` for the `small` size variant. ([@driesd](https://github.com/driesd) in [#696](https://github.com/teamleadercrm/ui/pull/696))
 - `Link`: set `left` as the default value for the `iconPlacement` prop. ([@driesd](https://github.com/driesd) in [#698](https://github.com/teamleadercrm/ui/pull/698))
-- `Radio`: increased spacing between radio and label for small sized variant. ([@driesd](https://github.com/driesd) in [#700](https://github.com/teamleadercrm/ui/pull/700))
+- `Radio`: increased spacing between radio and label for small sized variant. ([@driesd](https://github.com/driesd) in [#701](https://github.com/teamleadercrm/ui/pull/701))
 - `Banner`: remove padding on the right side of the banner content. ([@rathesDot](https://github.com/rathesDot)) in [#699](https://github.com/teamleadercrm/ui/pull/699)
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `Button & IconButton`: use `Box` as the base component. ([@driesd](https://github.com/driesd) in [#697](https://github.com/teamleadercrm/ui/pull/697))
 - `Counter`: decreased horizontal padding from `6px` to `3px` for the `small` size variant. ([@driesd](https://github.com/driesd) in [#696](https://github.com/teamleadercrm/ui/pull/696))
 - `Link`: set `left` as the default value for the `iconPlacement` prop. ([@driesd](https://github.com/driesd) in [#698](https://github.com/teamleadercrm/ui/pull/698))
-- `Radio`: increased spacing between checkbox and label for small sized variant. ([@driesd](https://github.com/driesd) in [#700](https://github.com/teamleadercrm/ui/pull/700))
+- `Radio`: increased spacing between radio and label for small sized variant. ([@driesd](https://github.com/driesd) in [#700](https://github.com/teamleadercrm/ui/pull/700))
 - `Banner`: remove padding on the right side of the banner content. ([@rathesDot](https://github.com/rathesDot)) in [#699](https://github.com/teamleadercrm/ui/pull/699)
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `Button & IconButton`: use `Box` as the base component. ([@driesd](https://github.com/driesd) in [#697](https://github.com/teamleadercrm/ui/pull/697))
 - `Counter`: decreased horizontal padding from `6px` to `3px` for the `small` size variant. ([@driesd](https://github.com/driesd) in [#696](https://github.com/teamleadercrm/ui/pull/696))
 - `Link`: set `left` as the default value for the `iconPlacement` prop. ([@driesd](https://github.com/driesd) in [#698](https://github.com/teamleadercrm/ui/pull/698))
+- `Radio`: increased spacing between checkbox and label for small sized variant. ([@driesd](https://github.com/driesd) in [#700](https://github.com/teamleadercrm/ui/pull/700))
 - `Banner`: remove padding on the right side of the banner content. ([@rathesDot](https://github.com/rathesDot)) in [#699](https://github.com/teamleadercrm/ui/pull/699)
 
 ### Deprecated

--- a/src/components/radio/theme.css
+++ b/src/components/radio/theme.css
@@ -27,6 +27,10 @@
     margin: 0;
   }
 
+  .label {
+    margin-left: var(--spacer-small);
+  }
+
   .shape {
     box-sizing: border-box;
     background: var(--color-neutral-light);
@@ -111,10 +115,6 @@
   }
 
   &.is-small {
-    .label {
-      margin-left: var(--spacer-smaller);
-    }
-
     .shape {
       width: var(--checkbox-shape-size-small);
       height: var(--checkbox-shape-size-small);
@@ -128,7 +128,6 @@
 
   &.is-medium {
     .label {
-      margin-left: var(--spacer-small);
       padding-top: 2px;
     }
 
@@ -145,7 +144,6 @@
 
   &.is-large {
     .label {
-      margin-left: var(--spacer-small);
       padding-top: 4px;
     }
 


### PR DESCRIPTION
### Description

This PR increases the spacing between radio and label for the small-sized variant of our `Radio` component.

#### Screenshot before this PR
![Screenshot 2019-10-04 11 39 44](https://user-images.githubusercontent.com/5336831/66198161-1d28a380-e69c-11e9-9872-e0ec01927b0c.png)

#### Screenshot after this PR
![Screenshot 2019-10-04 11 39 26](https://user-images.githubusercontent.com/5336831/66198173-231e8480-e69c-11e9-8c86-55325eb926b9.png)

### Breaking changes

None.
