### PR TITLE
Release 0.31.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `NumericInput`: fix spinner height for all size variants. ([@driesd](https://github.com/driesd) in [#713](https://github.com/teamleadercrm/ui/pull/713))
+
 ### Dependency updates
 
 ## [0.31.1] - 2019-10-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,17 @@
 
 ### Fixed
 
-- `NumericInput`: fix spinner height for all size variants. ([@driesd](https://github.com/driesd) in [#713](https://github.com/teamleadercrm/ui/pull/713))
-
 ### Dependency updates
+
+## [0.31.2] - 2019-10-31
+
+### Added
+
+- `Link`: added an outline effect to indicate focus state. ([@driesd](https://github.com/driesd) in [#712](https://github.com/teamleadercrm/ui/pull/712))
+
+### Fixed
+
+- `NumericInput`: fix spinner height for all size variants. ([@driesd](https://github.com/driesd) in [#713](https://github.com/teamleadercrm/ui/pull/713))
 
 ## [0.31.1] - 2019-10-24
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -282,7 +282,7 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  height: var(--input-height-medium);
+  height: 100%;
   justify-content: center;
   width: var(--spinner-width);
 }


### PR DESCRIPTION
### Added

- `Link`: added an outline effect to indicate focus state. ([@driesd](https://github.com/driesd) in [#712](https://github.com/teamleadercrm/ui/pull/712))

### Fixed

- `NumericInput`: fix spinner height for all size variants. ([@driesd](https://github.com/driesd) in [#713](https://github.com/teamleadercrm/ui/pull/713))


### Breaking changes

None.
