### PR TITLE
🔖Correct the version tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,14 @@
 
 ## [0.31.6] - 2019-12-02
 
+### Changed
+
 - [BREAKING] `Node version`: the minimum required node version is now `10.13.0`
+
+## [0.31.6] - 2019-12-02
+
+### Changed
+
 - `Tooltip`: Added a delay of 100ms when initially showing the tooltip, and added a new prop `onTooltipEnter` which gets triggered after the tooltip is mounted. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#730](https://github.com/teamleadercrm/ui/pull/730))
 - `Build process & dependency resolution`: changed from npm to yarn, added yarn.lock ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#731](https://github.com/teamleadercrm/ui/pull/731))
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.31.6",
+  "version": "0.32.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Description

The node version was a breaking change, so we need a minor version bump for it.
### Breaking changes

- `Node version`: the minimum required node version is now `10.13.0`
