### PR TITLE
Release 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Dependency updates
+
+## [0.33.0] - 2019-12-06
+
+### Added
+
 - `Box`: added `borderRadius`, `borderTopLeftRadius`, `borderTopRightRadius`, `borderBottomLeftRadius`, `borderBottomRightRadius` props with default value `square`. ([@driesd](https://github.com/driesd) in [#737](https://github.com/teamleadercrm/ui/pull/737))
 
 ### Changed
@@ -10,16 +24,14 @@
 - `Avatar`: added `onClick` prop to show a hover state. ([@driesd](https://github.com/driesd) in [#738](https://github.com/teamleadercrm/ui/pull/738))
 - `Avatar`: added `selected` prop with default value `false` to show a selected state. ([@driesd](https://github.com/driesd) in [#738](https://github.com/teamleadercrm/ui/pull/738))
 
-### Deprecated
-
 ### Removed
 
 - [BREAKING] `Avatar`: removed `imageClassName` prop from the internally used `AvatarImage` component. ([@driesd](https://github.com/driesd) in [#735](https://github.com/teamleadercrm/ui/pull/735))
 - `Storybook`: removed custom config override for `file-loader` to fix broken images. ([@driesd](https://github.com/driesd) in [#736](https://github.com/teamleadercrm/ui/pull/736))
 
-### Fixed
-
 ### Dependency updates
+
+- `css-loader` from `3.2.0` to `3.2.1`
 
 ## [0.32.0] - 2019-12-02
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Added

- `Box`: added `borderRadius`, `borderTopLeftRadius`, `borderTopRightRadius`, `borderBottomLeftRadius`, `borderBottomRightRadius` props with default value `square`. ([@driesd](https://github.com/driesd) in [#737](https://github.com/teamleadercrm/ui/pull/737))

### Changed

- `Avatar`: added `creatable` prop with default value `false`. ([@driesd](https://github.com/driesd) in [#735](https://github.com/teamleadercrm/ui/pull/735))
- `Avatar`: added `onClick` prop to show a hover state. ([@driesd](https://github.com/driesd) in [#738](https://github.com/teamleadercrm/ui/pull/738))
- `Avatar`: added `selected` prop with default value `false` to show a selected state. ([@driesd](https://github.com/driesd) in [#738](https://github.com/teamleadercrm/ui/pull/738))

### Removed

- [BREAKING] `Avatar`: removed `imageClassName` prop from the internally used `AvatarImage` component. ([@driesd](https://github.com/driesd) in [#735](https://github.com/teamleadercrm/ui/pull/735))
- `Storybook`: removed custom config override for `file-loader` to fix broken images. ([@driesd](https://github.com/driesd) in [#736](https://github.com/teamleadercrm/ui/pull/736))

### Dependency updates

- `css-loader` from `3.2.0` to `3.2.1`
