### PR TITLE
Input & Select: focus state should not overrule any other state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 ### Fixed
 
+- `Input`: focus state should not overrule any other state. ([@driesd](https://github.com/driesd) in [#759](https://github.com/teamleadercrm/ui/pull/759))
+- `Select`: focus state should not overrule any other state. ([@driesd](https://github.com/driesd) in [#759](https://github.com/teamleadercrm/ui/pull/759))
+
 ### Dependency updates
 
 ## [0.34.0] - 2019-12-12

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -386,7 +386,7 @@
 
 .has-success {
   &:not(.is-inverse) {
-    &:not(.has-focus) .input-inner-wrapper,
+    .input-inner-wrapper,
     .input {
       border-color: var(--input-success-border);
       box-shadow: 0 0 0 1px var(--input-success-border);
@@ -395,7 +395,7 @@
   }
 
   &.is-inverse {
-    &:not(.has-focus) .input-inner-wrapper,
+    .input-inner-wrapper,
     .input {
       border-color: var(--input-success-border-inverse);
       box-shadow: 0 0 0 1px var(--input-success-border-inverse);
@@ -406,7 +406,7 @@
 
 .has-warning {
   &:not(.is-inverse) {
-    &:not(.has-focus) .input-inner-wrapper,
+    .input-inner-wrapper,
     .input {
       border-color: var(--input-warning-border);
       box-shadow: 0 0 0 1px var(--input-warning-border);
@@ -415,7 +415,7 @@
   }
 
   &.is-inverse {
-    &:not(.has-focus) .input-inner-wrapper,
+    .input-inner-wrapper,
     .input {
       border-color: var(--input-warning-border-inverse);
       box-shadow: 0 0 0 1px var(--input-warning-border-inverse);
@@ -426,7 +426,7 @@
 
 .has-error {
   &:not(.is-inverse) {
-    &:not(.has-focus) .input-inner-wrapper,
+    .input-inner-wrapper,
     .input {
       border-color: var(--input-error-border);
       box-shadow: 0 0 0 1px var(--input-error-border);
@@ -435,7 +435,7 @@
   }
 
   &.is-inverse {
-    &:not(.has-focus) .input-inner-wrapper,
+    .input-inner-wrapper,
     .input {
       border-color: var(--input-error-border-inverse);
       box-shadow: 0 0 0 1px var(--input-error-border-inverse);

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -43,11 +43,9 @@ class Select extends PureComponent {
         ...commonStyles,
         backgroundColor: isDisabled ? COLOR.TEAL.DARK : COLOR.TEAL.NORMAL,
         '&:hover': {
-          borderColor: !isFocused && !error && !warning && !success && COLOR.TEAL.LIGHT,
+          borderColor: !error && !warning && !success && COLOR.TEAL.LIGHT,
         },
-        borderColor: isFocused
-          ? COLOR.TEAL.LIGHT
-          : error
+        borderColor: error
           ? COLOR.RUBY.LIGHT
           : warning
           ? COLOR.GOLD.LIGHT
@@ -55,15 +53,17 @@ class Select extends PureComponent {
           ? COLOR.MINT.LIGHT
           : isDisabled
           ? COLOR.TEAL.DARK
+          : isFocused
+          ? COLOR.TEAL.LIGHT
           : COLOR.TEAL.NORMAL,
-        boxShadow: isFocused
-          ? `0 0 0 1px ${COLOR.TEAL.LIGHT}`
-          : error
+        boxShadow: error
           ? `0 0 0 1px ${COLOR.RUBY.LIGHT}`
           : warning
           ? `0 0 0 1px ${COLOR.GOLD.LIGHT}`
           : success
           ? `0 0 0 1px ${COLOR.MINT.LIGHT}`
+          : isFocused
+          ? `0 0 0 1px ${COLOR.TEAL.LIGHT}`
           : 'none',
       };
     }
@@ -72,11 +72,9 @@ class Select extends PureComponent {
       ...commonStyles,
       backgroundColor: isDisabled ? COLOR.NEUTRAL.NORMAL : COLOR.NEUTRAL.LIGHTEST,
       '&:hover': {
-        borderColor: !isFocused && !error && !warning && !success && COLOR.NEUTRAL.DARKEST,
+        borderColor: !error && !warning && !success && COLOR.NEUTRAL.DARKEST,
       },
-      borderColor: isFocused
-        ? COLOR.NEUTRAL.DARKEST
-        : error
+      borderColor: error
         ? COLOR.RUBY.DARK
         : warning
         ? COLOR.GOLD.DARK
@@ -84,15 +82,17 @@ class Select extends PureComponent {
         ? COLOR.MINT.DARK
         : isDisabled
         ? COLOR.NEUTRAL.NORMAL
+        : isFocused
+        ? COLOR.NEUTRAL.DARKEST
         : COLOR.NEUTRAL.DARK,
-      boxShadow: isFocused
-        ? `0 0 0 1px ${COLOR.NEUTRAL.DARKEST}`
-        : error
+      boxShadow: error
         ? `0 0 0 1px ${COLOR.RUBY.DARK}`
         : warning
         ? `0 0 0 1px ${COLOR.GOLD.DARK}`
         : success
         ? `0 0 0 1px ${COLOR.MINT.DARK}`
+        : isFocused
+        ? `0 0 0 1px ${COLOR.NEUTRAL.DARKEST}`
         : 'none',
     };
   };


### PR DESCRIPTION
### Description

This PR fixes all `Input` & `Select` states in a way that the focus state cannot overrule any other state (error, warning, success & disabled).

#### Screenshot before this PR
![Screenshot 2019-12-18 10 55 41](https://user-images.githubusercontent.com/5336831/71075824-0109ae00-2185-11ea-92ec-7ef25e8657f4.png)

#### Screenshot after this PR
![Screenshot 2019-12-18 10 58 46](https://user-images.githubusercontent.com/5336831/71076070-62ca1800-2185-11ea-8d25-d5e0a42f5bc2.png)

### Breaking changes

None.
