### PR TITLE
Avatar: anonymous user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- [BREAKING] `Avatar`: added `creatable` prop with default value `false`. ([@driesd](https://github.com/driesd) in [#735](https://github.com/teamleadercrm/ui/pull/735))
+- `Avatar`: added `creatable` prop with default value `false`. ([@driesd](https://github.com/driesd) in [#735](https://github.com/teamleadercrm/ui/pull/735))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### Changed
 
+- [BREAKING] `Avatar`: added `creatable` prop with default value `false`. ([@driesd](https://github.com/driesd) in [#735](https://github.com/teamleadercrm/ui/pull/735))
+
 ### Deprecated
 
 ### Removed
+
+- [BREAKING] `Avatar`: removed `imageClassName` prop from the internally used `AvatarImage` component. ([@driesd](https://github.com/driesd) in [#735](https://github.com/teamleadercrm/ui/pull/735))
 
 ### Fixed
 

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -35,6 +35,8 @@ class Avatar extends PureComponent {
 }
 
 Avatar.propTypes = {
+  /** If true, an add user icon will be shown. */
+  creatable: PropTypes.bool,
   /** If true, an overlay will be shown with edit icon. */
   editable: PropTypes.bool,
   /** The image url to show as an avatar. */
@@ -52,6 +54,7 @@ Avatar.propTypes = {
 };
 
 Avatar.defaultProps = {
+  creatable: false,
   shape: 'circle',
   size: 'medium',
 };

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -8,13 +8,6 @@ import AvatarOverlay from './AvatarOverlay';
 import Box, { pickBoxProps, omitBoxProps } from '../box';
 import cx from 'classnames';
 import theme from './theme.css';
-import { colorsWithout } from '../../constants';
-
-const colors = colorsWithout(['neutral']);
-
-const hashCode = hexString => parseInt(hexString.substr(-5), 16);
-
-const getColor = id => (id ? colors[Math.abs(hashCode(id)) % colors.length] : 'neutral');
 
 class Avatar extends PureComponent {
   renderComponent = () => {
@@ -30,7 +23,7 @@ class Avatar extends PureComponent {
     }
 
     if (fullName && id) {
-      return <AvatarInitials color={getColor(id)} name={fullName} {...propsWithoutBoxProps} />;
+      return <AvatarInitials id={id} name={fullName} {...propsWithoutBoxProps} />;
     }
 
     return <AvatarAnonymous {...propsWithoutBoxProps} />;

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -68,6 +68,10 @@ class Avatar extends PureComponent {
 }
 
 Avatar.propTypes = {
+  /** Component that will be placed top right of the avatar image. */
+  children: PropTypes.any,
+  /** A class name for the wrapper to give custom styles. */
+  className: PropTypes.string,
   /** If true, an add user icon will be shown. */
   creatable: PropTypes.bool,
   /** If true, an overlay will be shown with edit icon. */
@@ -88,6 +92,7 @@ Avatar.propTypes = {
 
 Avatar.defaultProps = {
   creatable: false,
+  editable: false,
   shape: 'circle',
   size: 'medium',
 };

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -4,14 +4,13 @@ import AvatarAdd from './AvatarAdd';
 import AvatarAnonymous from './AvatarAnonymous';
 import AvatarImage from './AvatarImage';
 import AvatarInitials from './AvatarInitials';
-import AvatarOverlay from './AvatarOverlay';
 import Box, { pickBoxProps, omitBoxProps } from '../box';
 import cx from 'classnames';
 import theme from './theme.css';
 
 class Avatar extends PureComponent {
   renderComponent = () => {
-    const { creatable, imageUrl, fullName, id, ...others } = this.props;
+    const { creatable, editable, imageUrl, fullName, id, onImageChange, ...others } = this.props;
     const propsWithoutBoxProps = omitBoxProps(others);
 
     if (creatable) {
@@ -19,25 +18,40 @@ class Avatar extends PureComponent {
     }
 
     if (imageUrl) {
-      return <AvatarImage image={imageUrl} imageAlt={fullName} {...propsWithoutBoxProps} />;
+      return (
+        <AvatarImage
+          editable={editable}
+          image={imageUrl}
+          imageAlt={fullName}
+          onImageChange={onImageChange}
+          {...propsWithoutBoxProps}
+        />
+      );
     }
 
     if (fullName && id) {
-      return <AvatarInitials id={id} name={fullName} {...propsWithoutBoxProps} />;
+      return (
+        <AvatarInitials
+          editable={editable}
+          id={id}
+          name={fullName}
+          onImageChange={onImageChange}
+          {...propsWithoutBoxProps}
+        />
+      );
     }
 
     return <AvatarAnonymous {...propsWithoutBoxProps} />;
   };
 
   render() {
-    const { className, editable, imageUrl, fullName, id, onImageChange, size, shape, ...others } = this.props;
+    const { className, size, shape, ...others } = this.props;
     const avatarClassNames = cx(theme['avatar'], theme[`is-${size}`], theme[`is-${shape}`], className);
     const boxProps = pickBoxProps(others);
 
     return (
       <Box className={avatarClassNames} {...boxProps}>
         {this.renderComponent()}
-        {editable && (size === 'large' || size === 'hero') && <AvatarOverlay onClick={onImageChange} />}
       </Box>
     );
   }

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -1,5 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import AvatarAdd from './AvatarAdd';
+import AvatarAnonymous from './AvatarAnonymous';
 import AvatarImage from './AvatarImage';
 import AvatarInitials from './AvatarInitials';
 import AvatarOverlay from './AvatarOverlay';
@@ -15,19 +17,33 @@ const hashCode = hexString => parseInt(hexString.substr(-5), 16);
 const getColor = id => (id ? colors[Math.abs(hashCode(id)) % colors.length] : 'neutral');
 
 class Avatar extends PureComponent {
+  renderComponent = () => {
+    const { creatable, imageUrl, fullName, id, ...others } = this.props;
+    const propsWithoutBoxProps = omitBoxProps(others);
+
+    if (creatable) {
+      return <AvatarAdd {...propsWithoutBoxProps} />;
+    }
+
+    if (imageUrl) {
+      return <AvatarImage image={imageUrl} imageAlt={fullName} {...propsWithoutBoxProps} />;
+    }
+
+    if (fullName && id) {
+      return <AvatarInitials color={getColor(id)} name={fullName} {...propsWithoutBoxProps} />;
+    }
+
+    return <AvatarAnonymous {...propsWithoutBoxProps} />;
+  };
+
   render() {
     const { className, editable, imageUrl, fullName, id, onImageChange, size, shape, ...others } = this.props;
     const avatarClassNames = cx(theme['avatar'], theme[`is-${size}`], theme[`is-${shape}`], className);
     const boxProps = pickBoxProps(others);
-    const propsWithoutBoxProps = omitBoxProps(others);
 
     return (
       <Box className={avatarClassNames} {...boxProps}>
-        {imageUrl ? (
-          <AvatarImage image={imageUrl} imageAlt={fullName} {...propsWithoutBoxProps} />
-        ) : (
-          <AvatarInitials color={getColor(id)} name={fullName} {...propsWithoutBoxProps} />
-        )}
+        {this.renderComponent()}
         {editable && (size === 'large' || size === 'hero') && <AvatarOverlay onClick={onImageChange} />}
       </Box>
     );

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -4,16 +4,17 @@ import AvatarAdd from './AvatarAdd';
 import AvatarAnonymous from './AvatarAnonymous';
 import AvatarImage from './AvatarImage';
 import AvatarInitials from './AvatarInitials';
-import Box, { pickBoxProps } from '../box';
+import Box from '../box';
 import cx from 'classnames';
 import theme from './theme.css';
+import omit from 'lodash.omit';
 
 class Avatar extends PureComponent {
   renderComponent = () => {
     const { creatable, children, editable, imageUrl, fullName, id, onImageChange, size } = this.props;
 
     if (creatable) {
-      return <AvatarAdd size={size} />;
+      return <AvatarAdd children={children} size={size} />;
     }
 
     if (imageUrl) {
@@ -42,16 +43,24 @@ class Avatar extends PureComponent {
       );
     }
 
-    return <AvatarAnonymous size={size} />;
+    return <AvatarAnonymous children={children} size={size} />;
   };
 
   render() {
     const { className, size, shape, ...others } = this.props;
     const avatarClassNames = cx(theme['avatar'], theme[`is-${size}`], theme[`is-${shape}`], className);
-    const boxProps = pickBoxProps(others);
+    const restProps = omit(others, [
+      'children',
+      'creatable',
+      'editable',
+      'imageUrl',
+      'fullName',
+      'id',
+      'onImageChange',
+    ]);
 
     return (
-      <Box className={avatarClassNames} {...boxProps}>
+      <Box className={avatarClassNames} {...restProps}>
         {this.renderComponent()}
       </Box>
     );

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -4,27 +4,27 @@ import AvatarAdd from './AvatarAdd';
 import AvatarAnonymous from './AvatarAnonymous';
 import AvatarImage from './AvatarImage';
 import AvatarInitials from './AvatarInitials';
-import Box, { pickBoxProps, omitBoxProps } from '../box';
+import Box, { pickBoxProps } from '../box';
 import cx from 'classnames';
 import theme from './theme.css';
 
 class Avatar extends PureComponent {
   renderComponent = () => {
-    const { creatable, editable, imageUrl, fullName, id, onImageChange, ...others } = this.props;
-    const propsWithoutBoxProps = omitBoxProps(others);
+    const { creatable, children, editable, imageUrl, fullName, id, onImageChange, size } = this.props;
 
     if (creatable) {
-      return <AvatarAdd {...propsWithoutBoxProps} />;
+      return <AvatarAdd size={size} />;
     }
 
     if (imageUrl) {
       return (
         <AvatarImage
+          children={children}
           editable={editable}
           image={imageUrl}
           imageAlt={fullName}
           onImageChange={onImageChange}
-          {...propsWithoutBoxProps}
+          size={size}
         />
       );
     }
@@ -32,16 +32,17 @@ class Avatar extends PureComponent {
     if (fullName && id) {
       return (
         <AvatarInitials
+          children={children}
           editable={editable}
           id={id}
           name={fullName}
           onImageChange={onImageChange}
-          {...propsWithoutBoxProps}
+          size={size}
         />
       );
     }
 
-    return <AvatarAnonymous {...propsWithoutBoxProps} />;
+    return <AvatarAnonymous size={size} />;
   };
 
   render() {

--- a/src/components/avatar/AvatarAdd.js
+++ b/src/components/avatar/AvatarAdd.js
@@ -1,0 +1,32 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import theme from './theme.css';
+import Box from '../box';
+import Icon from '../icon';
+import { IconUserAddMediumOutline, IconUserAddSmallOutline } from '@teamleader/ui-icons';
+
+class AvatarAdd extends PureComponent {
+  render() {
+    const { size } = this.props;
+
+    return (
+      <Box
+        backgroundColor="neutral"
+        backgroundTint="normal"
+        className={theme['avatar-add']}
+        data-teamleader-ui="avatar-add"
+      >
+        <Icon color="neutral" tint="darkest">
+          {size === 'tiny' || size === 'small' ? <IconUserAddSmallOutline /> : <IconUserAddMediumOutline />}
+        </Icon>
+      </Box>
+    );
+  }
+}
+
+AvatarAdd.propTypes = {
+  /** The size of the avatar. */
+  size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'hero']),
+};
+
+export default AvatarAdd;

--- a/src/components/avatar/AvatarAdd.js
+++ b/src/components/avatar/AvatarAdd.js
@@ -7,7 +7,7 @@ import { IconUserAddMediumOutline, IconUserAddSmallOutline } from '@teamleader/u
 
 class AvatarAdd extends PureComponent {
   render() {
-    const { size } = this.props;
+    const { children, size } = this.props;
 
     return (
       <Box
@@ -19,6 +19,7 @@ class AvatarAdd extends PureComponent {
         <Icon color="neutral" tint="darkest">
           {size === 'tiny' || size === 'small' ? <IconUserAddSmallOutline /> : <IconUserAddMediumOutline />}
         </Icon>
+        {children && <div className={theme['children']}>{children}</div>}
       </Box>
     );
   }

--- a/src/components/avatar/AvatarAdd.js
+++ b/src/components/avatar/AvatarAdd.js
@@ -26,6 +26,8 @@ class AvatarAdd extends PureComponent {
 }
 
 AvatarAdd.propTypes = {
+  /** Component that will be placed top right of the avatar image. */
+  children: PropTypes.any,
   /** The size of the avatar. */
   size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'hero']),
 };

--- a/src/components/avatar/AvatarAnonymous.js
+++ b/src/components/avatar/AvatarAnonymous.js
@@ -7,7 +7,7 @@ import { IconUserMediumOutline, IconUserSmallOutline } from '@teamleader/ui-icon
 
 class AvatarAnonymous extends PureComponent {
   render() {
-    const { size } = this.props;
+    const { children, size } = this.props;
 
     return (
       <Box
@@ -19,6 +19,7 @@ class AvatarAnonymous extends PureComponent {
         <Icon color="neutral" tint="darkest">
           {size === 'tiny' || size === 'small' ? <IconUserSmallOutline /> : <IconUserMediumOutline />}
         </Icon>
+        {children && <div className={theme['children']}>{children}</div>}
       </Box>
     );
   }

--- a/src/components/avatar/AvatarAnonymous.js
+++ b/src/components/avatar/AvatarAnonymous.js
@@ -1,0 +1,32 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import theme from './theme.css';
+import Box from '../box';
+import Icon from '../icon';
+import { IconUserMediumOutline, IconUserSmallOutline } from '@teamleader/ui-icons';
+
+class AvatarAnonymous extends PureComponent {
+  render() {
+    const { size } = this.props;
+
+    return (
+      <Box
+        backgroundColor="neutral"
+        backgroundTint="normal"
+        className={theme['avatar-anonymous']}
+        data-teamleader-ui="avatar-anonymous"
+      >
+        <Icon color="neutral" tint="darkest">
+          {size === 'tiny' || size === 'small' ? <IconUserSmallOutline /> : <IconUserMediumOutline />}
+        </Icon>
+      </Box>
+    );
+  }
+}
+
+AvatarAnonymous.propTypes = {
+  /** The size of the avatar. */
+  size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'hero']),
+};
+
+export default AvatarAnonymous;

--- a/src/components/avatar/AvatarAnonymous.js
+++ b/src/components/avatar/AvatarAnonymous.js
@@ -26,6 +26,8 @@ class AvatarAnonymous extends PureComponent {
 }
 
 AvatarAnonymous.propTypes = {
+  /** Component that will be placed top right of the avatar image. */
+  children: PropTypes.any,
   /** The size of the avatar. */
   size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'hero']),
 };

--- a/src/components/avatar/AvatarImage.js
+++ b/src/components/avatar/AvatarImage.js
@@ -2,14 +2,16 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import theme from './theme.css';
+import AvatarOverlay from './AvatarOverlay';
 
 class AvatarImage extends PureComponent {
   render() {
-    const { children, image, imageAlt, imageClassName, ...others } = this.props;
+    const { children, editable, image, imageAlt, imageClassName, onImageChange, size, ...others } = this.props;
 
     return (
       <div className={theme['avatar-image']} {...others} data-teamleader-ui="avatar-image">
         <img alt={imageAlt} src={image} className={cx(theme['image'], imageClassName)} />
+        {editable && (size === 'large' || size === 'hero') && <AvatarOverlay onClick={onImageChange} />}
         {children && <div className={theme['children']}>{children}</div>}
       </div>
     );

--- a/src/components/avatar/AvatarImage.js
+++ b/src/components/avatar/AvatarImage.js
@@ -20,10 +20,16 @@ class AvatarImage extends PureComponent {
 AvatarImage.propTypes = {
   /** Component that will be placed top right of the avatar image. */
   children: PropTypes.any,
+  /** If true, an overlay will be shown with edit icon. */
+  editable: PropTypes.bool,
   /** An image source or an image element. */
   image: PropTypes.string,
   /** An alternative text for the image element. */
   imageAlt: PropTypes.string,
+  /** Callback function that is fired when user clicks the edit icon. */
+  onImageChange: PropTypes.func,
+  /** The size of the avatar. */
+  size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'hero']),
 };
 
 export default AvatarImage;

--- a/src/components/avatar/AvatarImage.js
+++ b/src/components/avatar/AvatarImage.js
@@ -1,16 +1,15 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import cx from 'classnames';
 import theme from './theme.css';
 import AvatarOverlay from './AvatarOverlay';
 
 class AvatarImage extends PureComponent {
   render() {
-    const { children, editable, image, imageAlt, imageClassName, onImageChange, size } = this.props;
+    const { children, editable, image, imageAlt, onImageChange, size } = this.props;
 
     return (
       <div className={theme['avatar-image']} data-teamleader-ui="avatar-image">
-        <img alt={imageAlt} src={image} className={cx(theme['image'], imageClassName)} />
+        <img alt={imageAlt} src={image} className={theme['image']} />
         {editable && (size === 'large' || size === 'hero') && <AvatarOverlay onClick={onImageChange} />}
         {children && <div className={theme['children']}>{children}</div>}
       </div>
@@ -25,8 +24,6 @@ AvatarImage.propTypes = {
   image: PropTypes.string,
   /** An alternative text for the image element. */
   imageAlt: PropTypes.string,
-  /** A class name for the image to give custom styles. */
-  imageClassName: PropTypes.string,
 };
 
 export default AvatarImage;

--- a/src/components/avatar/AvatarImage.js
+++ b/src/components/avatar/AvatarImage.js
@@ -6,10 +6,10 @@ import AvatarOverlay from './AvatarOverlay';
 
 class AvatarImage extends PureComponent {
   render() {
-    const { children, editable, image, imageAlt, imageClassName, onImageChange, size, ...others } = this.props;
+    const { children, editable, image, imageAlt, imageClassName, onImageChange, size } = this.props;
 
     return (
-      <div className={theme['avatar-image']} {...others} data-teamleader-ui="avatar-image">
+      <div className={theme['avatar-image']} data-teamleader-ui="avatar-image">
         <img alt={imageAlt} src={image} className={cx(theme['image'], imageClassName)} />
         {editable && (size === 'large' || size === 'hero') && <AvatarOverlay onClick={onImageChange} />}
         {children && <div className={theme['children']}>{children}</div>}

--- a/src/components/avatar/AvatarInitials.js
+++ b/src/components/avatar/AvatarInitials.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import theme from './theme.css';
+import AvatarOverlay from './AvatarOverlay';
 import Box from '../box';
 import { Heading4 } from '../typography';
 import { colorsWithout } from '../../constants';
@@ -31,7 +32,7 @@ class AvatarInitials extends PureComponent {
   };
 
   render() {
-    const { children, color, shape, ...others } = this.props;
+    const { children, color, editable, onImageChange, size, shape, ...others } = this.props;
 
     return (
       <Box
@@ -42,6 +43,7 @@ class AvatarInitials extends PureComponent {
         data-teamleader-ui="avatar-initials"
       >
         <Heading4 className={theme['initials']}>{this.getInitials()}</Heading4>
+        {editable && (size === 'large' || size === 'hero') && <AvatarOverlay onClick={onImageChange} />}
         {children && <div className={theme['children']}>{children}</div>}
       </Box>
     );

--- a/src/components/avatar/AvatarInitials.js
+++ b/src/components/avatar/AvatarInitials.js
@@ -52,7 +52,7 @@ class AvatarInitials extends PureComponent {
 AvatarInitials.propTypes = {
   /** Component that will be placed top right of the avatar image. */
   children: PropTypes.any,
-  /** The uui to determine the background color of the avatar. */
+  /** The uuid to determine the background color of the avatar. */
   id: PropTypes.string,
   /** The name for in the avatar. */
   name: PropTypes.string,

--- a/src/components/avatar/AvatarInitials.js
+++ b/src/components/avatar/AvatarInitials.js
@@ -2,10 +2,23 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import theme from './theme.css';
 import Box from '../box';
-import { COLORS } from '../../constants';
 import { Heading4 } from '../typography';
+import { colorsWithout } from '../../constants';
+
+const colors = colorsWithout(['neutral']);
+const hashCode = hexString => parseInt(hexString.substr(-5), 16);
 
 class AvatarInitials extends PureComponent {
+  getColor = () => {
+    const { id } = this.props;
+
+    if (!id) {
+      return 'neutral';
+    }
+
+    return colors[Math.abs(hashCode(id)) % colors.length];
+  };
+
   getInitials = () => {
     const { name } = this.props;
     const splitName = name.split(' ');
@@ -23,7 +36,7 @@ class AvatarInitials extends PureComponent {
     return (
       <Box
         {...others}
-        backgroundColor={color}
+        backgroundColor={this.getColor()}
         backgroundTint="normal"
         className={theme['avatar-initials']}
         data-teamleader-ui="avatar-initials"
@@ -38,14 +51,13 @@ class AvatarInitials extends PureComponent {
 AvatarInitials.propTypes = {
   /** Component that will be placed top right of the avatar image. */
   children: PropTypes.any,
-  /** The color of the avatar. */
-  color: PropTypes.oneOf(COLORS),
+  /** The uui to determine the background color of the avatar. */
+  id: PropTypes.string,
   /** The name for in the avatar. */
   name: PropTypes.string,
 };
 
 AvatarInitials.defaultProps = {
-  color: 'neutral',
   name: 'Michael Scott',
 };
 

--- a/src/components/avatar/AvatarInitials.js
+++ b/src/components/avatar/AvatarInitials.js
@@ -32,11 +32,10 @@ class AvatarInitials extends PureComponent {
   };
 
   render() {
-    const { children, color, editable, onImageChange, size, shape, ...others } = this.props;
+    const { children, editable, onImageChange, size } = this.props;
 
     return (
       <Box
-        {...others}
         backgroundColor={this.getColor()}
         backgroundTint="normal"
         className={theme['avatar-initials']}

--- a/src/components/avatar/AvatarInitials.js
+++ b/src/components/avatar/AvatarInitials.js
@@ -1,7 +1,8 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import cx from 'classnames';
 import theme from './theme.css';
+import Box from '../box';
+import { COLORS } from '../../constants';
 import { Heading4 } from '../typography';
 
 class AvatarInitials extends PureComponent {
@@ -18,13 +19,18 @@ class AvatarInitials extends PureComponent {
 
   render() {
     const { children, color, shape, ...others } = this.props;
-    const avatarClassNames = cx(theme['avatar-initials'], theme[color]);
 
     return (
-      <div className={avatarClassNames} {...others} data-teamleader-ui="avatar-initials">
+      <Box
+        {...others}
+        backgroundColor={color}
+        backgroundTint="normal"
+        className={theme['avatar-initials']}
+        data-teamleader-ui="avatar-initials"
+      >
         <Heading4 className={theme['initials']}>{this.getInitials()}</Heading4>
         {children && <div className={theme['children']}>{children}</div>}
-      </div>
+      </Box>
     );
   }
 }
@@ -33,7 +39,7 @@ AvatarInitials.propTypes = {
   /** Component that will be placed top right of the avatar image. */
   children: PropTypes.any,
   /** The color of the avatar. */
-  color: PropTypes.oneOf(['neutral', 'mint', 'aqua', 'violet', 'teal', 'gold', 'ruby']),
+  color: PropTypes.oneOf(COLORS),
   /** The name for in the avatar. */
   name: PropTypes.string,
 };

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -109,6 +109,7 @@
   &.avatar,
   .avatar-image,
   .avatar-initials,
+  .avatar-anonymous,
   .image {
     height: var(--tiny-size);
     width: var(--tiny-size);
@@ -135,6 +136,7 @@
   &.avatar,
   .avatar-image,
   .avatar-initials,
+  .avatar-anonymous,
   .image {
     height: var(--small-size);
     width: var(--small-size);
@@ -157,6 +159,7 @@
   &.avatar,
   .avatar-image,
   .avatar-initials,
+  .avatar-anonymous,
   .image {
     height: var(--medium-size);
     width: var(--medium-size);
@@ -179,6 +182,7 @@
   &.avatar,
   .avatar-image,
   .avatar-initials,
+  .avatar-anonymous,
   .image {
     height: var(--large-size);
     width: var(--large-size);
@@ -205,6 +209,7 @@
   &.avatar,
   .avatar-image,
   .avatar-initials,
+  .avatar-anonymous,
   .image {
     height: var(--hero-size);
     width: var(--hero-size);
@@ -230,6 +235,7 @@
 .is-circle {
   .avatar-image .image,
   .avatar-initials,
+  .avatar-anonymous,
   .overlay {
     border-radius: var(--shape-circle-image-border-radius);
   }
@@ -237,7 +243,8 @@
 
 .is-rounded {
   .avatar-image .image,
-  .avatar-initials {
+  .avatar-initials,
+  .avatar-anonymous {
     border-radius: var(--shape-rounded-image-border-radius);
   }
 
@@ -258,4 +265,11 @@
     text-transform: uppercase;
     letter-spacing: 0px;
   }
+}
+
+/* AvatarAnonymous */
+.avatar-anonymous {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -259,31 +259,3 @@
     letter-spacing: 0px;
   }
 }
-
-.neutral {
-  background-color: var(--color-neutral-darkest);
-}
-
-.mint {
-  background-color: var(--color-mint);
-}
-
-.violet {
-  background-color: var(--color-violet);
-}
-
-.teal {
-  background-color: var(--color-teal);
-}
-
-.ruby {
-  background-color: var(--color-ruby);
-}
-
-.gold {
-  background-color: var(--color-gold);
-}
-
-.aqua {
-  background-color: var(--color-aqua);
-}

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -109,6 +109,7 @@
   &.avatar,
   .avatar-image,
   .avatar-initials,
+  .avatar-add,
   .avatar-anonymous,
   .image {
     height: var(--tiny-size);
@@ -136,6 +137,7 @@
   &.avatar,
   .avatar-image,
   .avatar-initials,
+  .avatar-add,
   .avatar-anonymous,
   .image {
     height: var(--small-size);
@@ -159,6 +161,7 @@
   &.avatar,
   .avatar-image,
   .avatar-initials,
+  .avatar-add,
   .avatar-anonymous,
   .image {
     height: var(--medium-size);
@@ -182,6 +185,7 @@
   &.avatar,
   .avatar-image,
   .avatar-initials,
+  .avatar-add,
   .avatar-anonymous,
   .image {
     height: var(--large-size);
@@ -209,6 +213,7 @@
   &.avatar,
   .avatar-image,
   .avatar-initials,
+  .avatar-add,
   .avatar-anonymous,
   .image {
     height: var(--hero-size);
@@ -236,6 +241,7 @@
   .avatar-image .image,
   .avatar-initials,
   .avatar-anonymous,
+  .avatar-add,
   .overlay {
     border-radius: var(--shape-circle-image-border-radius);
   }
@@ -244,7 +250,8 @@
 .is-rounded {
   .avatar-image .image,
   .avatar-initials,
-  .avatar-anonymous {
+  .avatar-anonymous,
+  .avatar-add {
     border-radius: var(--shape-rounded-image-border-radius);
   }
 
@@ -265,6 +272,13 @@
     text-transform: uppercase;
     letter-spacing: 0px;
   }
+}
+
+/* AvatarAdd */
+.avatar-add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* AvatarAnonymous */

--- a/stories/avatars.js
+++ b/stories/avatars.js
@@ -18,6 +18,7 @@ storiesOf('Avatars', module)
   })
   .add('Avatar', () => (
     <Avatar
+      creatable={boolean('Creatable', false)}
       editable={boolean('Editable', false)}
       fullName={text('Full name', 'John Doe')}
       id={text('Id', '63227a3c-c80b-11e9-a32f-2a2ae2dbcce4')}
@@ -41,9 +42,10 @@ storiesOf('Avatars', module)
   ))
   .add('With bullet', () => (
     <Avatar
+      creatable={boolean('Creatable', false)}
       editable={boolean('Editable', false)}
       fullName={text('Full name', 'John Doe')}
-      id="63227a3c-c80b-11e9-a32f-2a2ae2dbcce4"
+      id={text('Id', '63227a3c-c80b-11e9-a32f-2a2ae2dbcce4')}
       imageUrl={boolean('Image available', false) ? avatars[0].image : null}
       onImageChange={() => console.log('Change image')}
       size={select('Size', sizes, 'large')}
@@ -54,9 +56,10 @@ storiesOf('Avatars', module)
   ))
   .add('With counter', () => (
     <Avatar
+      creatable={boolean('Creatable', false)}
       editable={boolean('Editable', false)}
       fullName={text('Full name', 'John Doe')}
-      id="63227a3c-c80b-11e9-a32f-2a2ae2dbcce4"
+      id={text('Id', '63227a3c-c80b-11e9-a32f-2a2ae2dbcce4')}
       imageUrl={boolean('Image available', false) ? avatars[0].image : null}
       onImageChange={() => console.log('Change image')}
       size={select('Size', sizes, 'large')}
@@ -67,9 +70,10 @@ storiesOf('Avatars', module)
   ))
   .add('With tooltip', () => (
     <TooltippedAvatar
+      creatable={boolean('Creatable', false)}
       editable={boolean('Editable', false)}
       fullName={text('Full name', 'John Doe')}
-      id="63227a3c-c80b-11e9-a32f-2a2ae2dbcce4"
+      id={text('Id', '63227a3c-c80b-11e9-a32f-2a2ae2dbcce4')}
       imageUrl={boolean('Image available', false) ? avatars[0].image : null}
       onImageChange={() => console.log('Change image')}
       size={select('Size', sizes, 'large')}


### PR DESCRIPTION
### Description

This PR extends the `Avatar` component with a fallback for anonymous users. Also, a `creatable` prop was implemented to render a `user plus` icon.

#### Screenshots
![Screenshot 2019-12-04 08 16 03](https://user-images.githubusercontent.com/5336831/70122411-e0176800-1670-11ea-81ee-8a3de68b27f3.png)

![Screenshot 2019-12-04 08 23 59](https://user-images.githubusercontent.com/5336831/70122421-e3aaef00-1670-11ea-92d4-1761bb2de0b0.png)

### Breaking changes

`AvatarImage`: removed `imageClassName` prop.

### Follow up todo
Refactor duplicate code