### PR TITLE
Release 0.31.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ### Added
 
-- `MenuItem`: render a `button` or `a`-tag depending on the `element` prop. ([@driesd](https://github.com/driesd) in [#721](https://github.com/teamleadercrm/ui/pull/721))
-- `Typography`: added `Heading5`. ([@driesd](https://github.com/driesd) in [#722](https://github.com/teamleadercrm/ui/pull/722))
-- `Typography`: added `TextBodyCompact`. ([@driesd](https://github.com/driesd) in [#724](https://github.com/teamleadercrm/ui/pull/724))
-
 ### Changed
 
 ### Deprecated
@@ -15,6 +11,21 @@
 ### Fixed
 
 ### Dependency updates
+
+## [0.31.4] - 2019-11-22
+
+### Added
+
+- `MenuItem`: render a `button` or `a`-tag depending on the `element` prop. ([@driesd](https://github.com/driesd) in [#721](https://github.com/teamleadercrm/ui/pull/721))
+- `Typography`: added `Heading5`. ([@driesd](https://github.com/driesd) in [#722](https://github.com/teamleadercrm/ui/pull/722))
+- `Typography`: added `TextBodyCompact`. ([@driesd](https://github.com/driesd) in [#724](https://github.com/teamleadercrm/ui/pull/724))
+
+### Dependency updates
+
+- `@teamleader/ui-illustrations` from `0.0.22` to `0.0.23`
+- `@teamleader/ui-typography` from `0.2.1` to `0.2.3`
+- `@teamleader/ui-utilities` from `0.1.2` to `0.2.0`
+- `prettier` from `1.18.2` to `1.19.1`
 
 ## [0.31.3] - 2019-11-07
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Added

- `MenuItem`: render a `button` or `a`-tag depending on the `element` prop. ([@driesd](https://github.com/driesd) in [#721](https://github.com/teamleadercrm/ui/pull/721))
- `Typography`: added `Heading5`. ([@driesd](https://github.com/driesd) in [#722](https://github.com/teamleadercrm/ui/pull/722))
- `Typography`: added `TextBodyCompact`. ([@driesd](https://github.com/driesd) in [#724](https://github.com/teamleadercrm/ui/pull/724))

### Dependency updates

- `@teamleader/ui-illustrations` from `0.0.22` to `0.0.23`
- `@teamleader/ui-typography` from `0.2.1` to `0.2.3`
- `@teamleader/ui-utilities` from `0.1.2` to `0.2.0`
- `prettier` from `1.18.2` to `1.19.1`
