### PR TITLE
release/0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@
 
 ### Changed
 
-- [BUILD]: Revert "🔧 Don't require library users to use postcss". ([@ArnaudWeyts](https://github.com/driesd) in [#768](https://github.com/teamleadercrm/ui/pull/768))
-- `DataGrid`: extended the `flex` prop `values` of the `Cell` component up to `12`. ([@driesd](https://github.com/driesd) in [#761](https://github.com/teamleadercrm/ui/pull/761))
-
 ### Deprecated
 
 ### Removed
@@ -14,6 +11,13 @@
 ### Fixed
 
 ### Dependency updates
+
+## [0.35.1] - 2019-12-23
+
+### Changed
+
+- [BUILD]: Revert "🔧 Don't require library users to use postcss". ([@ArnaudWeyts](https://github.com/driesd) in [#768](https://github.com/teamleadercrm/ui/pull/768))
+- `DataGrid`: extended the `flex` prop `values` of the `Cell` component up to `12`. ([@driesd](https://github.com/driesd) in [#761](https://github.com/teamleadercrm/ui/pull/761))
 
 ## [0.35.0] - 2019-12-18
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Description

- [BUILD]: Revert "🔧 Don't require library users to use postcss". ([@ArnaudWeyts](https://github.com/driesd) in [#768](https://github.com/teamleadercrm/ui/pull/768))
- `DataGrid`: extended the `flex` prop `values` of the `Cell` component up to `12`. ([@driesd](https://github.com/driesd) in [#761](https://github.com/teamleadercrm/ui/pull/761))
