### PR TITLE
🐛Don't pass boxProps to Avatar child components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- `Avatar`: Don't pass boxProps to Avatar child components. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#708](https://github.com/teamleadercrm/ui/pull/708))
+
 ### Dependency updates
 
 ## [0.31.0] - 2019-10-07

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import AvatarImage from './AvatarImage';
 import AvatarInitials from './AvatarInitials';
 import AvatarOverlay from './AvatarOverlay';
-import Box, { pickBoxProps } from '../box';
+import Box, { pickBoxProps, omitBoxProps } from '../box';
 import cx from 'classnames';
 import theme from './theme.css';
 import { colorsWithout } from '../../constants';
@@ -19,13 +19,14 @@ class Avatar extends PureComponent {
     const { className, editable, imageUrl, fullName, id, onImageChange, size, shape, ...others } = this.props;
     const avatarClassNames = cx(theme['avatar'], theme[`is-${size}`], theme[`is-${shape}`], className);
     const boxProps = pickBoxProps(others);
+    const propsWithoutBoxProps = omitBoxProps(others);
 
     return (
       <Box className={avatarClassNames} {...boxProps}>
         {imageUrl ? (
-          <AvatarImage image={imageUrl} imageAlt={fullName} {...others} />
+          <AvatarImage image={imageUrl} imageAlt={fullName} {...propsWithoutBoxProps} />
         ) : (
-          <AvatarInitials color={getColor(id)} name={fullName} {...others} />
+          <AvatarInitials color={getColor(id)} name={fullName} {...propsWithoutBoxProps} />
         )}
         {editable && (size === 'large' || size === 'hero') && <AvatarOverlay onClick={onImageChange} />}
       </Box>


### PR DESCRIPTION
### Description

- Don't pass on Box props to the child components of the avatar component to get rid of console errors

### Breaking changes

- None
