### PR TITLE
Release 0.31.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@
 
 ### Dependency updates
 
+## [0.31.3] - 2019-11-07
+
+### Fixed
+
+- `DatePickerInput`: instead of the DateTime error, show the placeholder when `selectedDate` is not set. ([@driesd](https://github.com/driesd) in [#716](https://github.com/teamleadercrm/ui/pull/716))
+
+### Dependency updates
+
+- `pretty-quick` from `2.0.0` to `2.0.1`
+
 ## [0.31.2] - 2019-10-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Fixed

- `DatePickerInput`: instead of the DateTime error, show the placeholder when `selectedDate` is not set. ([@driesd](https://github.com/driesd) in [#716](https://github.com/teamleadercrm/ui/pull/716))

### Dependency updates

- `pretty-quick` from `2.0.0` to `2.0.1`

### Breaking changes

None
