### PR TITLE
DatePicker: MonthPicker with single select field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Added
 
+- `MonthPicker`: added `MonthPicker` component, for use in `DatePicker` caption ([@mikeverf](https://github.com/mikeverf) in [#840](https://github.com/teamleadercrm/ui/pull/840))
+- `DatePicker`: added `withMonthPicker` prop, to use the newly added `MonthPicker` ([@mikeverf](https://github.com/mikeverf) in [#840](https://github.com/teamleadercrm/ui/pull/840))
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `MonthPicker`: added `MonthPicker` component, for use in `DatePicker` caption ([@mikeverf](https://github.com/mikeverf) in [#840](https://github.com/teamleadercrm/ui/pull/840))
 - `DatePicker`: added `withMonthPicker` prop, to use the newly added `MonthPicker` ([@mikeverf](https://github.com/mikeverf) in [#840](https://github.com/teamleadercrm/ui/pull/840))
+- `SingleLineInputBase`: added `noInputStyling` prop, to disable styling hinting at being able to type in the input field ([@mikeverf](https://github.com/mikeverf) in [#840](https://github.com/teamleadercrm/ui/pull/840))
 
 ### Changed
 

--- a/src/components/datepicker/DatePicker.js
+++ b/src/components/datepicker/DatePicker.js
@@ -4,6 +4,7 @@ import DayPicker from 'react-day-picker';
 import Box, { omitBoxProps, pickBoxProps } from '../box';
 import NavigationBar from './NavigationBar';
 import WeekDay from './WeekDay';
+import MonthPicker from './MonthPicker';
 import { convertModifiersToClassnames } from './utils';
 import cx from 'classnames';
 import theme from './theme.css';
@@ -12,6 +13,7 @@ import uiUtilities from '@teamleader/ui-utilities';
 class DatePicker extends PureComponent {
   state = {
     selectedDate: null,
+    selectedMonth: null,
   };
 
   static getDerivedStateFromProps(props, state) {
@@ -37,9 +39,13 @@ class DatePicker extends PureComponent {
     );
   };
 
+  handleYearMonthChange = selectedMonth => {
+    this.setState({ selectedMonth });
+  };
+
   render() {
-    const { bordered, className, modifiers, size, ...others } = this.props;
-    const { selectedDate } = this.state;
+    const { bordered, className, modifiers, size, withMonthPicker, showWeekNumbers, ...others } = this.props;
+    const { selectedDate, selectedMonth } = this.state;
     const boxProps = pickBoxProps(others);
     const restProps = omitBoxProps(others);
     const classNames = cx(
@@ -56,13 +62,27 @@ class DatePicker extends PureComponent {
       <Box {...boxProps}>
         <DayPicker
           {...restProps}
+          month={selectedMonth}
           className={classNames}
           classNames={theme}
           modifiers={convertModifiersToClassnames(modifiers, theme)}
-          navbarElement={<NavigationBar size={size} />}
+          navbarElement={<NavigationBar size={size} withMonthPicker={withMonthPicker} />}
           onDayClick={this.handleDayClick}
           selectedDays={selectedDate}
           weekdayElement={<WeekDay size={size} />}
+          showWeekNumbers={showWeekNumbers}
+          captionElement={
+            withMonthPicker
+              ? ({ date, localeUtils }) => (
+                  <MonthPicker
+                    date={date}
+                    localeUtils={localeUtils}
+                    onChange={this.handleYearMonthChange}
+                    small={!showWeekNumbers}
+                  />
+                )
+              : undefined
+          }
         />
       </Box>
     );

--- a/src/components/datepicker/DatePicker.js
+++ b/src/components/datepicker/DatePicker.js
@@ -43,6 +43,16 @@ class DatePicker extends PureComponent {
     this.setState({ selectedMonth });
   };
 
+  getMonthPickerSize = () => {
+    const { showWeekNumbers, size } = this.props;
+    const monthPickerSizeByDatePickerSize = {
+      small: 'smallest',
+      medium: showWeekNumbers ? 'medium' : 'small',
+      large: 'large',
+    };
+    return monthPickerSizeByDatePickerSize[size];
+  };
+
   render() {
     const { bordered, className, modifiers, size, withMonthPicker, showWeekNumbers, ...others } = this.props;
     const { selectedDate, selectedMonth } = this.state;
@@ -78,7 +88,7 @@ class DatePicker extends PureComponent {
                     date={date}
                     localeUtils={localeUtils}
                     onChange={this.handleYearMonthChange}
-                    small={!showWeekNumbers}
+                    size={this.getMonthPickerSize()}
                   />
                 )
               : undefined

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -101,6 +101,7 @@ class DatePickerInput extends PureComponent {
           size={size}
           value={this.getFormattedDate()}
           width="120px"
+          noInputStyling={dayPickerProps && dayPickerProps.withMonthPicker}
           {...inputProps}
         />
         <Popover

--- a/src/components/datepicker/MonthPicker.js
+++ b/src/components/datepicker/MonthPicker.js
@@ -9,7 +9,7 @@ import theme from './theme.css';
 
 const formatSelectedMonth = ({ label, value }) => ({ value, label: label.substring(0, 3) });
 
-const MonthPicker = ({ date, localeUtils, onChange, size }) => {
+const MonthPickerSplit = ({ date, localeUtils, onChange, size }) => {
   const [selectedMonth, setSelectedMonth] = useState({
     value: date.getMonth(),
     label: localeUtils.formatMonthTitle(date),
@@ -54,6 +54,10 @@ const MonthPicker = ({ date, localeUtils, onChange, size }) => {
       </Box>
     </Box>
   );
+};
+
+const MonthPicker = ({ size, ...props }) => {
+  return <MonthPickerSplit {...props} />;
 };
 
 MonthPicker.propTypes = {

--- a/src/components/datepicker/MonthPicker.js
+++ b/src/components/datepicker/MonthPicker.js
@@ -6,8 +6,59 @@ import { Select } from '../select';
 import { NumericInput } from '../input';
 import theme from './theme.css';
 
+// We want all the months from current month to current month in next year
+const getMonthOptions = localeUtils => {
+  let currentYear = new Date().getFullYear();
+  const currentMonth = new Date().getMonth();
+
+  const monthOptions = [];
+  for (let i = currentMonth; i <= 13; i++) {
+    const currentMonthInYear = i % 12;
+
+    if (currentMonthInYear === 0) {
+      currentYear++;
+    }
+
+    const monthOption = new Date(currentYear, currentMonthInYear);
+    monthOptions.push({
+      value: monthOption,
+      label: localeUtils.formatMonthTitle(monthOption),
+    });
+  }
+  return monthOptions;
+};
 
 const formatSelectedMonth = ({ label, value }) => ({ value, label: label.substring(0, 3) });
+
+const MonthPickerUnary = ({ date, localeUtils, onChange }) => {
+  const [selectedMonth, setSelectedMonth] = useState({
+    value: date.getMonth(),
+    label: localeUtils.formatMonthTitle(date),
+  });
+
+  useEffect(() => {
+    setSelectedMonth({ value: date, label: localeUtils.formatMonthTitle(date) });
+  }, [date]);
+
+  const handleChangeMonth = selectedMonth => {
+    onChange(selectedMonth.value);
+  };
+
+  return (
+    <Box className={theme['caption']}>
+      <Box display="flex" justifyContent="center">
+        <Select
+          value={selectedMonth}
+          className={theme['month-picker-field']}
+          options={getMonthOptions(localeUtils)}
+          onChange={handleChangeMonth}
+          width={112}
+          size="small"
+        />
+      </Box>
+    </Box>
+  );
+};
 
 const MonthPickerSplit = ({ date, localeUtils, onChange, size }) => {
   const [selectedMonth, setSelectedMonth] = useState({
@@ -57,6 +108,10 @@ const MonthPickerSplit = ({ date, localeUtils, onChange, size }) => {
 };
 
 const MonthPicker = ({ size, ...props }) => {
+  if (size === 'smallest') {
+    return <MonthPickerUnary {...props} />;
+  }
+
   return <MonthPickerSplit {...props} />;
 };
 

--- a/src/components/datepicker/MonthPicker.js
+++ b/src/components/datepicker/MonthPicker.js
@@ -12,7 +12,7 @@ const toMonth = new Date(currentYear + 10, 11);
 
 const formatSelectedMonth = ({ label, value }) => ({ value, label: label.substring(0, 3) });
 
-const MonthPicker = ({ date, localeUtils, onChange, small }) => {
+const MonthPicker = ({ date, localeUtils, onChange, size }) => {
   const [selectedMonth, setSelectedMonth] = useState({
     value: date.getMonth(),
     label: localeUtils.formatMonthTitle(date),
@@ -49,14 +49,14 @@ const MonthPicker = ({ date, localeUtils, onChange, small }) => {
           className={theme['month-picker-field']}
           options={months}
           onChange={handleChangeMonth}
-          width={small ? 88 : 112}
+          width={size === 'small' ? 88 : 112}
           size="small"
         />
         <NumericInput
           value={`${selectedYear}`}
           className={theme['month-picker-field']}
           onChange={handleChangeYear}
-          width={small ? 72 : 80}
+          width={size === 'small' ? 72 : 80}
           size="small"
         />
       </Box>
@@ -71,6 +71,8 @@ MonthPicker.propTypes = {
   onChange: PropTypes.func,
   /** The localeUtils from the DatePicker */
   localeUtils: PropTypes.instanceOf(Date),
+  /** Size of the MonthPicker component. */
+  size: PropTypes.oneOf(['smallest', 'small', 'medium', 'large']),
 };
 
 export default MonthPicker;

--- a/src/components/datepicker/MonthPicker.js
+++ b/src/components/datepicker/MonthPicker.js
@@ -6,9 +6,6 @@ import { Select } from '../select';
 import { NumericInput } from '../input';
 import theme from './theme.css';
 
-const currentYear = new Date().getFullYear();
-const fromMonth = new Date(currentYear, 0);
-const toMonth = new Date(currentYear + 10, 11);
 
 const formatSelectedMonth = ({ label, value }) => ({ value, label: label.substring(0, 3) });
 
@@ -22,11 +19,6 @@ const MonthPicker = ({ date, localeUtils, onChange, size }) => {
   const months = localeUtils.getMonths().map((monthName, index) => {
     return { value: index, label: monthName };
   });
-
-  const years = [];
-  for (let i = fromMonth.getFullYear(); i <= toMonth.getFullYear(); i += 1) {
-    years.push(i);
-  }
 
   useEffect(() => {
     setSelectedMonth({ value: date.getMonth(), label: localeUtils.formatMonthTitle(date) });

--- a/src/components/datepicker/MonthPicker.js
+++ b/src/components/datepicker/MonthPicker.js
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+import Box from '../box';
+import { Select } from '../select';
+import { NumericInput } from '../input';
+import theme from './theme.css';
+
+const currentYear = new Date().getFullYear();
+const fromMonth = new Date(currentYear, 0);
+const toMonth = new Date(currentYear + 10, 11);
+
+const MonthPicker = ({ date, localeUtils, onChange, small }) => {
+  const [selectedMonth, setSelectedMonth] = useState({
+    value: date.getMonth(),
+    label: localeUtils.formatMonthTitle(date),
+  });
+  const [selectedYear, setSelectedYear] = useState(date.getFullYear());
+
+  const months = localeUtils.getMonths().map((monthName, index) => {
+    return { value: index, label: monthName };
+  });
+
+  const years = [];
+  for (let i = fromMonth.getFullYear(); i <= toMonth.getFullYear(); i += 1) {
+    years.push(i);
+  }
+
+  useEffect(() => {
+    setSelectedMonth({ value: date.getMonth(), label: localeUtils.formatMonthTitle(date) });
+    setSelectedYear(date.getFullYear());
+  }, [date]);
+
+  const handleChangeMonth = selectedMonth => {
+    onChange(new Date(selectedYear, selectedMonth.value));
+  };
+
+  const handleChangeYear = (_, selectedYear) => {
+    onChange(new Date(selectedYear, selectedMonth.value));
+  };
+
+  return (
+    <Box className={theme['caption']}>
+      <Box display="flex" justifyContent="center">
+        <Select
+          value={selectedMonth}
+          className={theme['month-picker-field']}
+          options={months}
+          onChange={handleChangeMonth}
+          width={small ? 88 : 112}
+          size="small"
+        />
+        <NumericInput
+          value={`${selectedYear}`}
+          className={theme['month-picker-field']}
+          onChange={handleChangeYear}
+          width={small ? 72 : 80}
+          size="small"
+        />
+      </Box>
+    </Box>
+  );
+};
+
+MonthPicker.propTypes = {
+  /** Current date */
+  date: PropTypes.bool,
+  /** Callback function that is fired when the month has changed. */
+  onChange: PropTypes.func,
+  /** The localeUtils from the DatePicker */
+  localeUtils: PropTypes.instanceOf(Date),
+};
+
+export default MonthPicker;

--- a/src/components/datepicker/MonthPicker.js
+++ b/src/components/datepicker/MonthPicker.js
@@ -28,7 +28,10 @@ const getMonthOptions = localeUtils => {
   return monthOptions;
 };
 
+// e.g. "February 2020" => "Feb"
 const formatSelectedMonth = ({ label, value }) => ({ value, label: label.substring(0, 3) });
+
+// e.g. "February 2020" => "Feb 2020"
 const formatSelectMonthAndYear = ({ label, value }) => ({
   value,
   label: label.replace(/(\w{3})\w+\s(\d{4})/, '$1 $2'),

--- a/src/components/datepicker/MonthPicker.js
+++ b/src/components/datepicker/MonthPicker.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import Box from '../box';
@@ -38,14 +38,7 @@ const formatSelectMonthAndYear = ({ label, value }) => ({
 });
 
 const MonthPickerUnary = ({ date, localeUtils, onChange }) => {
-  const [selectedMonth, setSelectedMonth] = useState({
-    value: date.getMonth(),
-    label: localeUtils.formatMonthTitle(date),
-  });
-
-  useEffect(() => {
-    setSelectedMonth({ value: date, label: localeUtils.formatMonthTitle(date) });
-  }, [date]);
+  const selectedMonth = useMemo(() => ({ value: date.getMonth(), label: localeUtils.formatMonthTitle(date) }), [date]);
 
   const handleChangeMonth = selectedMonth => {
     onChange(selectedMonth.value);
@@ -68,20 +61,12 @@ const MonthPickerUnary = ({ date, localeUtils, onChange }) => {
 };
 
 const MonthPickerSplit = ({ date, localeUtils, onChange, size }) => {
-  const [selectedMonth, setSelectedMonth] = useState({
-    value: date.getMonth(),
-    label: localeUtils.formatMonthTitle(date),
-  });
-  const [selectedYear, setSelectedYear] = useState(date.getFullYear());
+  const selectedMonth = useMemo(() => ({ value: date.getMonth(), label: localeUtils.formatMonthTitle(date) }), [date]);
+  const selectedYear = useMemo(() => date.getFullYear(), [date]);
 
   const months = localeUtils.getMonths().map((monthName, index) => {
     return { value: index, label: monthName };
   });
-
-  useEffect(() => {
-    setSelectedMonth({ value: date.getMonth(), label: localeUtils.formatMonthTitle(date) });
-    setSelectedYear(date.getFullYear());
-  }, [date]);
 
   const handleChangeMonth = selectedMonth => {
     onChange(new Date(selectedYear, selectedMonth.value));

--- a/src/components/datepicker/MonthPicker.js
+++ b/src/components/datepicker/MonthPicker.js
@@ -10,6 +10,8 @@ const currentYear = new Date().getFullYear();
 const fromMonth = new Date(currentYear, 0);
 const toMonth = new Date(currentYear + 10, 11);
 
+const formatSelectedMonth = ({ label, value }) => ({ value, label: label.substring(0, 3) });
+
 const MonthPicker = ({ date, localeUtils, onChange, small }) => {
   const [selectedMonth, setSelectedMonth] = useState({
     value: date.getMonth(),
@@ -43,7 +45,7 @@ const MonthPicker = ({ date, localeUtils, onChange, small }) => {
     <Box className={theme['caption']}>
       <Box display="flex" justifyContent="center">
         <Select
-          value={selectedMonth}
+          value={formatSelectedMonth(selectedMonth)}
           className={theme['month-picker-field']}
           options={months}
           onChange={handleChangeMonth}

--- a/src/components/datepicker/MonthPicker.js
+++ b/src/components/datepicker/MonthPicker.js
@@ -29,6 +29,10 @@ const getMonthOptions = localeUtils => {
 };
 
 const formatSelectedMonth = ({ label, value }) => ({ value, label: label.substring(0, 3) });
+const formatSelectMonthAndYear = ({ label, value }) => ({
+  value,
+  label: label.replace(/(\w{3})\w+\s(\d{4})/, '$1 $2'),
+});
 
 const MonthPickerUnary = ({ date, localeUtils, onChange }) => {
   const [selectedMonth, setSelectedMonth] = useState({
@@ -48,7 +52,7 @@ const MonthPickerUnary = ({ date, localeUtils, onChange }) => {
     <Box className={theme['caption']}>
       <Box display="flex" justifyContent="center">
         <Select
-          value={selectedMonth}
+          value={formatSelectMonthAndYear(selectedMonth)}
           className={theme['month-picker-field']}
           options={getMonthOptions(localeUtils)}
           onChange={handleChangeMonth}

--- a/src/components/datepicker/NavigationBar.js
+++ b/src/components/datepicker/NavigationBar.js
@@ -8,6 +8,8 @@ import {
   IconArrowLeftSmallOutline,
   IconArrowRightSmallOutline,
 } from '@teamleader/ui-icons';
+import theme from './theme.css';
+import cx from 'classnames';
 
 class NavigationBar extends PureComponent {
   handlePreviousClick = () => {
@@ -19,14 +21,18 @@ class NavigationBar extends PureComponent {
   };
 
   render() {
-    const { className, localeUtils, nextMonth, previousMonth, size } = this.props;
+    const { className, localeUtils, nextMonth, previousMonth, size, withMonthPicker } = this.props;
 
     const months = localeUtils.getMonths();
     const previousMonthButtonLabel = months[previousMonth.getMonth()];
     const nextMonthButtonLabel = months[nextMonth.getMonth()];
 
     return (
-      <Box className={className} display="flex" justifyContent="space-between">
+      <Box
+        className={withMonthPicker ? cx(theme['navBar-with-month-picker'], className) : className}
+        display="flex"
+        justifyContent="space-between"
+      >
         <IconButton
           icon={size === 'large' ? <IconArrowLeftMediumOutline /> : <IconArrowLeftSmallOutline />}
           onClick={this.handlePreviousClick}

--- a/src/components/datepicker/datePicker.stories.js
+++ b/src/components/datepicker/datePicker.stories.js
@@ -66,6 +66,7 @@ export const singleDate = () => {
       showOutsideDays={boolean('Show outside days', true)}
       showWeekNumbers={boolean('Show week numbers', true)}
       size={select('Size', sizes, 'medium')}
+      withMonthPicker={boolean('Use month picker', false)}
     />
   );
 };
@@ -86,6 +87,7 @@ export const inputSingleDate = () => {
         numberOfMonths: number('Number of months', 1),
         showOutsideDays: boolean('Show outside days', true),
         showWeekNumbers: boolean('Show week numbers', true),
+        withMonthPicker: boolean('Use month picker', false),
       }}
       formatDate={customFormatDate}
       inputProps={{

--- a/src/components/datepicker/theme.css
+++ b/src/components/datepicker/theme.css
@@ -67,6 +67,13 @@
   right: 0;
 }
 
+.navBar-with-month-picker {
+  position: absolute;
+  left: 0;
+  top: 6px;
+  right: 0;
+}
+
 .caption {
   color: var(--color-teal-darkest);
   display: table-caption;

--- a/src/components/datepicker/theme.css
+++ b/src/components/datepicker/theme.css
@@ -74,6 +74,11 @@
   text-align: center;
 }
 
+.month-picker-field {
+  width: 87px;
+  margin: 0 3px;
+}
+
 .weekdays {
   background-color: var(--color-neutral-light);
   border-radius: var(--border-radius) var(--border-radius) 0 0;

--- a/src/components/datepicker/theme.css
+++ b/src/components/datepicker/theme.css
@@ -82,7 +82,7 @@
 }
 
 .month-picker-field {
-  width: 87px;
+  width: auto !important;
   margin: 0 3px;
 }
 

--- a/src/components/input/SingleLineInputBase.js
+++ b/src/components/input/SingleLineInputBase.js
@@ -52,6 +52,7 @@ class SingleLineInputBase extends PureComponent {
       suffix,
       width,
       warning,
+      noInputStyling,
       ...others
     } = this.props;
 
@@ -83,7 +84,7 @@ class SingleLineInputBase extends PureComponent {
 
     return (
       <Box className={classNames} {...boxProps}>
-        <div className={theme['input-wrapper']}>
+        <div className={cx(theme['input-wrapper'], noInputStyling && theme['is-input-disabled'])}>
           {connectedLeft}
           <div className={theme['input-inner-wrapper']} style={{ width, flex: width && '0 0 auto' }}>
             {prefix && <div className={theme['prefix-wrapper']}>{this.renderOneOrMultipleElements(prefix)}</div>}
@@ -117,6 +118,8 @@ SingleLineInputBase.propTypes = {
   warning: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
   /** A custom width for the input field */
   width: PropTypes.string,
+  /** Whether to disable styling that hints being able to type in the input field */
+  noInputStyling: PropTypes.bool,
 };
 
 export default SingleLineInputBase;

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -443,3 +443,12 @@
     }
   }
 }
+
+.is-input-disabled {
+  caret-color: transparent;
+
+  &.wrapper:hover .input-inner-wrapper,
+  .input:hover {
+    cursor: default;
+  }
+}


### PR DESCRIPTION
### Description

Add a smaller variant of MonthPicker that uses one selector instead of two fields for when `DatePicker` `size` is set the `small`

#### Screenshot before this PR

![Screenshot 2020-02-06 at 11 16 18](https://user-images.githubusercontent.com/19315705/73927699-23d95880-48d2-11ea-9871-52f0faed34b7.png)

#### Screenshot after this PR

![Screenshot 2020-02-06 at 11 15 56](https://user-images.githubusercontent.com/19315705/73927711-2c319380-48d2-11ea-9ac8-20fe1b759784.png)


### Breaking changes

None
