### PR TITLE
Link: add an outline effect to indicate focus state

### DIFF
--- a/src/components/link/theme.css
+++ b/src/components/link/theme.css
@@ -23,6 +23,10 @@
     pointer-events: none;
   }
 
+  &:focus {
+    outline: var(--color-aqua-dark) auto 3px;
+  }
+
   &:active {
     outline: 0;
   }


### PR DESCRIPTION
### Description

This PR adds an `outline effect` to indicate `focus state` on our `Link` component.

#### Screenshot
![Screenshot 2019-10-30 16 51 11](https://user-images.githubusercontent.com/5336831/67874727-9ef1dc80-fb35-11e9-9dfa-51ae3f41fd45.png)

### Breaking changes

None
