### PR TITLE
Typography: TextBodyCompact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `MenuItem`: render a `button` or `a`-tag depending on the `element` prop. ([@driesd](https://github.com/driesd) in [#721](https://github.com/teamleadercrm/ui/pull/721))
 - `Typography`: added `Heading5`. ([@driesd](https://github.com/driesd) in [#722](https://github.com/teamleadercrm/ui/pull/722))
+- `Typography`: added `TextBodyCompact`. ([@driesd](https://github.com/driesd) in [#724](https://github.com/teamleadercrm/ui/pull/724))
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@teamleader/ui-colors": "^0.0.7",
     "@teamleader/ui-icons": "^0.2.17",
     "@teamleader/ui-illustrations": "^0.0.23",
-    "@teamleader/ui-typography": "^0.2.2",
+    "@teamleader/ui-typography": "^0.2.3",
     "@teamleader/ui-utilities": "^0.2.0",
     "classnames": "^2.2.5",
     "lodash.omit": "^4.5.0",

--- a/src/components/typography/index.js
+++ b/src/components/typography/index.js
@@ -9,6 +9,7 @@ const Heading5 = textFactory('heading', 'heading-5', 'h5');
 
 const TextDisplay = textFactory('text', 'text-display', 'p');
 const TextBody = textFactory('text', 'text-body', 'p');
+const TextBodyCompact = textFactory('text', 'text-body-compact', 'p');
 const TextSmall = textFactory('text', 'text-small', 'p');
 
 Heading1.displayName = 'Heading1';
@@ -18,6 +19,18 @@ Heading4.displayName = 'Heading4';
 Heading5.displayName = 'Heading5';
 TextDisplay.displayName = 'TextDisplay';
 TextBody.displayName = 'TextBody';
+TextBodyCompact.displayName = 'TextBodyCompact';
 TextSmall.displayName = 'TextSmall';
 
-export { Heading1, Heading2, Heading3, Heading4, Heading5, Monospaced, TextBody, TextDisplay, TextSmall };
+export {
+  Heading1,
+  Heading2,
+  Heading3,
+  Heading4,
+  Heading5,
+  Monospaced,
+  TextBody,
+  TextBodyCompact,
+  TextDisplay,
+  TextSmall,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import {
   Heading5,
   Monospaced,
   TextBody,
+  TextBodyCompact,
   TextDisplay,
   TextSmall,
 } from './components/typography';
@@ -131,6 +132,7 @@ export {
   StatusBullet,
   StatusLabel,
   TextBody,
+  TextBodyCompact,
   TextDisplay,
   TextSmall,
   TabGroup,

--- a/stories/typography.js
+++ b/stories/typography.js
@@ -12,6 +12,7 @@ import {
   Heading5,
   Monospaced,
   TextBody,
+  TextBodyCompact,
   TextDisplay,
   TextSmall,
 } from '../src';
@@ -72,23 +73,31 @@ storiesOf('Typography', module)
         ellipsis={boolean('Overflow ellipsis', false)}
         tint={select('Tint', TINTS, 'darkest')}
       >
-        Text display / font-size: 16px / line-height: 24px / weight: regular (400) / tracking: 0
+        <strong>Text display</strong> / font-size: 16px / line-height: 24px / weight: regular (400) / tracking: 0
       </TextDisplay>
       <TextBody
         color={select('Color', COLORS, 'teal')}
         ellipsis={boolean('Overflow ellipsis', false)}
         tint={select('Tint', TINTS, 'darkest')}
-        marginTop={2}
+        marginTop={4}
       >
-        Text body / font-size: 14px / line-height: 21px / weight: regular (400) / tracking: 0
+        <strong>Text body</strong> / font-size: 14px / line-height: 21px / weight: regular (400) / tracking: 0
       </TextBody>
+      <TextBodyCompact
+        color={select('Color', COLORS, 'teal')}
+        ellipsis={boolean('Overflow ellipsis', false)}
+        tint={select('Tint', TINTS, 'darkest')}
+        marginTop={4}
+      >
+        <strong>Text body compact</strong> / font-size: 14px / line-height: 18px / weight: regular (400) / tracking: 0
+      </TextBodyCompact>
       <TextSmall
         color={select('Color', COLORS, 'teal')}
         ellipsis={boolean('Overflow ellipsis', false)}
         tint={select('Tint', TINTS, 'darkest')}
-        marginTop={2}
+        marginTop={4}
       >
-        Text small / font-size: 12px / line-height: 18px / weight: regular (400) / tracking: 0
+        <strong>Text small</strong> / font-size: 12px / line-height: 18px / weight: regular (400) / tracking: 0
       </TextSmall>
     </Box>
   ))


### PR DESCRIPTION
### Description

This PR adds a `TextBodyCompact` component. Same as `TextBody`, but it has a `line-height` of `18px` instead of 21px.

#### Screenshot
<img width="624" alt="Screenshot 2019-11-22 11 25 35" src="https://user-images.githubusercontent.com/5336831/69418361-d1e55580-0d1a-11ea-9ae3-31ba33672ccf.png">

### Breaking changes

None.
