### PR TITLE
[AHOY-338] MenuItem add label & recycle caption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `Button & IconButton`: use `Box` as the base component. ([@driesd](https://github.com/driesd) in [#697](https://github.com/teamleadercrm/ui/pull/697))
 - `Counter`: decreased horizontal padding from `6px` to `3px` for the `small` size variant. ([@driesd](https://github.com/driesd) in [#696](https://github.com/teamleadercrm/ui/pull/696))
 - `Link`: set `left` as the default value for the `iconPlacement` prop. ([@driesd](https://github.com/driesd) in [#698](https://github.com/teamleadercrm/ui/pull/698))
+- [BREAKING] `MenuItem`: The old `caption` prop has been recycled to be used as an actual caption, which is now displayed underneath the `label`. ([@driesd](https://github.com/driesd) in [#703](https://github.com/teamleadercrm/ui/pull/703))
 - `Banner`: remove padding on the right side of the banner content. ([@rathesDot](https://github.com/rathesDot)) in [#699](https://github.com/teamleadercrm/ui/pull/699)
 
 ### Deprecated

--- a/src/components/button/SplitButton.js
+++ b/src/components/button/SplitButton.js
@@ -9,10 +9,10 @@ import { IconChevronDownSmallOutline } from '@teamleader/ui-icons';
 import pick from 'lodash.pick';
 
 class SplitButton extends PureComponent {
-  firstChild = pick(this.props.children[0].props, ['caption']);
+  firstChild = pick(this.props.children[0].props, ['label']);
 
   state = {
-    buttonLabel: this.firstChild.caption,
+    buttonLabel: this.firstChild.label,
     popoverActive: false,
     popoverAnchorEl: null,
   };
@@ -30,7 +30,7 @@ class SplitButton extends PureComponent {
     this.setState({
       popoverActive: false,
     });
-    childProps.onClick(childProps.caption);
+    childProps.onClick(childProps.label);
   };
 
   handleCloseClick = () => {
@@ -62,7 +62,7 @@ class SplitButton extends PureComponent {
         >
           <Menu>
             {React.Children.map(children, child => {
-              if (child.props.caption !== buttonLabel) {
+              if (child.props.label !== buttonLabel) {
                 return React.cloneElement(child, {
                   onClick: () => this.handleMenuItemClick(child),
                 });

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -16,7 +16,7 @@ class MenuItem extends PureComponent {
   };
 
   render() {
-    const { icon, caption, className, destructive, selected, disabled, ...others } = this.props;
+    const { icon, caption, className, destructive, label, selected, disabled, ...others } = this.props;
 
     const classNames = cx(
       theme['menu-item'],
@@ -40,31 +40,43 @@ class MenuItem extends PureComponent {
         element="li"
         onClick={this.handleClick}
         paddingHorizontal={3}
+        paddingVertical={2}
       >
         {icon && (
           <Icon color={color} tint={tint} marginRight={3}>
             {icon}
           </Icon>
         )}
-        <TextBody color={color} tint={tint} element="span">
-          {caption}
-        </TextBody>
+        <Box flex={1}>
+          {label && (
+            <TextBody color={color} tint={tint}>
+              {label}
+            </TextBody>
+          )}
+          {caption && (
+            <TextBody color="neutral" tint="darkest">
+              {caption}
+            </TextBody>
+          )}
+        </Box>
       </Box>
     );
   }
 }
 
 MenuItem.propTypes = {
-  /** The text to display inside the component. */
+  /** A caption displayed underneath the label. */
   caption: PropTypes.string,
   /** A class name for the wrapper to give custom styles. */
   className: PropTypes.string,
-  /** If true, the color of caption and icon will be ruby */
+  /** If true, the color of label and icon will be ruby */
   destructive: PropTypes.bool,
   /** If true, component will be disabled. */
   disabled: PropTypes.bool,
-  /** The icon to display on the left side of the caption. */
+  /** The icon to display on the left side of the label. */
   icon: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  /** The text used as the label for the component. */
+  label: PropTypes.string,
   /** Callback function that is fired when clicking the component. */
   onClick: PropTypes.func,
   /** If true, component will look active. */

--- a/src/components/menu/theme.css
+++ b/src/components/menu/theme.css
@@ -127,7 +127,7 @@
 }
 
 .menu-item {
-  height: var(--menu-item-height);
+  min-height: var(--menu-item-height);
   overflow: hidden;
   position: relative;
   -webkit-user-select: none;

--- a/stories/datagrid.js
+++ b/stories/datagrid.js
@@ -87,9 +87,9 @@ storiesOf('DataGrids', module)
             <DataGrid.Cell soft>{row.column4}</DataGrid.Cell>
             <DataGrid.Cell align="right" flex="min-width" preventOverflow={false}>
               <IconMenu position="top-right">
-                <MenuItem caption="Duplicate row" onClick={() => console.log('onClick: duplicate row')} />
-                <MenuItem caption="Inactive row" onClick={() => console.log('onClick: inactivate row')} />
-                <MenuItem caption="Remove row" onClick={() => console.log('onClick: remove row')} />
+                <MenuItem label="Duplicate row" onClick={() => console.log('onClick: duplicate row')} />
+                <MenuItem label="Inactive row" onClick={() => console.log('onClick: inactivate row')} />
+                <MenuItem label="Remove row" onClick={() => console.log('onClick: remove row')} />
               </IconMenu>
             </DataGrid.Cell>
           </DataGrid.BodyRow>
@@ -153,9 +153,9 @@ storiesOf('DataGrids', module)
             <DataGrid.Cell soft>{row.column4}</DataGrid.Cell>
             <DataGrid.Cell align="right" flex="min-width" preventOverflow={false}>
               <IconMenu position="top-right">
-                <MenuItem caption="Duplicate row" onClick={() => console.log('onClick: duplicate row')} />
-                <MenuItem caption="Inactive row" onClick={() => console.log('onClick: inactivate row')} />
-                <MenuItem caption="Remove row" onClick={() => console.log('onClick: remove row')} />
+                <MenuItem label="Duplicate row" onClick={() => console.log('onClick: duplicate row')} />
+                <MenuItem label="Inactive row" onClick={() => console.log('onClick: inactivate row')} />
+                <MenuItem label="Remove row" onClick={() => console.log('onClick: remove row')} />
               </IconMenu>
             </DataGrid.Cell>
           </DataGrid.BodyRow>
@@ -224,9 +224,9 @@ storiesOf('DataGrids', module)
             <DataGrid.Cell soft>{row.column4}</DataGrid.Cell>
             <DataGrid.Cell align="right" flex="min-width" preventOverflow={false}>
               <IconMenu position="top-right">
-                <MenuItem caption="Duplicate row" onClick={() => console.log('onClick: duplicate row')} />
-                <MenuItem caption="Inactive row" onClick={() => console.log('onClick: inactivate row')} />
-                <MenuItem caption="Remove row" onClick={() => console.log('onClick: remove row')} />
+                <MenuItem label="Duplicate row" onClick={() => console.log('onClick: duplicate row')} />
+                <MenuItem label="Inactive row" onClick={() => console.log('onClick: inactivate row')} />
+                <MenuItem label="Remove row" onClick={() => console.log('onClick: remove row')} />
               </IconMenu>
             </DataGrid.Cell>
           </DataGrid.BodyRow>
@@ -292,9 +292,9 @@ storiesOf('DataGrids', module)
             <DataGrid.Cell soft>{row.column4}</DataGrid.Cell>
             <DataGrid.Cell align="right" flex="min-width" preventOverflow={false}>
               <IconMenu position="top-right">
-                <MenuItem caption="Duplicate row" onClick={() => console.log('onClick: duplicate row')} />
-                <MenuItem caption="Inactive row" onClick={() => console.log('onClick: inactivate row')} />
-                <MenuItem caption="Remove row" onClick={() => console.log('onClick: remove row')} />
+                <MenuItem label="Duplicate row" onClick={() => console.log('onClick: duplicate row')} />
+                <MenuItem label="Inactive row" onClick={() => console.log('onClick: inactivate row')} />
+                <MenuItem label="Remove row" onClick={() => console.log('onClick: remove row')} />
               </IconMenu>
             </DataGrid.Cell>
           </DataGrid.BodyRow>

--- a/stories/menu.js
+++ b/stories/menu.js
@@ -11,23 +11,23 @@ const positions = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
 storiesOf('Menus', module)
   .add('Menu', () => (
     <Menu selectable={boolean('Selectable', false)} selected="bar">
-      <MenuItem value="foo" caption="Foo caption" />
-      <MenuItem value="bar" caption="Bar caption" />
-      <MenuItem caption="Disabled ..." disabled />
+      <MenuItem value="foo" label="Foo label" caption="This is foo's caption" />
+      <MenuItem value="bar" label="Bar label" caption="Caption of bar" />
+      <MenuItem label="Disabled ..." disabled />
       <MenuDivider />
-      <MenuItem caption="Caption & avatar" icon={avatar} />
+      <MenuItem label="Label & avatar" icon={avatar} />
       <MenuDivider />
       <MenuTitle>Group title</MenuTitle>
-      <MenuItem caption="Caption & icon" icon={<IconClockSmallOutline />} />
-      <MenuItem caption="Destructive" icon={<IconTrashSmallOutline />} destructive />
-      <MenuItem caption="Destructive & disabled" icon={<IconTrashSmallOutline />} destructive disabled />
+      <MenuItem label="Label & icon" icon={<IconClockSmallOutline />} />
+      <MenuItem label="Destructive" icon={<IconTrashSmallOutline />} destructive />
+      <MenuItem label="Destructive & disabled" icon={<IconTrashSmallOutline />} destructive disabled />
     </Menu>
   ))
   .add('IconMenu', () => (
     <IconMenu active position={select('Position', positions, 'top-left')}>
-      <MenuItem caption="Menu item 1" />
-      <MenuItem caption="Menu item 2" />
+      <MenuItem label="Menu item 1" />
+      <MenuItem label="Menu item 2" />
       <MenuDivider />
-      <MenuItem caption="Disabled menu item..." disabled />
+      <MenuItem label="Disabled menu item..." disabled />
     </IconMenu>
   ));

--- a/stories/popover.js
+++ b/stories/popover.js
@@ -248,14 +248,14 @@ storiesOf('Popover', module)
         >
           <Box overflowY="auto">
             <Menu outline={false} selected="bar">
-              <MenuItem value="foo" caption="Foo caption" />
-              <MenuItem value="bar" caption="Bar caption" />
-              <MenuItem caption="Disabled ..." disabled />
+              <MenuItem value="foo" label="Foo label" />
+              <MenuItem value="bar" label="Bar label" />
+              <MenuItem label="Disabled ..." disabled />
               <MenuDivider />
               <MenuTitle>Group title</MenuTitle>
-              <MenuItem caption="Caption & icon" icon={<IconClockSmallOutline />} />
-              <MenuItem caption="Destructive" icon={<IconTrashSmallOutline />} destructive />
-              <MenuItem caption="Destructive & disabled" icon={<IconCloseSmallOutline />} destructive disabled />
+              <MenuItem label="Label & icon" icon={<IconClockSmallOutline />} />
+              <MenuItem label="Destructive" icon={<IconTrashSmallOutline />} destructive />
+              <MenuItem label="Destructive & disabled" icon={<IconCloseSmallOutline />} destructive disabled />
             </Menu>
           </Box>
         </Popover>
@@ -285,13 +285,13 @@ storiesOf('Popover', module)
             <Menu outline={false}>
               <MenuItem
                 value="foo"
-                caption="Primary action"
+                label="Primary action"
                 icon={<IconClockSmallOutline />}
                 onClick={handleSplitButtonNormalMenuItemClick}
               />
               <MenuItem
                 value="bar"
-                caption="Destructive action"
+                label="Destructive action"
                 icon={<IconTrashSmallOutline />}
                 destructive
                 onClick={handleSplitButtonDestructiveMenuItemClick}

--- a/stories/splitButton.js
+++ b/stories/splitButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { select } from '@storybook/addon-knobs/react';
-import { SplitButton, MenuItem } from '../src';
+import { SplitButton, MenuDivider, MenuItem } from '../src';
 
 const levels = ['primary', 'secondary', 'destructive'];
 const sizes = ['small', 'medium', 'large'];
@@ -20,8 +20,9 @@ storiesOf('Split button', module).add('Basic', () => (
     onButtonClick={handleButtonClick}
     size={select('Size', sizes, 'medium')}
   >
-    <MenuItem onClick={handleMenuItemClick} caption="Main action" />
-    <MenuItem onClick={handleMenuItemClick} caption="Action 1" />
-    <MenuItem onClick={handleMenuItemClick} caption="Action 2" />
+    <MenuItem onClick={handleMenuItemClick} label="Main action" />
+    <MenuItem onClick={handleMenuItemClick} label="Via file upload" caption="(.CVS, . XLS & .XLSX)" />
+    <MenuDivider />
+    <MenuItem onClick={handleMenuItemClick} label="Via Marketplace integrations" />
   </SplitButton>
 ));

--- a/stories/widget.js
+++ b/stories/widget.js
@@ -80,10 +80,10 @@ storiesOf('Widget', module)
           <IconButton icon={<IconEditMediumOutline />} />
           <IconButton icon={<IconAddMediumOutline />} />
           <IconMenu active position="top-right">
-            <MenuItem caption="Menu item 1" />
-            <MenuItem caption="Menu item 2" />
+            <MenuItem label="Menu item 1" />
+            <MenuItem label="Menu item 2" />
             <MenuDivider />
-            <MenuItem caption="Disabled menu item..." disabled />
+            <MenuItem label="Disabled menu item..." disabled />
           </IconMenu>
         </Box>
       </Widget.Header>


### PR DESCRIPTION
### Description

This PR adds a `label` prop to our `Menuitem` component. The old `caption` prop will now be used as an actual caption, displayed underneath the label.

#### Screenshot before this PR
![Screenshot 2019-10-04 13 56 35](https://user-images.githubusercontent.com/5336831/66205865-cc6e7600-e6ae-11e9-80b4-a971d4cdc997.png)

#### Screenshot after this PR
![Screenshot 2019-10-04 13 51 53](https://user-images.githubusercontent.com/5336831/66205877-d3958400-e6ae-11e9-8ab3-cda42fdd7bff.png)

### Breaking changes

The old `caption` prop has been recycled to be used as an actual caption which is displayed underneath the `label`.
