### PR TITLE
[AHOY-360] Remove icon from validation messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Removed
 
+- `ErrorText`, `SuccessText` & `WarningText`: removed the icon in front of the text. ([@driesd](https://github.com/driesd) in [#881](https://github.com/teamleadercrm/ui/pull/881))
+
 ### Fixed
 
 ### Dependency updates

--- a/src/components/validationText/ErrorText.js
+++ b/src/components/validationText/ErrorText.js
@@ -1,9 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { IconWarningBadgedSmallFilled } from '@teamleader/ui-icons';
 import { TextSmall } from '../typography';
 import Box from '../box';
-import Icon from '../icon';
 
 export default class ErrorText extends PureComponent {
   render() {
@@ -18,10 +16,7 @@ export default class ErrorText extends PureComponent {
         marginTop={2}
         {...others}
       >
-        <Icon color="ruby" tint={inverse ? 'light' : 'dark'}>
-          <IconWarningBadgedSmallFilled />
-        </Icon>
-        <TextSmall color="ruby" element="span" marginLeft={1} tint={inverse ? 'light' : 'dark'}>
+        <TextSmall color="ruby" element="span" tint={inverse ? 'light' : 'dark'}>
           {children}
         </TextSmall>
       </Box>

--- a/src/components/validationText/ErrorText.js
+++ b/src/components/validationText/ErrorText.js
@@ -4,11 +4,10 @@ import { TextSmall } from '../typography';
 
 export default class ErrorText extends PureComponent {
   render() {
-    const { children, className, inverse, ...others } = this.props;
+    const { children, inverse, ...others } = this.props;
 
     return (
       <TextSmall
-        className={className}
         color="ruby"
         data-teamleader-ui="error-text"
         marginTop={1}
@@ -24,8 +23,6 @@ export default class ErrorText extends PureComponent {
 ErrorText.propTypes = {
   /** The displayed text */
   children: PropTypes.node,
-  /** The class name for the wrapper to give custom styles */
-  className: PropTypes.string,
   /** Determines if the component will be rendered in inverse mode */
   inverse: PropTypes.bool,
 };

--- a/src/components/validationText/ErrorText.js
+++ b/src/components/validationText/ErrorText.js
@@ -11,7 +11,7 @@ export default class ErrorText extends PureComponent {
         className={className}
         color="ruby"
         data-teamleader-ui="error-text"
-        marginTop={2}
+        marginTop={1}
         tint={inverse ? 'light' : 'dark'}
         {...others}
       >

--- a/src/components/validationText/ErrorText.js
+++ b/src/components/validationText/ErrorText.js
@@ -1,25 +1,22 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { TextSmall } from '../typography';
-import Box from '../box';
 
 export default class ErrorText extends PureComponent {
   render() {
     const { children, className, inverse, ...others } = this.props;
 
     return (
-      <Box
+      <TextSmall
         className={className}
-        alignItems="center"
+        color="ruby"
         data-teamleader-ui="error-text"
-        display="flex"
         marginTop={2}
+        tint={inverse ? 'light' : 'dark'}
         {...others}
       >
-        <TextSmall color="ruby" element="span" tint={inverse ? 'light' : 'dark'}>
-          {children}
-        </TextSmall>
-      </Box>
+        {children}
+      </TextSmall>
     );
   }
 }

--- a/src/components/validationText/HelpText.js
+++ b/src/components/validationText/HelpText.js
@@ -5,11 +5,10 @@ import { TextSmall } from '../typography';
 
 export default class HelpText extends PureComponent {
   render() {
-    const { children, className, inverse, ...others } = this.props;
+    const { children, inverse, ...others } = this.props;
 
     return (
       <TextSmall
-        className={className}
         color={inverse ? 'teal' : 'neutral'}
         data-teamleader-ui="help-text"
         marginTop={1}
@@ -25,8 +24,6 @@ export default class HelpText extends PureComponent {
 HelpText.propTypes = {
   /** The displayed text */
   children: PropTypes.node,
-  /** The class name for the wrapper to give custom styles */
-  className: PropTypes.string,
   /** Determines if the component will be rendered in inverse mode */
   inverse: PropTypes.bool,
 };

--- a/src/components/validationText/SuccessText.js
+++ b/src/components/validationText/SuccessText.js
@@ -4,11 +4,10 @@ import { TextSmall } from '../typography';
 
 export default class SuccessText extends PureComponent {
   render() {
-    const { children, className, inverse, ...others } = this.props;
+    const { children, inverse, ...others } = this.props;
 
     return (
       <TextSmall
-        className={className}
         color="mint"
         data-teamleader-ui="success-text"
         marginTop={1}
@@ -24,8 +23,6 @@ export default class SuccessText extends PureComponent {
 SuccessText.propTypes = {
   /** The displayed text */
   children: PropTypes.node,
-  /** The class name for the wrapper to give custom styles */
-  className: PropTypes.string,
   /** Determines if the component will be rendered in inverse mode */
   inverse: PropTypes.bool,
 };

--- a/src/components/validationText/SuccessText.js
+++ b/src/components/validationText/SuccessText.js
@@ -1,9 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { IconCheckmarkSmallFilled } from '@teamleader/ui-icons';
 import { TextSmall } from '../typography';
 import Box from '../box';
-import Icon from '../icon';
 
 export default class SuccessText extends PureComponent {
   render() {
@@ -18,9 +16,6 @@ export default class SuccessText extends PureComponent {
         marginTop={2}
         {...others}
       >
-        <Icon color="mint" tint={inverse ? 'light' : 'dark'}>
-          <IconCheckmarkSmallFilled />
-        </Icon>
         <TextSmall color="mint" element="span" marginLeft={1} tint={inverse ? 'light' : 'dark'}>
           {children}
         </TextSmall>

--- a/src/components/validationText/SuccessText.js
+++ b/src/components/validationText/SuccessText.js
@@ -1,25 +1,22 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { TextSmall } from '../typography';
-import Box from '../box';
 
 export default class SuccessText extends PureComponent {
   render() {
     const { children, className, inverse, ...others } = this.props;
 
     return (
-      <Box
+      <TextSmall
         className={className}
-        alignItems="center"
+        color="mint"
         data-teamleader-ui="success-text"
-        display="flex"
-        marginTop={2}
+        marginTop={1}
+        tint={inverse ? 'light' : 'dark'}
         {...others}
       >
-        <TextSmall color="mint" element="span" marginLeft={1} tint={inverse ? 'light' : 'dark'}>
-          {children}
-        </TextSmall>
-      </Box>
+        {children}
+      </TextSmall>
     );
   }
 }

--- a/src/components/validationText/WarningText.js
+++ b/src/components/validationText/WarningText.js
@@ -1,9 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { IconWarningBadgedSmallFilled } from '@teamleader/ui-icons';
 import { TextSmall } from '../typography';
 import Box from '../box';
-import Icon from '../icon';
 
 export default class WarningText extends PureComponent {
   render() {
@@ -18,9 +16,6 @@ export default class WarningText extends PureComponent {
         marginTop={2}
         {...others}
       >
-        <Icon color="gold" tint={inverse ? 'light' : 'dark'}>
-          <IconWarningBadgedSmallFilled />
-        </Icon>
         <TextSmall color="gold" element="span" marginLeft={1} tint={inverse ? 'light' : 'dark'}>
           {children}
         </TextSmall>

--- a/src/components/validationText/WarningText.js
+++ b/src/components/validationText/WarningText.js
@@ -4,11 +4,10 @@ import { TextSmall } from '../typography';
 
 export default class WarningText extends PureComponent {
   render() {
-    const { children, className, inverse, ...others } = this.props;
+    const { children, inverse, ...others } = this.props;
 
     return (
       <TextSmall
-        className={className}
         color="gold"
         data-teamleader-ui="warning-text"
         marginTop={1}
@@ -24,8 +23,6 @@ export default class WarningText extends PureComponent {
 WarningText.propTypes = {
   /** The displayed text */
   children: PropTypes.node,
-  /** The class name for the wrapper to give custom styles */
-  className: PropTypes.string,
   /** Determines if the component will be rendered in inverse mode */
   inverse: PropTypes.bool,
 };

--- a/src/components/validationText/WarningText.js
+++ b/src/components/validationText/WarningText.js
@@ -1,25 +1,22 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { TextSmall } from '../typography';
-import Box from '../box';
 
 export default class WarningText extends PureComponent {
   render() {
     const { children, className, inverse, ...others } = this.props;
 
     return (
-      <Box
+      <TextSmall
         className={className}
-        alignItems="center"
+        color="gold"
         data-teamleader-ui="warning-text"
-        display="flex"
-        marginTop={2}
+        marginTop={1}
+        tint={inverse ? 'light' : 'dark'}
         {...others}
       >
-        <TextSmall color="gold" element="span" marginLeft={1} tint={inverse ? 'light' : 'dark'}>
-          {children}
-        </TextSmall>
-      </Box>
+        {children}
+      </TextSmall>
     );
   }
 }


### PR DESCRIPTION
### Description

This PR removes the `icon` from our validation messages:
- `ErrorText`
- `SuccessText`
- `WarningText`

We do this because when in a form multiple fields are showing an error message, it became visually too crowded.

#### Screenshot before this PR

![Screenshot 2020-02-20 13 44 41](https://user-images.githubusercontent.com/5336831/74934932-945e9a00-53e7-11ea-86b6-79ac16248e54.png)

#### Screenshot after this PR
![Screenshot 2020-02-20 13 44 17](https://user-images.githubusercontent.com/5336831/74934942-9aed1180-53e7-11ea-811f-b5eaf1beb517.png)

### Breaking changes

None.
