### PR TITLE
Release/0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@
 
 ### Changed
 
-- [INTERNAL]: changed all stories to Component Story Format (CSF) and moved them next to their respective components. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#740](https://github.com/teamleadercrm/ui/pull/740))
-- [BREAKING] `Toggle`: Fix onChange signature to pass the actual internally used checkbox event. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#745](https://github.com/teamleadercrm/ui/pull/745))
-
 ### Deprecated
 
 ### Removed
@@ -14,6 +11,13 @@
 ### Fixed
 
 ### Dependency updates
+
+## [0.34.0] - 2019-12-12
+
+### Changed
+
+- [INTERNAL]: changed all stories to Component Story Format (CSF) and moved them next to their respective components. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#740](https://github.com/teamleadercrm/ui/pull/740))
+- [BREAKING] `Toggle`: Fix onChange signature to pass the actual internally used checkbox event. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#745](https://github.com/teamleadercrm/ui/pull/745))
 
 ## [0.33.0] - 2019-12-06
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [0.34.0] - 2019-12-12

### Changed

- [INTERNAL]: changed all stories to Component Story Format (CSF) and moved them next to their respective components. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#740](https://github.com/teamleadercrm/ui/pull/740))
- [BREAKING] `Toggle`: Fix onChange signature to pass the actual internally used checkbox event. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#745](https://github.com/teamleadercrm/ui/pull/745))
