### PR TITLE
NumericInput: remove value parsing on change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `NumericInput`: remove min and max validation when input value changes. ([@driesd](https://github.com/driesd) in [#851](https://github.com/teamleadercrm/ui/pull/851))
+
 ### Dependency updates
 
 ## [0.36.0] - 2019-02-07

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -55,8 +55,7 @@ class NumericInput extends PureComponent {
   };
 
   handleOnChange = event => {
-    const { min, max } = this.props;
-    this.setState({ value: parseValue(event.currentTarget.value, min, max) });
+    this.setState({ value: event.currentTarget.value });
   };
 
   updateStep = n => {


### PR DESCRIPTION
This PR removes the on change value parsing of our `NumericInput` component. We do this because we don't want to bind to min/max values here.

With this PR, we can clear the field with backspace again, which we broke in [release 0.36.0](https://github.com/teamleadercrm/ui/releases/tag/0.36.0).

### Breaking changes

None.
