### PR TITLE
♻️ Render AvatarInitials without providing id

### DIFF
--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -49,7 +49,7 @@ class Avatar extends PureComponent {
       );
     }
 
-    if (fullName && id) {
+    if (fullName) {
       return (
         <AvatarInitials
           children={childrenToRender}

--- a/src/components/avatar/AvatarInitials.js
+++ b/src/components/avatar/AvatarInitials.js
@@ -32,7 +32,7 @@ class AvatarInitials extends PureComponent {
   };
 
   render() {
-    const { children, editable, onImageChange, size } = this.props;
+    const { children, editable, id, onImageChange, size } = this.props;
 
     return (
       <Box
@@ -41,7 +41,9 @@ class AvatarInitials extends PureComponent {
         className={theme['avatar-initials']}
         data-teamleader-ui="avatar-initials"
       >
-        <Heading4 className={theme['initials']}>{this.getInitials()}</Heading4>
+        <Heading4 className={theme['initials']} color="neutral" tint={id ? 'lightest' : 'darkest'}>
+          {this.getInitials()}
+        </Heading4>
         {editable && (size === 'large' || size === 'hero') && <AvatarOverlay onClick={onImageChange} />}
         {children && <div className={theme['children']}>{children}</div>}
       </Box>

--- a/src/components/avatar/AvatarInitials.js
+++ b/src/components/avatar/AvatarInitials.js
@@ -10,7 +10,7 @@ const colors = colorsWithout(['neutral']);
 const hashCode = hexString => parseInt(hexString.substr(-5), 16);
 
 class AvatarInitials extends PureComponent {
-  getColor = () => {
+  getBackgroundColor = () => {
     const { id } = this.props;
 
     if (!id) {
@@ -36,7 +36,7 @@ class AvatarInitials extends PureComponent {
 
     return (
       <Box
-        backgroundColor={this.getColor()}
+        backgroundColor={this.getBackgroundColor()}
         backgroundTint="normal"
         className={theme['avatar-initials']}
         data-teamleader-ui="avatar-initials"

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -323,7 +323,6 @@
   user-select: none;
 
   .initials {
-    color: var(--color-neutral-lightest);
     text-transform: uppercase;
     letter-spacing: 0px;
   }

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -323,7 +323,6 @@
   user-select: none;
 
   .initials {
-    text-transform: uppercase;
     letter-spacing: 0px;
   }
 }


### PR DESCRIPTION
### Description

This PR makes sure the AvatarInitials still gets rendered even when an `id` is not provided. The only thing you actually need is the full name to create the initials. There's already a check inside the component that when the `id` is not provided it should return the `neutral` color. However, the if clause never allowed an `id` to be undefined so it just would skip that component and return AvatarAnonymous.

#### Screenshot before this PR

![image](https://user-images.githubusercontent.com/9056632/75769375-5d24ad00-5d46-11ea-8e69-ffd3da939ba8.png)

#### Screenshot after this PR


![image](https://user-images.githubusercontent.com/9056632/75769343-4c743700-5d46-11ea-9cda-f76456be075a.png)


### Breaking changes

none
