### PR TITLE
Select: check if document exists while setting menuPortalTarget's default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Select`: check if `document` exists while setting `menuPortalTarget`'s default value. ([@driesd](https://github.com/driesd) in [#795](https://github.com/teamleadercrm/ui/pull/795))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -371,7 +371,7 @@ Select.propTypes = {
 Select.defaultProps = {
   creatable: false,
   inverse: false,
-  menuPortalTarget: document.body,
+  menuPortalTarget: document && document.body,
   size: 'medium',
   width: '100%',
 };

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -371,7 +371,7 @@ Select.propTypes = {
 Select.defaultProps = {
   creatable: false,
   inverse: false,
-  menuPortalTarget: document && document.body,
+  menuPortalTarget: document ? document.body : undefined,
   size: 'medium',
   width: '100%',
 };


### PR DESCRIPTION
### Description

This PR first checks in our `Select` component if `document` exists while setting `menuPortalTarget`'s `default value`. We're doing this because server-side rendering doesn't know about `document`.

### Breaking changes

None.
