### PR TITLE
DatePickerInput: render placeholder when selected date is not set

### DIFF
--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -27,6 +27,21 @@ class DatePickerInput extends PureComponent {
     return null;
   }
 
+  getFormattedDate = () => {
+    const { formatDate: customFormatDate, locale } = this.props;
+    const { selectedDate } = this.state;
+
+    if (!selectedDate) {
+      return null;
+    }
+
+    if (!customFormatDate) {
+      return formatDate(selectedDate, locale);
+    }
+
+    return customFormatDate(selectedDate, locale);
+  };
+
   handleInputFocus = event => {
     const { onFocus, readOnly } = this.props.inputProps;
 
@@ -76,9 +91,6 @@ class DatePickerInput extends PureComponent {
     const { isPopoverActive, popoverAnchorEl, selectedDate } = this.state;
     const boxProps = pickBoxProps(others);
     const datePickerClassNames = cx(theme['date-picker-input'], theme[`is-${size}`]);
-    const formattedDate = this.props.formatDate
-      ? this.props.formatDate(selectedDate, locale)
-      : formatDate(selectedDate, locale);
 
     return (
       <Box className={className} {...boxProps}>
@@ -87,7 +99,7 @@ class DatePickerInput extends PureComponent {
           onFocus={this.handleInputFocus}
           prefix={this.renderIcon()}
           size={size}
-          value={formattedDate}
+          value={this.getFormattedDate()}
           width="120px"
           {...inputProps}
         />


### PR DESCRIPTION
### Description

This PR fixed the `DateTime error` in the input field of the `DatePickerInput` when no `selectedDate` was passed to the props.

#### Screenshot before this PR
![Screenshot 2019-11-07 10 00 30](https://user-images.githubusercontent.com/5336831/68374680-9efd6800-0145-11ea-9dec-7ffe01301555.png)

#### Screenshot after this PR
![Screenshot 2019-11-07 09 59 39](https://user-images.githubusercontent.com/5336831/68374692-a6247600-0145-11ea-916f-98b1195c1321.png)

### Breaking changes

None.