### PR TITLE
✨Tooltip: delayed enter and new onTooltipEnter prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - [BREAKING] `Node version`: the minimum required node version is now `10.13.0`
+- `Tooltip`: Added a delay of 100ms when initially showing the tooltip, and added a new prop `onTooltipEnter` which gets triggered after the tooltip is mounted. [@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#730](https://github.com/teamleadercrm/ui/pull/730)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - [BREAKING] `Node version`: the minimum required node version is now `10.13.0`
-- `Tooltip`: Added a delay of 100ms when initially showing the tooltip, and added a new prop `onTooltipEnter` which gets triggered after the tooltip is mounted. [@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#730](https://github.com/teamleadercrm/ui/pull/730)
+- `Tooltip`: Added a delay of 100ms when initially showing the tooltip, and added a new prop `onTooltipEnter` which gets triggered after the tooltip is mounted. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#730](https://github.com/teamleadercrm/ui/pull/730))
 
 ### Deprecated
 

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -161,7 +161,11 @@ const Tooltip = ComposedComponent => {
         childProps,
         children,
         createPortal(
-          <Transition in={active} onExited={this.handleTransitionExited} timeout={{ enter: 0, exit: 1000 }}>
+          <Transition
+            in={active}
+            onExited={this.handleTransitionExited}
+            timeout={{ enter: 100, exit: 1000 }}
+          >
             {state => {
               const classNames = cx(
                 uiUtilities['box-shadow-200'],

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -134,6 +134,11 @@ const Tooltip = ComposedComponent => {
       this.props.documentObject.body.removeChild(this.tooltipRoot);
     };
 
+    handleTransitionEntered = () => {
+      const { onTooltipEntered } = this.props;
+      onTooltipEntered && onTooltipEntered();
+    };
+
     render() {
       const { active, left, top, position } = this.state;
       const { children, className, tooltip, tooltipColor, tooltipIcon, tooltipSize, ...other } = this.props;
@@ -142,6 +147,7 @@ const Tooltip = ComposedComponent => {
         'onClick',
         'onMouseEnter',
         'onMouseLeave',
+        'onTooltipEntered',
         'tooltipHideOnClick',
         'tooltipPosition',
         'tooltipShowOnClick',
@@ -164,6 +170,7 @@ const Tooltip = ComposedComponent => {
           <Transition
             in={active}
             onExited={this.handleTransitionExited}
+            onEntered={this.handleTransitionEntered}
             timeout={{ enter: 100, exit: 1000 }}
           >
             {state => {
@@ -202,6 +209,7 @@ const Tooltip = ComposedComponent => {
     onClick: PropTypes.func,
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
+    onTooltipEntered: PropTypes.func,
     tooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     tooltipColor: PropTypes.oneOf(['white', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'inverse']),
     tooltipHideOnClick: PropTypes.bool,


### PR DESCRIPTION
### Description

Added a delay of 100ms when initially showing the tooltip, and added a new prop `onTooltipEnter` which gets triggered after the tooltip is mounted. An example use case for this event is tracking.
