### PR TITLE
NumericInput: text align right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `InputBase`: added `textAlignRight` prop. If true, the input text is aligned to the right. ([@driesd](https://github.com/driesd) in [#879](https://github.com/teamleadercrm/ui/pull/879))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/input/InputBase.js
+++ b/src/components/input/InputBase.js
@@ -6,7 +6,7 @@ import theme from './theme.css';
 
 class InputBase extends PureComponent {
   render() {
-    const { bold, className, element, innerRef, inverse, size, ...otherProps } = this.props;
+    const { bold, className, element, innerRef, inverse, size, textAlignRight, ...otherProps } = this.props;
 
     const classNames = cx(
       theme['input'],
@@ -14,6 +14,7 @@ class InputBase extends PureComponent {
       {
         [theme['is-inverse']]: inverse,
         [theme['is-bold']]: bold,
+        [theme['has-text-align-right']]: textAlignRight,
       },
       className,
     );

--- a/src/components/input/input.stories.js
+++ b/src/components/input/input.stories.js
@@ -109,6 +109,7 @@ export const input = () => (
     }
     prefix={boolean('Toggle prefix', false) ? prefix : undefined}
     suffix={boolean('Toggle suffix', false) ? suffix : undefined}
+    textAlignRight={boolean('Text align right', false)}
     width={text('Width', undefined)}
   />
 );
@@ -151,6 +152,7 @@ export const numericInput = () => {
         onChange={handleNumericInputChange}
         prefix={boolean('Toggle prefix', false) ? prefix : undefined}
         suffix={boolean('Toggle suffix', false) ? suffix : undefined}
+        textAlignRight={boolean('Text align right', false)}
         width={text('Width', undefined)}
       />
     </State>
@@ -193,6 +195,7 @@ export const timeInput = () => (
       }
       prefix={boolean('Toggle prefix', false) ? prefix : undefined}
       suffix={boolean('Toggle suffix', false) ? suffix : undefined}
+      textAlignRight={boolean('Text align right', false)}
       width={text('Width', '90px')}
       onChange={handleTimeInputChange}
     />
@@ -216,6 +219,7 @@ export const textarea = () => (
     placeholder={text('Placeholder', placeholder)}
     readOnly={boolean('Read only', false)}
     size={select('Size', sizes) || undefined}
+    textAlignRight={boolean('Text align right', false)}
     value={text('Value', undefined)}
   />
 );

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -384,6 +384,10 @@
   }
 }
 
+.has-text-align-right {
+  text-align: right;
+}
+
 .has-success {
   &:not(.is-inverse) {
     .input-inner-wrapper,


### PR DESCRIPTION
### Description

This PR adds the `textAlignRight` boolean prop to our `InputBase` component. If true, the input text is aligned to the right.

#### Screenshot with textAlignRight FALSE

![Screenshot 2020-02-19 16 18 35](https://user-images.githubusercontent.com/5336831/74913345-bc86d280-53c0-11ea-935e-a28cf803b1e1.png)

#### Screenshot with textAlignRight TRUE

![Screenshot 2020-02-19 16 18 28](https://user-images.githubusercontent.com/5336831/74913363-c3ade080-53c0-11ea-93c1-59d70a29b959.png)

### Breaking changes

None.
