### PR TITLE
DataGrid: 12 column grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `DataGrid`: extended the `flex` prop `values` of the `Cell` component up to `12`. ([@driesd](https://github.com/driesd) in [#761](https://github.com/teamleadercrm/ui/pull/761))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/datagrid/Cell.js
+++ b/src/components/datagrid/Cell.js
@@ -54,7 +54,7 @@ Cell.propTypes = {
   /** A class name for the cell to give custom styles. */
   className: PropTypes.string,
   /** The width proportion of the cell against the others. */
-  flex: PropTypes.oneOf(['min-width', '1', '2', '3', '4']),
+  flex: PropTypes.oneOf(['min-width', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']),
   /** If true, an ellipsis will be shown when the cell content is too long. */
   preventOverflow: PropTypes.bool,
   /** If true, the text inside the cell will be bold */

--- a/src/components/datagrid/datagrid.stories.js
+++ b/src/components/datagrid/datagrid.stories.js
@@ -59,7 +59,7 @@ export const basic = () => (
       <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} align="right">
         Amount
       </DataGrid.HeaderCell>
-      <DataGrid.HeaderCell flex="2" onClick={() => console.log('onClick: column sort')}>
+      <DataGrid.HeaderCell flex="5" onClick={() => console.log('onClick: column sort')}>
         Customer
       </DataGrid.HeaderCell>
       <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')}>Due date</DataGrid.HeaderCell>
@@ -86,7 +86,7 @@ export const basic = () => (
             {' '}
             {`€ ${row.column3}`}
           </DataGrid.Cell>
-          <DataGrid.Cell flex="2">{row.column2}</DataGrid.Cell>
+          <DataGrid.Cell flex="5">{row.column2}</DataGrid.Cell>
           <DataGrid.Cell soft>{row.column4}</DataGrid.Cell>
           <DataGrid.Cell align="right" flex="min-width" preventOverflow={false}>
             <IconMenu position="top-right">

--- a/src/components/datagrid/theme.css
+++ b/src/components/datagrid/theme.css
@@ -4,6 +4,7 @@
 
 :root {
   --datagrid-blend-width: 12px;
+  --datagrid-cell-width-base: 80px;
 }
 
 .data-grid {
@@ -225,24 +226,11 @@
   min-width: 30px;
 }
 
-.flex-1 {
-  flex: 1 0 100px;
-  min-width: 100px;
-}
-
-.flex-2 {
-  flex: 2 0 200px;
-  min-width: 200px;
-}
-
-.flex-3 {
-  flex: 3 0 300px;
-  min-width: 300px;
-}
-
-.flex-4 {
-  flex: 4 0 400px;
-  min-width: 400px;
+@each $factor in (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12) {
+  .flex-$(factor) {
+    flex: $factor 0 calc($factor * var(--datagrid-cell-width-base));
+    min-width: calc($factor * var(--datagrid-cell-width-base));
+  }
 }
 
 /* Cell alignment */


### PR DESCRIPTION
### Description

This PR extends the `flex` prop `values` of our `DataGrid`'s `Cell` component up to 12. We do this to have more flexibility in our column widths.

#### Screenshot before this PR

![Screenshot 2019-12-18 16 19 07](https://user-images.githubusercontent.com/5336831/71098532-219c2d00-21b2-11ea-94cf-6cf4683bafb1.png)


#### Screenshot after this PR
![Screenshot 2019-12-18 16 11 53](https://user-images.githubusercontent.com/5336831/71098155-8a36da00-21b1-11ea-92b4-45c5e42bfb70.png)

### Breaking changes

None.
