### PR TITLE
Box: remove children from the boxProps list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `Avatar`: changed the way our `hashCode` function calculates the `background-color` passed to the `AvatarInitials` component. ([@driesd](https://github.com/driesd) in [#706](https://github.com/teamleadercrm/ui/pull/706))
 - `Avatar`: changed the size of our `small variant`, from 36x36px to `30x30px`. ([@driesd](https://github.com/driesd) in [#709](https://github.com/teamleadercrm/ui/pull/709))
+- `Box`: remove `children` from the box props list. ([@driesd](https://github.com/driesd) in [#710](https://github.com/teamleadercrm/ui/pull/710))
 
 ### Deprecated
 

--- a/src/components/box/boxProps.js
+++ b/src/components/box/boxProps.js
@@ -13,7 +13,6 @@ const boxProps = [
   'borderTint',
   'borderTopWidth',
   'boxSizing',
-  'children',
   'className',
   'display',
   'element',


### PR DESCRIPTION
### Description

This PR removes `children` from the `box prop list`. It just shouldn't be there in the first place.

### Breaking changes

None.
