### PR TITLE
Menu item: allow anchor tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `MenuItem`: render a `button` or `a`-tag depending on the `element` prop. ([@driesd](https://github.com/driesd) in [#721](https://github.com/teamleadercrm/ui/pull/721))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Box from '../box';
+import Box, { omitBoxProps, pickBoxProps } from '../box';
 import Icon from '../icon';
 import { TextBody } from '../typography';
 import cx from 'classnames';
@@ -16,7 +16,7 @@ class MenuItem extends PureComponent {
   };
 
   render() {
-    const { icon, caption, className, destructive, label, selected, disabled, ...others } = this.props;
+    const { icon, caption, className, destructive, element, label, selected, disabled, ...others } = this.props;
 
     const classNames = cx(
       theme['menu-item'],
@@ -30,34 +30,42 @@ class MenuItem extends PureComponent {
     const color = destructive ? 'ruby' : disabled ? 'neutral' : 'teal';
     const tint = disabled && destructive ? 'light' : disabled || destructive ? 'dark' : 'darkest';
 
+    const boxProps = pickBoxProps(others);
+    const restProps = omitBoxProps(others);
+
     return (
-      <Box
-        {...others}
-        alignItems="center"
-        className={classNames}
-        data-teamleader-ui="menu-item"
-        display="flex"
-        element="li"
-        onClick={this.handleClick}
-        paddingHorizontal={3}
-        paddingVertical={2}
-      >
-        {icon && (
-          <Icon color={color} tint={tint} marginRight={3}>
-            {icon}
-          </Icon>
-        )}
-        <Box flex={1}>
-          {label && (
-            <TextBody color={color} tint={tint}>
-              {label}
-            </TextBody>
+      <Box {...boxProps} data-teamleader-ui="menu-item" display="flex" element="li">
+        <Box
+          onClick={this.handleClick}
+          alignItems="center"
+          className={classNames}
+          disabled={disabled}
+          display="flex"
+          element={element}
+          flex="1 0 auto"
+          paddingHorizontal={3}
+          paddingVertical={2}
+          textAlign="left"
+          {...(element === 'a' && disabled && { tabIndex: '-1' })}
+          {...restProps}
+        >
+          {icon && (
+            <Icon color={color} tint={tint} marginRight={3}>
+              {icon}
+            </Icon>
           )}
-          {caption && (
-            <TextBody color="neutral" tint="darkest">
-              {caption}
-            </TextBody>
-          )}
+          <Box flex="1 0 auto">
+            {label && (
+              <TextBody color={color} tint={tint}>
+                {label}
+              </TextBody>
+            )}
+            {caption && (
+              <TextBody color="neutral" tint="darkest">
+                {caption}
+              </TextBody>
+            )}
+          </Box>
         </Box>
       </Box>
     );
@@ -73,6 +81,8 @@ MenuItem.propTypes = {
   destructive: PropTypes.bool,
   /** If true, component will be disabled. */
   disabled: PropTypes.bool,
+  /** The element to render. */
+  element: PropTypes.oneOf(['a', 'button']),
   /** The icon to display on the left side of the label. */
   icon: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   /** The text used as the label for the component. */
@@ -87,6 +97,7 @@ MenuItem.defaultProps = {
   className: '',
   destructive: false,
   disabled: false,
+  element: 'button',
   selected: false,
 };
 

--- a/src/components/menu/theme.css
+++ b/src/components/menu/theme.css
@@ -9,6 +9,7 @@
   --menu-padding: calc(0.6 * var(--unit)) 0;
   --menu-outline-border-radius: var(--border-radius-medium);
   --menu-outline-box-shadow: 0 0 0 1px color(var(--color-teal-darkest) a(24%));
+  --menu-item-background: var(--color-neutral-lightest);
   --menu-item-hover-background: var(--color-neutral-light);
   --menu-item-selected-background: var(--color-aqua-lightest);
   --menu-item-height: calc(3.6 * var(--unit));
@@ -127,9 +128,12 @@
 }
 
 .menu-item {
+  background-color: var(--menu-item-background);
+  border: 0;
   min-height: var(--menu-item-height);
   overflow: hidden;
   position: relative;
+  text-decoration: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -140,13 +144,25 @@
     cursor: pointer;
   }
 
+  &:not(.is-disabled):not(.is-selected):focus {
+    background-color: var(--menu-item-hover-background);
+  }
+
+  &:hover {
+    text-decoration: none;
+  }
+
+  &:focus {
+    z-index: 1;
+  }
+
   &.is-disabled {
     pointer-events: none;
+    outline: 0;
   }
 
   &.is-selected {
     background-color: var(--menu-item-selected-background);
-    font-weight: 500;
   }
 }
 

--- a/stories/menu.js
+++ b/stories/menu.js
@@ -9,7 +9,7 @@ const avatar = <Avatar imageUrl={avatars[0].image} size="tiny" shape="circle" />
 const positions = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
 
 storiesOf('Menus', module)
-  .add('Menu', () => (
+  .add('Menu with buttons', () => (
     <Menu selectable={boolean('Selectable', false)} selected="bar">
       <MenuItem value="foo" label="Foo label" caption="This is foo's caption" />
       <MenuItem value="bar" label="Bar label" caption="Caption of bar" />
@@ -18,9 +18,59 @@ storiesOf('Menus', module)
       <MenuItem label="Label & avatar" icon={avatar} />
       <MenuDivider />
       <MenuTitle>Group title</MenuTitle>
-      <MenuItem label="Label & icon" icon={<IconClockSmallOutline />} />
+      <MenuItem label="Label & icon" icon={<IconClockSmallOutline />} onClick={() => console.log('You clicked me!')} />
       <MenuItem label="Destructive" icon={<IconTrashSmallOutline />} destructive />
       <MenuItem label="Destructive & disabled" icon={<IconTrashSmallOutline />} destructive disabled />
+    </Menu>
+  ))
+  .add('Menu with anchors', () => (
+    <Menu selectable={boolean('Selectable', false)} selected="bar">
+      <MenuItem
+        element="a"
+        href="https://teamleader.eu"
+        target="_blank"
+        value="foo"
+        label="Foo label"
+        caption="This is foo's caption"
+      />
+      <MenuItem
+        element="a"
+        href="https://teamleader.eu"
+        target="_blank"
+        value="bar"
+        label="Bar label"
+        caption="Caption of bar"
+      />
+      <MenuItem element="a" href="https://teamleader.eu" target="_blank" label="Disabled ..." disabled />
+      <MenuDivider />
+      <MenuItem element="a" href="https://teamleader.eu" target="_blank" label="Label & avatar" icon={avatar} />
+      <MenuDivider />
+      <MenuTitle>Group title</MenuTitle>
+      <MenuItem
+        element="a"
+        href="https://teamleader.eu"
+        target="_blank"
+        label="Label & icon"
+        icon={<IconClockSmallOutline />}
+        onClick={() => console.log('You clicked me!')}
+      />
+      <MenuItem
+        element="a"
+        href="https://teamleader.eu"
+        target="_blank"
+        label="Destructive"
+        icon={<IconTrashSmallOutline />}
+        destructive
+      />
+      <MenuItem
+        element="a"
+        href="https://teamleader.eu"
+        target="_blank"
+        label="Destructive & disabled"
+        icon={<IconTrashSmallOutline />}
+        destructive
+        disabled
+      />
     </Menu>
   ))
   .add('IconMenu', () => (


### PR DESCRIPTION
### Description

This PR adds an `element` prop which accepts either a `button` (default value) or an `anchor tag`. I also needed to adjust the markup and styling to make sure it still looks like the intended design.

Also, I made it keyboard accessible:

![Screenshot 2019-11-21 10 37 09](https://user-images.githubusercontent.com/5336831/69328995-89616580-0c50-11ea-8403-b2b07caaf64c.png)

### Breaking changes

None.