### PR TITLE
Fix/toggle component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- [BREAKING] `Toggle`: Fix onChange signature to pass the actual internally used checkbox event. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#745](https://github.com/teamleadercrm/ui/pull/745))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -61,7 +61,6 @@ class Toggle extends PureComponent {
           disabled={disabled}
           onChange={this.handleToggle}
           ref={this.inputNode}
-          readOnly
           {...inputProps}
         />
         <span className={theme['track']}>

--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -10,14 +10,14 @@ class Toggle extends PureComponent {
   inputNode = createRef();
 
   handleToggle = event => {
-    const { disabled, checked, onChange } = this.props;
+    const { disabled, onChange } = this.props;
 
     if (event.pageX !== 0 && event.pageY !== 0) {
       this.blur();
     }
 
     if (!disabled && onChange) {
-      onChange(!checked, event);
+      onChange(event);
     }
   };
 
@@ -59,7 +59,7 @@ class Toggle extends PureComponent {
           type="checkbox"
           checked={checked}
           disabled={disabled}
-          onClick={this.handleToggle}
+          onChange={this.handleToggle}
           ref={this.inputNode}
           readOnly
           {...inputProps}

--- a/src/components/toggle/toggle.stories.js
+++ b/src/components/toggle/toggle.stories.js
@@ -8,8 +8,23 @@ export default {
   title: 'Form elements/Toggle',
 };
 
+const ControlledToggle = props => {
+  const handleChange = event => {
+    window.__STORYBOOK_ADDONS.channel.emit('storybookjs/knobs/change', {
+      name: 'Checked',
+      value: event.target.checked,
+    });
+  };
+
+  return <Toggle {...props} onChange={handleChange} />;
+};
+
+ControlledToggle.propTypes = Toggle.propTypes;
+ControlledToggle.defaultProps = Toggle.defaultProps;
+ControlledToggle.displayName = 'Toggle';
+
 export const basic = () => (
-  <Toggle
+  <ControlledToggle
     checked={boolean('Checked', false)}
     disabled={boolean('Disabled', false)}
     size={select('Size', sizes, 'medium')}
@@ -17,7 +32,7 @@ export const basic = () => (
 );
 
 export const withLabels = () => (
-  <Toggle
+  <ControlledToggle
     checked={boolean('Checked', false)}
     disabled={boolean('Disabled', false)}
     label={`I'm a toggle`}

--- a/src/components/toggle/toggle.stories.js
+++ b/src/components/toggle/toggle.stories.js
@@ -10,6 +10,8 @@ export default {
 
 const ControlledToggle = props => {
   const handleChange = event => {
+    // storybook/knobs controls our state, this changes its state
+    // https://github.com/storybookjs/storybook/issues/3855#issuecomment-503795595
     window.__STORYBOOK_ADDONS.channel.emit('storybookjs/knobs/change', {
       name: 'Checked',
       value: event.target.checked,


### PR DESCRIPTION
### Description

* Fix the Toggle component's onChange event

Instead of just passing the checkbox `onChange` event, we were passing the `checked value`, and then the `onClick` event. I think we should try to preserve the default signature of a checkbox onChange instead of giving it our own signature.

This makes it easier to integrate with certain form libraries as they are already prepared for the default event signatures.

* Fix story for the toggle component

### Breaking changes

- The toggle component's onChange event signature has changed. It now just passes the onChange event from the internally used checkbox. If you want to get the value, you need to extract it from the event like so:

```js
onChange={event => console.log(event.target.checked}
```
