### PR TITLE
Fix _blank click on core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `MenuItem`: when element is `a` the text container gets `pointer-events: none` ([@kevinwaelkens](https://github.com/kevinwaelkens) in [#727](https://github.com/teamleadercrm/ui/pull/727))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -54,7 +54,12 @@ class MenuItem extends PureComponent {
               {icon}
             </Icon>
           )}
-          <Box flex="1 0 auto">
+          <Box
+            className={cx({
+              [theme['menu-item-text-container']]: element === 'a',
+            })}
+            flex="1 0 auto"
+          >
             {label && (
               <TextBody color={color} tint={tint}>
                 {label}

--- a/src/components/menu/theme.css
+++ b/src/components/menu/theme.css
@@ -184,3 +184,7 @@
   -ms-user-select: none;
   user-select: none;
 }
+
+.menu-item-text-container {
+  pointer-events: none;
+}


### PR DESCRIPTION
### Description

On core, clicking on a menu item which has the `a` element would append the `href` to the current URL you were on. This only happened when clicking on the `div`/`p` element. When you clicked on the wrapping `a` tag (on the margin of it) it would open in a new tab, which is desired behaviour.

So because, for some reason on core, the `div`/`p` tag are doing something we don't want on click we should pass `pointer-events: none` on it.  (Or we could scour through the core codebase to check where the annoying part is, but that sounds very time-intensive.)

### Breaking changes

- none