### PR TITLE
[BUG] DatePickerInput: don't allow null to be returned as value

### DIFF
--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -32,7 +32,7 @@ class DatePickerInput extends PureComponent {
     const { selectedDate } = this.state;
 
     if (!selectedDate) {
-      return null;
+      return undefined;
     }
 
     if (!customFormatDate) {


### PR DESCRIPTION
### Description

- Returning `null` as value is not allowed and throws an error
  - This is fixed by returning `undefined` instead of `value`

![image](https://user-images.githubusercontent.com/17139460/74541799-97b6d900-4f42-11ea-95e0-42f32cbc668a.png)
