### PR TITLE
Avatar stack: fix margins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `AvatarStack`: fixed the spacing between the avatars. ([@driesd](https://github.com/driesd) in [#895](https://github.com/teamleadercrm/ui/pull/895))
+
 ### Dependency updates
 
 ## [0.36.6] - 2020-02-26
@@ -17,14 +19,6 @@
 ### Added
 
 - `SplitButton`: added `disabled` prop. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#883](https://github.com/teamleadercrm/ui/pull/883))
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
 
 ### Dependency updates
 

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -9,20 +9,24 @@ class AvatarStack extends PureComponent {
   render() {
     const { children, className, direction, displayMax, inverse, onOverflowClick, size, ...others } = this.props;
 
+    const childrenToDisplay = displayMax > 0 ? children.slice(0, displayMax) : children;
+    const overflowAmount = children.length - displayMax;
+    const hasOverflow = overflowAmount > 0;
+
     const classNames = cx(
       theme['stack'],
       theme[direction],
       theme[`is-${size}`],
       inverse ? [theme['light']] : [theme['dark']],
+      {
+        [theme['has-overflow']]: hasOverflow,
+      },
       className,
     );
-
-    const childrenToDisplay = displayMax > 0 ? children.slice(0, displayMax) : children;
-    const overflowAmount = children.length - displayMax;
     return (
       <Box data-teamleader-ui="avatar-stack" className={classNames} {...others}>
         {childrenToDisplay.map((child, index) => cloneElement(child, { key: index, ...child.props, size }))}
-        {overflowAmount > 0 && (
+        {hasOverflow && (
           <div
             className={cx(uiUtilities['reset-font-smoothing'], theme['overflow'])}
             onClick={onOverflowClick}

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -303,6 +303,18 @@
   }
 }
 
+.has-overflow {
+  .is-selectable,
+  .is-selected {
+    &:not(.is-hero) + .overflow {
+      margin: 3px;
+    }
+    &.is-hero + .overflow {
+      margin: 6px;
+    }
+  }
+}
+
 /*AvatarInitials*/
 .avatar-initials {
   display: flex;

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -92,7 +92,7 @@
   flex-direction: row;
 
   > *:not(:last-child) {
-    margin-left: var(--stacked-avatars-spacing);
+    margin-right: var(--stacked-avatars-spacing);
   }
 }
 
@@ -100,7 +100,7 @@
   flex-direction: column;
 
   > *:not(:last-child) {
-    margin-top: var(--stacked-avatars-spacing);
+    margin-bottom: var(--stacked-avatars-spacing);
   }
 }
 


### PR DESCRIPTION
### Description

This PR fixes the spacing between the avatars and overflow indicator. Also the left margin became a right margin [since we don't use inverse flex direction anymore](https://github.com/teamleadercrm/ui/pull/738/commits/558362ed7ecfff11ff6a295b53bfde5011e3c4df).

#### Screenshot before this PR
<img width="353" alt="Screenshot 2020-02-28 11 10 58" src="https://user-images.githubusercontent.com/5336831/75539740-0d2ea900-5a1b-11ea-822b-b5bb8327b731.png">

#### Screenshot after this PR

<img width="355" alt="Screenshot 2020-02-28 11 10 32" src="https://user-images.githubusercontent.com/5336831/75539763-1455b700-5a1b-11ea-886d-1aaabc5f91b9.png">

### Breaking changes

None.
