### PR TITLE
Select: override the default menu width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Select`: added `menuWidth` prop to set a custom width for the menu dropdown. ([@driesd](https://github.com/driesd) in [#845](https://github.com/teamleadercrm/ui/pull/845))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -197,7 +197,7 @@ class Select extends PureComponent {
   getOptionStyles = (base, { isDisabled, isFocused, isSelected }) => {
     const commonStyles = {
       ...base,
-      wordBreak: 'break-all',
+      wordBreak: 'break-word',
       padding: '8px 12px',
     };
 

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -133,10 +133,11 @@ class Select extends PureComponent {
   };
 
   getMenuPortalStyles = base => {
-    const { inverse } = this.props;
+    const { inverse, menuWidth } = this.props;
 
     return {
       ...base,
+      ...(menuWidth && { width: menuWidth }),
       backgroundColor: inverse ? COLOR.TEAL.NORMAL : COLOR.NEUTRAL.LIGHTEST,
       fontFamily: 'Inter-Regular',
       fontSize: '14px',
@@ -369,6 +370,8 @@ Select.propTypes = {
   inverse: PropTypes.bool,
   /** The HTML DOM node on which the portal should append */
   menuPortalTarget: PropTypes.instanceOf(Element),
+  /** A custom width for the menu dropdown */
+  menuWidth: PropTypes.string,
   /** Size of the input element. */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   /** The text string/element to use as success message below the input. */

--- a/src/components/select/select.stories.js
+++ b/src/components/select/select.stories.js
@@ -49,6 +49,7 @@ export const basic = () => (
     placeholder="Select your favourite(s)"
     size={select('Size', sizes, 'medium')}
     hideSelectedOptions={boolean('Hide selected options', true)}
+    menuWidth={text('Menu width', undefined)}
     error={text('error', '')}
     helpText={text('helpText', '')}
     success={text('success', '')}

--- a/src/components/select/select.stories.js
+++ b/src/components/select/select.stories.js
@@ -103,32 +103,6 @@ export const customOption = () => (
   />
 );
 
-export const withLabel = () => (
-  <Label inverse={boolean('Inverse', false)} size={select('Size', sizes, 'medium')}>
-    Select something
-    <Select
-      closeMenuOnSelect={boolean('Close menu on select', true)}
-      creatable={boolean('creatable', false)}
-      isClearable={boolean('Clearable', false)}
-      isDisabled={boolean('Disabled', false)}
-      isMulti={boolean('Multi select', false)}
-      isSearchable={boolean('Searchable', false)}
-      options={options}
-      placeholder="Select your favourite(s)"
-      hideSelectedOptions={boolean('Hide selected options', true)}
-      error={text('error', '')}
-      helpText={text('helpText', '')}
-      success={text('success', '')}
-      warning={text('warning', '')}
-      width={text('width', undefined)}
-    />
-  </Label>
-);
-
-withLabel.story = {
-  name: 'With label',
-};
-
 export const async = () => {
   const loadOptions = (searchTerm, pageSize = 10, pageNumber = 1) => {
     return new Promise(resolve => {


### PR DESCRIPTION
### Description

This PR adds the `menuWidth` prop to our Select component. This way we can override the default width of the menu dropdown.

Also, for menu options, I changed the `word-break` value from `break-all` to `break-word`. This does basically the same, but it will first try to break on words.

#### Screenshot before this PR

![Screenshot 2020-02-07 14 39 40](https://user-images.githubusercontent.com/5336831/74034342-5fe6e900-49b8-11ea-92e1-7d880b257e59.png)

#### Screenshot after this PR

![Screenshot 2020-02-07 14 39 27](https://user-images.githubusercontent.com/5336831/74034355-66756080-49b8-11ea-8105-4b1a34cf0728.png)

### Breaking changes

None.
