### PR TITLE
Dialog: expose a Header, Body and Footer component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Dialog`: added a `DialogBase.Header`, `DialogBase.Body` and `DialogBase.Footer` component, for if you want to make custom dialogs ([@lowiebenoot](https://github.com/lowiebenoot) in [#875](https://github.com/teamleadercrm/ui/pull/875))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/dialog/Body.js
+++ b/src/components/dialog/Body.js
@@ -1,0 +1,29 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import { Box } from '../../index';
+
+class Body extends PureComponent {
+  render() {
+    const { scrollable, children, ...rest } = this.props;
+
+    if (!scrollable) {
+      return children;
+    }
+
+    return (
+      <Box display="flex" flexDirection="column" overflowY="auto" {...rest}>
+        {children}
+      </Box>
+    );
+  }
+}
+
+Body.propTypes = {
+  /** The content to display inside the dialog. */
+  children: PropTypes.any,
+  /** If true, the content will be scrollable when it exceeds the available height. */
+  scrollable: PropTypes.bool,
+};
+
+export default Body;

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -5,7 +5,7 @@ import cx from 'classnames';
 
 import theme from './theme.css';
 
-import { Banner, Box, Button, ButtonGroup, DialogBase, Heading2, Heading3, Link } from '../../index';
+import { Button, ButtonGroup, DialogBase, Heading2, Heading3, Link } from '../../index';
 import { COLORS } from '../../constants';
 
 class Dialog extends PureComponent {
@@ -13,9 +13,9 @@ class Dialog extends PureComponent {
     const { headerColor, headerIcon, headingLevel, onCloseClick, title } = this.props;
 
     return (
-      <Banner color={headerColor} fullWidth icon={headerIcon} onClose={onCloseClick}>
+      <DialogBase.Header color={headerColor} icon={headerIcon} onClose={onCloseClick}>
         {headingLevel === 2 ? <Heading2>{title}</Heading2> : <Heading3>{title}</Heading3>}
-      </Banner>
+      </DialogBase.Header>
     );
   };
 
@@ -23,11 +23,13 @@ class Dialog extends PureComponent {
     const { tertiaryAction, secondaryAction, primaryAction } = this.props;
 
     return (
-      <ButtonGroup justifyContent="flex-end" padding={4}>
-        {tertiaryAction && <Link inherit={false} {...tertiaryAction} />}
-        {secondaryAction && <Button {...secondaryAction} />}
-        <Button level="primary" {...primaryAction} />
-      </ButtonGroup>
+      <DialogBase.Footer>
+        <ButtonGroup justifyContent="flex-end">
+          {tertiaryAction && <Link inherit={false} {...tertiaryAction} />}
+          {secondaryAction && <Button {...secondaryAction} />}
+          <Button level="primary" {...primaryAction} />
+        </ButtonGroup>
+      </DialogBase.Footer>
     );
   };
 
@@ -47,13 +49,7 @@ class Dialog extends PureComponent {
     return (
       <DialogBase className={classNames} {...restProps} scrollable={false}>
         {title && this.getHeader()}
-        {scrollable ? (
-          <Box display="flex" flexDirection="column" overflowY="auto">
-            {children}
-          </Box>
-        ) : (
-          children
-        )}
+        <DialogBase.Body scrollable={scrollable}>{children}</DialogBase.Body>
         {this.getFooter()}
       </DialogBase>
     );

--- a/src/components/dialog/DialogBase.js
+++ b/src/components/dialog/DialogBase.js
@@ -5,6 +5,9 @@ import cx from 'classnames';
 import Box from '../box';
 import Overlay from '../overlay/Overlay';
 import Transition from 'react-transition-group/Transition';
+import Header from './Header';
+import Body from './Body';
+import Footer from './Footer';
 import theme from './theme.css';
 import uiUtilities from '@teamleader/ui-utilities';
 
@@ -112,5 +115,9 @@ DialogBase.defaultProps = {
   scrollable: true,
   size: 'medium',
 };
+
+DialogBase.Header = Header;
+DialogBase.Body = Body;
+DialogBase.Footer = Footer;
 
 export default DialogBase;

--- a/src/components/dialog/Footer.js
+++ b/src/components/dialog/Footer.js
@@ -1,0 +1,23 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import { Box } from '../../index';
+
+class Footer extends PureComponent {
+  render() {
+    const { children, ...rest } = this.props;
+
+    return (
+      <Box justifyContent="flex-end" padding={4} {...rest}>
+        {children}
+      </Box>
+    );
+  }
+}
+
+Footer.propTypes = {
+  /** The content to display inside the dialog. */
+  children: PropTypes.any,
+};
+
+export default Footer;

--- a/src/components/dialog/Header.js
+++ b/src/components/dialog/Header.js
@@ -1,0 +1,30 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import { Banner } from '../../index';
+import { COLORS } from '../../constants';
+
+class Header extends PureComponent {
+  render() {
+    const { color, icon, onCloseClick, children, ...rest } = this.props;
+
+    return (
+      <Banner color={color} fullWidth icon={icon} onClose={onCloseClick} {...rest}>
+        {children}
+      </Banner>
+    );
+  }
+}
+
+Header.propTypes = {
+  /** The content to display inside the dialog. */
+  children: PropTypes.any,
+  /** The color of the banner */
+  color: PropTypes.oneOf(COLORS),
+  /** The icon in the banner. */
+  icon: PropTypes.element,
+  /** Callback function that is fired when the close icon clicked. */
+  onCloseClick: PropTypes.func,
+};
+
+export default Header;


### PR DESCRIPTION
### Description

This PR will expose a Header, Body and Footer component on the DialogBase component. You can use for building custom dialogs, without having to copy/mimic the internal parts of the Dialog component

`<DialogBase.Header>`
`<DialogBase.Body>`
`<DialogBase.Footer>`


### Breaking changes

None.
