### PR TITLE
♿️ Fallback to avatar initials when image not found

### DIFF
--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -12,7 +12,18 @@ import omit from 'lodash.omit';
 import { IconCloseMediumOutline, IconCloseSmallOutline } from '@teamleader/ui-icons';
 
 class Avatar extends PureComponent {
+  state = {
+    failedToLoadImage: false,
+  };
+
+  onImageLoadFailure = () => {
+    this.setState({
+      failedToLoadImage: true,
+    })
+  };
+
   renderComponent = () => {
+    const { failedToLoadImage } = this.state;
     const { creatable, children, editable, imageUrl, fullName, id, onImageChange, selected, size } = this.props;
 
     const childrenToRender = selected ? (
@@ -36,7 +47,7 @@ class Avatar extends PureComponent {
       return <AvatarAdd children={children} size={size} />;
     }
 
-    if (imageUrl) {
+    if (imageUrl && !failedToLoadImage) {
       return (
         <AvatarImage
           children={childrenToRender}
@@ -44,6 +55,7 @@ class Avatar extends PureComponent {
           image={imageUrl}
           imageAlt={fullName}
           onImageChange={onImageChange}
+          onImageLoadFailure={this.onImageLoadFailure}
           size={size}
         />
       );

--- a/src/components/avatar/AvatarImage.js
+++ b/src/components/avatar/AvatarImage.js
@@ -5,11 +5,11 @@ import AvatarOverlay from './AvatarOverlay';
 
 class AvatarImage extends PureComponent {
   render() {
-    const { children, editable, image, imageAlt, onImageChange, size } = this.props;
+    const { children, editable, image, imageAlt, onImageChange, size, onImageLoadFailure } = this.props;
 
     return (
       <div className={theme['avatar-image']} data-teamleader-ui="avatar-image">
-        <img alt={imageAlt} src={image} className={theme['image']} />
+        <img alt={imageAlt} onError={onImageLoadFailure} src={image} className={theme['image']} />
         {editable && (size === 'large' || size === 'hero') && <AvatarOverlay onClick={onImageChange} />}
         {children && <div className={theme['children']}>{children}</div>}
       </div>


### PR DESCRIPTION
### Description

This PR makes sure that when an image is not found and the fullName is passed we render the AvatarInitials component. It's nicer than the `alt` attribute, we've got a nicely designed component for it, so let's use it.

#### Screenshot before this PR

![image](https://user-images.githubusercontent.com/9056632/75768562-e0450380-5d44-11ea-8904-2c6cd6e96db3.png)


#### Screenshot after this PR

![image](https://user-images.githubusercontent.com/9056632/75768589-ec30c580-5d44-11ea-9fc9-beaacfab102d.png)


### Breaking changes

- None
