### PR TITLE
Release 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### Added
 
-- `Select`: added `menuWidth` prop to set a custom width for the menu dropdown. ([@driesd](https://github.com/driesd) in [#845](https://github.com/teamleadercrm/ui/pull/845))
-
 ### Changed
 
 ### Deprecated
@@ -13,6 +11,25 @@
 ### Fixed
 
 ### Dependency updates
+
+## [0.36.0] - 2019-02-07
+
+### Added
+
+- `Select`: added `menuWidth` prop to set a custom width for the menu dropdown. ([@driesd](https://github.com/driesd) in [#845](https://github.com/teamleadercrm/ui/pull/845))
+
+### Fixed
+
+- [Breaking] `NumericInput`: fixed the min and max value validation. ([@driesd](https://github.com/driesd) in [#846](https://github.com/teamleadercrm/ui/pull/846))
+
+### Dependency updates
+
+- `@storybook/ui` from `5.3.8` to `5.3.12`
+- `@storybook/addon-links` from `5.3.9` to `5.3.12`
+- `@babel/preset-env` from `7.8.3` to `7.8.4`
+- `@babel/runtime` from `7.8.3` to `7.8.4`
+- `eslint-config-prettier` from `6.9.0` to `6.10.0`
+- `husky` from `4.0.10` to `4.2.1`
 
 ## [0.35.8] - 2019-01-29
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.35.8",
+  "version": "0.36.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Added

- `Select`: added `menuWidth` prop to set a custom width for the menu dropdown. ([@driesd](https://github.com/driesd) in [#845](https://github.com/teamleadercrm/ui/pull/845))

### Fixed

- [Breaking] `NumericInput`: fixed the min and max value validation. ([@driesd](https://github.com/driesd) in [#846](https://github.com/teamleadercrm/ui/pull/846))

### Dependency updates

- `@storybook/ui` from `5.3.8` to `5.3.12`
- `@storybook/addon-links` from `5.3.9` to `5.3.12`
- `@babel/preset-env` from `7.8.3` to `7.8.4`
- `@babel/runtime` from `7.8.3` to `7.8.4`
- `eslint-config-prettier` from `6.9.0` to `6.10.0`
- `husky` from `4.0.10` to `4.2.1`
