### PR TITLE
Avatar: simplify the hashCode function logic

### DIFF
--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -10,18 +10,7 @@ import { colorsWithout } from '../../constants';
 
 const colors = colorsWithout(['neutral']);
 
-const hashCode = str => {
-  let hash = 0;
-  if (!str || str.length === 0) {
-    return hash;
-  }
-  for (let i = 0; i < str.length; i++) {
-    const char = str.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash &= hash; // Convert to 32bit integer
-  }
-  return hash;
-};
+const hashCode = hexString => parseInt(hexString.substr(-5), 16);
 
 const getColor = id => (id ? colors[Math.abs(hashCode(id)) % colors.length] : 'neutral');
 


### PR DESCRIPTION
### Description

This PR changes the way our `hashCode` function calculates the `background-color` passed to the `AvatarInitials` component. The goal was to make this function much more readable and thus much more understandable.

#### Screenshot before this PR

![Screenshot 2019-10-09 15 51 28](https://user-images.githubusercontent.com/5336831/66487499-b4cb2f00-eaac-11e9-855c-2e61c7f236e7.png)

#### Screenshot after this PR

![Screenshot 2019-10-09 15 50 55](https://user-images.githubusercontent.com/5336831/66487519-bac11000-eaac-11e9-8848-08ee63d4b1ed.png)

### Breaking changes

None.
