### PR TITLE
NumericInput: refactor and extend spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- [BREAKING] `NumericInput`: changed prop type `spinner` from `boolean` (default `true`) to `oneOf` (default `suffix`). ([@driesd](https://github.com/driesd) in [#756](https://github.com/teamleadercrm/ui/pull/756))
+- [BREAKING] `NumericInput`: renamed `spinner` prop to `stepper`. ([@driesd](https://github.com/driesd) in [#756](https://github.com/teamleadercrm/ui/pull/756))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -9,6 +9,7 @@ import {
 import Button from '../button';
 import Icon from '../icon';
 import SingleLineInputBase from './SingleLineInputBase';
+import omit from 'lodash.omit';
 import theme from './theme.css';
 
 class StepperControls extends PureComponent {
@@ -154,7 +155,8 @@ class NumericInput extends PureComponent {
   };
 
   render() {
-    const { onChange, suffix, ...others } = this.props;
+    const { onChange, ...others } = this.props;
+    const restProps = omit(others, ['suffix']);
 
     return (
       <SingleLineInputBase
@@ -164,7 +166,7 @@ class NumericInput extends PureComponent {
           this.handleOnChange(event);
           onChange && onChange(event, event.currentTarget.value);
         }}
-        {...others}
+        {...restProps}
         connectedLeft={this.getConnectedLeft()}
         connectedRight={this.getConnectedRight()}
         suffix={this.getSuffix()}

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -89,21 +89,29 @@ class NumericInput extends PureComponent {
 
   isMinReached = () => this.state.value <= this.props.min;
 
-  getSuffixWithSpinner = () => [
-    ...this.props.suffix,
-    /* eslint-disable-next-line react/jsx-key */
-    <SpinnerControls
-      inverse={this.props.inverse}
-      spinnerUpProps={{
-        onClick: this.handleIncreaseValue,
-        disabled: this.isMaxReached(),
-      }}
-      spinnerDownProps={{
-        onClick: this.handleDecreaseValue,
-        disabled: this.isMinReached(),
-      }}
-    />,
-  ];
+  getSuffix = () => {
+    const { inverse, spinner, suffix } = this.props;
+
+    if (spinner === 'suffix') {
+      return [
+        ...suffix,
+        /* eslint-disable-next-line react/jsx-key */
+        <SpinnerControls
+          inverse={inverse}
+          spinnerUpProps={{
+            onClick: this.handleIncreaseValue,
+            disabled: this.isMaxReached(),
+          }}
+          spinnerDownProps={{
+            onClick: this.handleDecreaseValue,
+            disabled: this.isMinReached(),
+          }}
+        />,
+      ];
+    }
+
+    return suffix;
+  };
 
   render() {
     const { spinner, suffix, onChange, ...others } = this.props;
@@ -112,7 +120,7 @@ class NumericInput extends PureComponent {
       <SingleLineInputBase
         type="number"
         value={this.state.value}
-        suffix={spinner === 'suffix' ? this.getSuffixWithSpinner() : suffix}
+        suffix={this.getSuffix()}
         onChange={event => {
           this.handleOnChange(event);
           onChange && onChange(event, event.currentTarget.value);

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -1,6 +1,12 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { IconChevronUpSmallOutline, IconChevronDownSmallOutline } from '@teamleader/ui-icons';
+import {
+  IconAddSmallOutline,
+  IconChevronUpSmallOutline,
+  IconChevronDownSmallOutline,
+  IconMinusSmallOutline,
+} from '@teamleader/ui-icons';
+import Button from '../button';
 import Icon from '../icon';
 import SingleLineInputBase from './SingleLineInputBase';
 import theme from './theme.css';
@@ -89,6 +95,30 @@ class NumericInput extends PureComponent {
 
   isMinReached = () => this.state.value <= this.props.min;
 
+  getConnectedRight = () => {
+    const { connectedRight, stepper } = this.props;
+
+    if (stepper === 'connected') {
+      return (
+        <Button disabled={this.isMaxReached()} icon={<IconAddSmallOutline />} onClick={this.handleIncreaseValue} />
+      );
+    }
+
+    return connectedRight;
+  };
+
+  getConnectedLeft = () => {
+    const { connectedLeft, stepper } = this.props;
+
+    if (stepper === 'connected') {
+      return (
+        <Button disabled={this.isMinReached()} icon={<IconMinusSmallOutline />} onClick={this.handleDecreaseValue} />
+      );
+    }
+
+    return connectedLeft;
+  };
+
   getSuffix = () => {
     const { inverse, stepper, suffix } = this.props;
 
@@ -120,12 +150,14 @@ class NumericInput extends PureComponent {
       <SingleLineInputBase
         type="number"
         value={this.state.value}
-        suffix={this.getSuffix()}
         onChange={event => {
           this.handleOnChange(event);
           onChange && onChange(event, event.currentTarget.value);
         }}
         {...others}
+        connectedLeft={this.getConnectedLeft()}
+        connectedRight={this.getConnectedRight()}
+        suffix={this.getSuffix()}
       />
     );
   }

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -5,9 +5,9 @@ import Icon from '../icon';
 import SingleLineInputBase from './SingleLineInputBase';
 import theme from './theme.css';
 
-class SpinnerControls extends PureComponent {
+class StepperControls extends PureComponent {
   render() {
-    const { inverse, spinnerUpProps, spinnerDownProps } = this.props;
+    const { inverse, stepperUpProps, stepperDownProps } = this.props;
     const iconProps = {
       color: inverse ? 'teal' : 'neutral',
       element: 'button',
@@ -17,11 +17,11 @@ class SpinnerControls extends PureComponent {
     };
 
     return (
-      <div className={theme['spinner']}>
-        <Icon className={theme['spinner-up']} {...spinnerUpProps} {...iconProps}>
+      <div className={theme['stepper']}>
+        <Icon className={theme['stepper-up']} {...stepperUpProps} {...iconProps}>
           <IconChevronUpSmallOutline />
         </Icon>
-        <Icon className={theme['spinner-down']} {...spinnerDownProps} {...iconProps}>
+        <Icon className={theme['stepper-down']} {...stepperDownProps} {...iconProps}>
           <IconChevronDownSmallOutline />
         </Icon>
       </div>
@@ -90,19 +90,19 @@ class NumericInput extends PureComponent {
   isMinReached = () => this.state.value <= this.props.min;
 
   getSuffix = () => {
-    const { inverse, spinner, suffix } = this.props;
+    const { inverse, stepper, suffix } = this.props;
 
-    if (spinner === 'suffix') {
+    if (stepper === 'suffix') {
       return [
         ...suffix,
         /* eslint-disable-next-line react/jsx-key */
-        <SpinnerControls
+        <StepperControls
           inverse={inverse}
-          spinnerUpProps={{
+          stepperUpProps={{
             onClick: this.handleIncreaseValue,
             disabled: this.isMaxReached(),
           }}
-          spinnerDownProps={{
+          stepperDownProps={{
             onClick: this.handleDecreaseValue,
             disabled: this.isMinReached(),
           }}
@@ -114,7 +114,7 @@ class NumericInput extends PureComponent {
   };
 
   render() {
-    const { spinner, suffix, onChange, ...others } = this.props;
+    const { onChange, suffix, ...others } = this.props;
 
     return (
       <SingleLineInputBase
@@ -138,8 +138,8 @@ NumericInput.propTypes = {
   max: PropTypes.number,
   /** The minimum value that can be inputted */
   min: PropTypes.number,
-  /** Specify where the spinner controls should be rendered */
-  spinner: PropTypes.oneOf(['none', 'connected', 'suffix']),
+  /** Specify where the stepper controls should be rendered */
+  stepper: PropTypes.oneOf(['none', 'connected', 'suffix']),
   /** Limit increment value for numeric inputs. */
   step: PropTypes.number,
 };
@@ -149,7 +149,7 @@ NumericInput.defaultProps = {
   max: Number.MAX_SAFE_INTEGER,
   step: 1,
   suffix: [],
-  spinner: 'suffix',
+  stepper: 'suffix',
 };
 
 export default NumericInput;

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -112,7 +112,7 @@ class NumericInput extends PureComponent {
       <SingleLineInputBase
         type="number"
         value={this.state.value}
-        suffix={spinner ? this.getSuffixWithSpinner() : suffix}
+        suffix={spinner === 'suffix' ? this.getSuffixWithSpinner() : suffix}
         onChange={event => {
           this.handleOnChange(event);
           onChange && onChange(event, event.currentTarget.value);
@@ -130,8 +130,8 @@ NumericInput.propTypes = {
   max: PropTypes.number,
   /** The minimum value that can be inputted */
   min: PropTypes.number,
-  /** Boolean indicating whether to number type input should render spinner controls */
-  spinner: PropTypes.bool,
+  /** Specify where the spinner controls should be rendered */
+  spinner: PropTypes.oneOf(['none', 'connected', 'suffix']),
   /** Limit increment value for numeric inputs. */
   step: PropTypes.number,
 };
@@ -141,7 +141,7 @@ NumericInput.defaultProps = {
   max: Number.MAX_SAFE_INTEGER,
   step: 1,
   suffix: [],
-  spinner: true,
+  spinner: 'suffix',
 };
 
 export default NumericInput;

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -96,11 +96,16 @@ class NumericInput extends PureComponent {
   isMinReached = () => this.state.value <= this.props.min;
 
   getConnectedRight = () => {
-    const { connectedRight, stepper } = this.props;
+    const { connectedRight, size, stepper } = this.props;
 
     if (stepper === 'connected') {
       return (
-        <Button disabled={this.isMaxReached()} icon={<IconAddSmallOutline />} onClick={this.handleIncreaseValue} />
+        <Button
+          disabled={this.isMaxReached()}
+          icon={<IconAddSmallOutline />}
+          onClick={this.handleIncreaseValue}
+          size={size}
+        />
       );
     }
 
@@ -108,11 +113,16 @@ class NumericInput extends PureComponent {
   };
 
   getConnectedLeft = () => {
-    const { connectedLeft, stepper } = this.props;
+    const { connectedLeft, size, stepper } = this.props;
 
     if (stepper === 'connected') {
       return (
-        <Button disabled={this.isMinReached()} icon={<IconMinusSmallOutline />} onClick={this.handleDecreaseValue} />
+        <Button
+          disabled={this.isMinReached()}
+          icon={<IconMinusSmallOutline />}
+          onClick={this.handleDecreaseValue}
+          size={size}
+        />
       );
     }
 

--- a/src/components/input/input.stories.js
+++ b/src/components/input/input.stories.js
@@ -51,6 +51,7 @@ const prefix = [
   /* eslint-disable-next-line react/jsx-key */
   <TextBody color="neutral">€</TextBody>,
 ];
+const spinnerOptions = ['none', 'connected', 'suffix'];
 /* eslint-disable-next-line react/jsx-key */
 const suffix = [<TextSmall color="neutral">incl. BTW</TextSmall>, <Counter count={99} />, <LoadingSpinner />];
 
@@ -119,7 +120,7 @@ export const numericInput = () => (
     placeholder={text('Placeholder', placeholder)}
     readOnly={boolean('Read only', false)}
     size={select('Size', sizes) || undefined}
-    spinner={boolean('Spinner', true)}
+    spinner={select('Spinner', spinnerOptions, 'suffix')}
     step={number('Step', 1)}
     connectedLeft={
       boolean('Toggle connected left', false) ? <Button size={select('Size', sizes, 'medium')} label="€" /> : undefined

--- a/src/components/input/input.stories.js
+++ b/src/components/input/input.stories.js
@@ -51,7 +51,7 @@ const prefix = [
   /* eslint-disable-next-line react/jsx-key */
   <TextBody color="neutral">€</TextBody>,
 ];
-const spinnerOptions = ['none', 'connected', 'suffix'];
+const stepperOptions = ['none', 'connected', 'suffix'];
 /* eslint-disable-next-line react/jsx-key */
 const suffix = [<TextSmall color="neutral">incl. BTW</TextSmall>, <Counter count={99} />, <LoadingSpinner />];
 
@@ -120,7 +120,7 @@ export const numericInput = () => (
     placeholder={text('Placeholder', placeholder)}
     readOnly={boolean('Read only', false)}
     size={select('Size', sizes) || undefined}
-    spinner={select('Spinner', spinnerOptions, 'suffix')}
+    stepper={select('Stepper', stepperOptions, 'suffix')}
     step={number('Step', 1)}
     connectedLeft={
       boolean('Toggle connected left', false) ? <Button size={select('Size', sizes, 'medium')} label="€" /> : undefined

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -20,8 +20,8 @@
   --input-warning-border: var(--color-gold-dark);
   --input-warning-border-inverse: var(--color-gold-light);
 
-  --spinner-width: calc(1.8 * var(--unit));
-  --spinner-width-large: calc(3.6 * var(--unit));
+  --stepper-width: calc(1.8 * var(--unit));
+  --stepper-width-large: calc(3.6 * var(--unit));
 
   --textarea-large-min-height: calc(20.2 * var(--unit));
   --textarea-medium-min-height: calc(15.4 * var(--unit));
@@ -278,17 +278,17 @@
   }
 }
 
-.spinner {
+.stepper {
   align-items: center;
   display: flex;
   flex-direction: column;
   height: 100%;
   justify-content: center;
-  width: var(--spinner-width);
+  width: var(--stepper-width);
 }
 
-.spinner-up,
-.spinner-down {
+.stepper-up,
+.stepper-down {
   background: transparent;
   border: 0;
   border-radius: 0;
@@ -318,16 +318,16 @@
  */
 .is-disabled {
   .input,
-  .spinner-up,
-  .spinner-down {
+  .stepper-up,
+  .stepper-down {
     pointer-events: none;
     user-select: none;
   }
 }
 
 .is-read-only {
-  .spinner-up,
-  .spinner-down {
+  .stepper-up,
+  .stepper-down {
     pointer-events: none;
     user-select: none;
   }
@@ -339,9 +339,9 @@
     font-size: var(--input-text-size-large);
   }
 
-  .spinner {
+  .stepper {
     height: var(--input-height-large);
-    width: var(--spinner-width-large);
+    width: var(--stepper-width-large);
   }
 
   &.textarea {
@@ -353,7 +353,7 @@
 
 .is-small {
   &.input,
-  .spinner {
+  .stepper {
     height: var(--input-height-small);
   }
 


### PR DESCRIPTION
### Description

Before this PR it was only possible to render de `spinner controls` inside the input field, on the left. This PR not only renames the `spinner` prop to `stepper`, but also introduces a new way of rendering these controls.

### Screenshots
#### No stepper at all
![Screenshot 2019-12-17 16 13 12](https://user-images.githubusercontent.com/5336831/71008575-2052fd80-20e9-11ea-9c90-f1821f6d6b72.png)

#### Stepper as a suffix
![Screenshot 2019-12-17 16 12 54](https://user-images.githubusercontent.com/5336831/71008360-c3efde00-20e8-11ea-8a31-9a6dc6d012bb.png)

#### Stepper as two connected buttons (new)
![Screenshot 2019-12-17 16 13 04](https://user-images.githubusercontent.com/5336831/71008393-d1a56380-20e8-11ea-803d-611de65bfef8.png)

### Breaking changes

- changed prop type `spinner` from `boolean` (default `true`) to `oneOf` (default `suffix`)
- renamed `spinner` prop to `stepper`
