### PR TITLE
NumericInput: remove value parsing in getDerivedStateFromProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Removed
 
+- `NumericInput`: remove value parsing in `getDerivedStateFromProps`. ([@driesd](https://github.com/driesd) in [#876](https://github.com/teamleadercrm/ui/pull/876))
+
 ### Fixed
 
 ### Dependency updates

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -43,7 +43,7 @@ class NumericInput extends PureComponent {
       const newValue = nextProps.value || '';
       if (newValue !== prevState.value) {
         return {
-          value: parseValue(newValue, nextProps.min, nextProps.max),
+          value: newValue,
         };
       }
     }


### PR DESCRIPTION
### Description

This PR removes the value parsing in getDerivedStateFromProps. In an [earlier PR](https://github.com/teamleadercrm/ui/pull/846/commits/5c273076ff647cf3c9556f4abefb29e37aaed15b), we introduced this initial value parsing in getDerivedStateFromProps. After evaluating this, it became clear that it was breaking more than it was fixing things.

### Breaking changes

None.
