### PR TITLE
Storybook: remove custom file-loader config

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -41,38 +41,6 @@ module.exports = async ({ config }) => {
     ],
   });
 
-  config.module.rules.push({
-    test: /\.(jpe?g|png|gif|svg)$/i,
-    use: [
-      {
-        loader: 'file-loader',
-        options: {
-          query: {
-            hash: 'sha512',
-            digest: 'hex',
-            name: '[hash].[ext]',
-          },
-        },
-      },
-      {
-        loader: 'image-webpack-loader',
-        options: {
-          query: {
-            mozjpeg: {
-              progressive: true,
-            },
-            gifsicle: {
-              interlaced: true,
-            },
-            optipng: {
-              optimizationLevel: 7,
-            },
-          },
-        },
-      },
-    ],
-  });
-
   if (config.optimization) {
     config.optimization.minimize = false;
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Removed
 
+- `Storybook`: removed custom config override for `file-loader` to fix broken images. ([@driesd](https://github.com/driesd) in [#736](https://github.com/teamleadercrm/ui/pull/736))
+
 ### Fixed
 
 ### Dependency updates


### PR DESCRIPTION
### Description

This PR fixes the broken images in Storybook, by `removing` our `custom config override` for `file-loader`.

#### Screenshot before this PR
![Screenshot 2019-12-04 10 39 20](https://user-images.githubusercontent.com/5336831/70131316-625c5800-1682-11ea-91cd-846ff21ee1ef.png)

#### Screenshot after this PR
![Screenshot 2019-12-04 10 33 54](https://user-images.githubusercontent.com/5336831/70131329-69836600-1682-11ea-9967-1d9d609f1798.png)

### Breaking changes

None.