### PR TITLE
Husky: suppress deprecation warning

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "pre-commit": "pretty-quick --staged"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -138,9 +138,13 @@
     "deploy:prod": "yarn lint:clean && NODE_ENV=production yarn compile",
     "lint": "eslint ./src",
     "lint:fix": "yarn lint --fix",
-    "precommit": "pretty-quick --staged",
     "prettier": "prettier --write '**/*.{js,json,md,css}'",
     "prepare": "yarn build",
     "start": "PORT=${PORT:-3000}; start-storybook --port $PORT"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -141,10 +141,5 @@
     "prettier": "prettier --write '**/*.{js,json,md,css}'",
     "prepare": "yarn build",
     "start": "PORT=${PORT:-3000}; start-storybook --port $PORT"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "pretty-quick --staged"
-    }
   }
 }


### PR DESCRIPTION
This PR adapts to `new Husky config` to suppress deprecation warning.

```
Warning: Setting pre-commit script in package.json > scripts will be deprecated.
Please move it to husky.hooks in package.json or .huskyrc file.

For an automatic update you can also run:
npx --no-install husky-upgrade
yarn husky-upgrade

See https://github.com/typicode/husky for more information.
```