### PR TITLE
[BUG] Use empty string as default on null values in the DatePickerInput.js component.

### DIFF
--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -32,7 +32,7 @@ class DatePickerInput extends PureComponent {
     const { selectedDate } = this.state;
 
     if (!selectedDate) {
-      return undefined;
+      return '';
     }
 
     if (!customFormatDate) {


### PR DESCRIPTION
### Description

- Since `undefined` made the input component and uncontrolled one, there was an error when picking a date. This is fixed by giving it "empty" input.
