### PR TITLE
Avatar: refactor [part 1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Changed
 
+- `Avatar`: removed 3px spacing around avatars. ([@driesd](https://github.com/driesd) in [#914](https://github.com/teamleadercrm/ui/pull/914)
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- `Avatar`: fixed a visual glitch when `editable` prop was `true`. ([@driesd](https://github.com/driesd) in [#914](https://github.com/teamleadercrm/ui/pull/914)
 
 ### Dependency updates
 
@@ -20,7 +24,7 @@
 
 ### Fixed
 
-- `Avatar`: fix linting error to fix CI build process. ([@driesd](https://github.com/driesd) in [#910](https://github.com/teamleadercrm/ui/pull/910))
+- `Avatar`: fix linting error to fix CI build process. ([@driesd](https://github.com/driesd) in [#910](https://github.com/teamleadercrm/ui/pull/910)
 
 ### Dependency updates
 

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -102,12 +102,7 @@ class Avatar extends PureComponent {
     ]);
 
     return (
-      <Box
-        {...restProps}
-        className={avatarClassNames}
-        padding={onClick ? (size === 'hero' ? 2 : 1) : 0}
-        boxSizing="content-box"
-      >
+      <Box {...restProps} className={avatarClassNames}>
         {this.renderComponent()}
       </Box>
     );

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -81,7 +81,7 @@ class Avatar extends PureComponent {
     const { className, onClick, selected, size, shape, ...others } = this.props;
 
     const avatarClassNames = cx(
-      theme['avatar'],
+      theme['wrapper'],
       theme[`is-${size}`],
       theme[`is-${shape}`],
       {

--- a/src/components/avatar/AvatarAdd.js
+++ b/src/components/avatar/AvatarAdd.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import theme from './theme.css';
 import Box from '../box';
 import Icon from '../icon';
@@ -14,7 +15,7 @@ class AvatarAdd extends PureComponent {
         alignItems="center"
         backgroundColor="neutral"
         backgroundTint="normal"
-        className={theme['avatar-add']}
+        className={cx(theme['avatar'], theme['avatar-add'])}
         data-teamleader-ui="avatar-add"
         display="flex"
         justifyContent="center"

--- a/src/components/avatar/AvatarAdd.js
+++ b/src/components/avatar/AvatarAdd.js
@@ -11,10 +11,13 @@ class AvatarAdd extends PureComponent {
 
     return (
       <Box
+        alignItems="center"
         backgroundColor="neutral"
         backgroundTint="normal"
         className={theme['avatar-add']}
         data-teamleader-ui="avatar-add"
+        display="flex"
+        justifyContent="center"
       >
         <Icon color="neutral" tint="darkest">
           {size === 'tiny' || size === 'small' ? <IconUserAddSmallOutline /> : <IconUserAddMediumOutline />}

--- a/src/components/avatar/AvatarAnonymous.js
+++ b/src/components/avatar/AvatarAnonymous.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import theme from './theme.css';
 import Box from '../box';
 import Icon from '../icon';
@@ -14,7 +15,7 @@ class AvatarAnonymous extends PureComponent {
         alignItems="center"
         backgroundColor="neutral"
         backgroundTint="normal"
-        className={theme['avatar-anonymous']}
+        className={cx(theme['avatar'], theme['avatar-anonymous'])}
         data-teamleader-ui="avatar-anonymous"
         display="flex"
         justifyContent="center"

--- a/src/components/avatar/AvatarAnonymous.js
+++ b/src/components/avatar/AvatarAnonymous.js
@@ -11,10 +11,13 @@ class AvatarAnonymous extends PureComponent {
 
     return (
       <Box
+        alignItems="center"
         backgroundColor="neutral"
         backgroundTint="normal"
         className={theme['avatar-anonymous']}
         data-teamleader-ui="avatar-anonymous"
+        display="flex"
+        justifyContent="center"
       >
         <Icon color="neutral" tint="darkest">
           {size === 'tiny' || size === 'small' ? <IconUserSmallOutline /> : <IconUserMediumOutline />}

--- a/src/components/avatar/AvatarImage.js
+++ b/src/components/avatar/AvatarImage.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import theme from './theme.css';
 import AvatarOverlay from './AvatarOverlay';
 
@@ -8,7 +9,7 @@ class AvatarImage extends PureComponent {
     const { children, editable, image, imageAlt, onImageChange, size, onImageLoadFailure } = this.props;
 
     return (
-      <div className={theme['avatar-image']} data-teamleader-ui="avatar-image">
+      <div className={cx(theme['avatar'], theme['avatar-image'])} data-teamleader-ui="avatar-image">
         <img alt={imageAlt} onError={onImageLoadFailure} src={image} className={theme['image']} />
         {editable && (size === 'large' || size === 'hero') && <AvatarOverlay onClick={onImageChange} />}
         {children && <div className={theme['children']}>{children}</div>}

--- a/src/components/avatar/AvatarInitials.js
+++ b/src/components/avatar/AvatarInitials.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import theme from './theme.css';
 import AvatarOverlay from './AvatarOverlay';
 import Box from '../box';
@@ -39,7 +40,7 @@ class AvatarInitials extends PureComponent {
         alignItems="center"
         backgroundColor={this.getBackgroundColor()}
         backgroundTint="normal"
-        className={theme['avatar-initials']}
+        className={cx(theme['avatar'], theme['avatar-initials'])}
         data-teamleader-ui="avatar-initials"
         display="flex"
         justifyContent="center"

--- a/src/components/avatar/AvatarInitials.js
+++ b/src/components/avatar/AvatarInitials.js
@@ -36,10 +36,13 @@ class AvatarInitials extends PureComponent {
 
     return (
       <Box
+        alignItems="center"
         backgroundColor={this.getBackgroundColor()}
         backgroundTint="normal"
         className={theme['avatar-initials']}
         data-teamleader-ui="avatar-initials"
+        display="flex"
+        justifyContent="center"
       >
         <Heading4 className={theme['initials']} color="neutral" tint={id ? 'lightest' : 'darkest'}>
           {this.getInitials()}

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -14,7 +14,6 @@ class AvatarStack extends PureComponent {
     const hasOverflow = overflowAmount > 0;
 
     const classNames = cx(
-      theme['stack'],
       theme[direction],
       theme[`is-${size}`],
       inverse ? [theme['light']] : [theme['dark']],
@@ -24,7 +23,7 @@ class AvatarStack extends PureComponent {
       className,
     );
     return (
-      <Box data-teamleader-ui="avatar-stack" className={classNames} {...others}>
+      <Box data-teamleader-ui="avatar-stack" className={classNames} {...others} alignItems="center" display="flex">
         {childrenToDisplay.map((child, index) => cloneElement(child, { key: index, ...child.props, size }))}
         {hasOverflow && (
           <Box

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -27,10 +27,15 @@ class AvatarStack extends PureComponent {
       <Box data-teamleader-ui="avatar-stack" className={classNames} {...others}>
         {childrenToDisplay.map((child, index) => cloneElement(child, { key: index, ...child.props, size }))}
         {hasOverflow && (
-          <div
+          <Box
+            alignItems="center"
             className={cx(uiUtilities['reset-font-smoothing'], theme['overflow'])}
+            display="flex"
+            justifyContent="center"
             onClick={onOverflowClick}
-          >{`+${overflowAmount}`}</div>
+          >
+            {`+${overflowAmount}`}
+          </Box>
         )}
       </Box>
     );

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -25,17 +25,11 @@
   z-index: 1;
 }
 
-/*AvatarInitials*/
-.avatar-initials {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  .initials {
-    letter-spacing: 0px;
-    line-height: 1;
-    user-select: none;
-  }
+/* AvatarInitials */
+.initials {
+  letter-spacing: 0px;
+  line-height: 1;
+  user-select: none;
 }
 
 .image {

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -25,8 +25,17 @@
   z-index: 1;
 }
 
-.initials {
-  line-height: 1;
+/*AvatarInitials*/
+.avatar-initials {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .initials {
+    letter-spacing: 0px;
+    line-height: 1;
+    user-select: none;
+  }
 }
 
 .image {
@@ -307,18 +316,6 @@
     &.is-hero + .overflow {
       margin: 6px;
     }
-  }
-}
-
-/*AvatarInitials*/
-.avatar-initials {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  user-select: none;
-
-  .initials {
-    letter-spacing: 0px;
   }
 }
 

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -4,7 +4,7 @@
 
 :root {
   --overflow-padding-horizontal: 8px;
-  --stacked-avatars-spacing: 6px;
+  --stacked-avatars-spacing: 12px;
 
   --tiny-size: 24px;
   --small-size: 30px;

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -44,7 +44,6 @@
 }
 
 .overflow {
-  align-self: center;
   font-family: var(--font-family-medium);
   line-height: 1;
   padding: 0 var(--overflow-padding-horizontal);

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -312,10 +312,3 @@
     }
   }
 }
-
-/* AvatarAnonymous */
-.avatar-anonymous {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -313,13 +313,6 @@
   }
 }
 
-/* AvatarAdd */
-.avatar-add {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 /* AvatarAnonymous */
 .avatar-anonymous {
   display: flex;

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -97,10 +97,7 @@
 
 .is-tiny {
   &.wrapper,
-  .avatar-image,
-  .avatar-initials,
-  .avatar-add,
-  .avatar-anonymous {
+  .avatar {
     height: var(--tiny-size);
     width: var(--tiny-size);
   }
@@ -124,10 +121,7 @@
 
 .is-small {
   &.wrapper,
-  .avatar-image,
-  .avatar-initials,
-  .avatar-add,
-  .avatar-anonymous {
+  .avatar {
     height: var(--small-size);
     width: var(--small-size);
   }
@@ -147,10 +141,7 @@
 
 .is-medium {
   &.wrapper,
-  .avatar-image,
-  .avatar-initials,
-  .avatar-add,
-  .avatar-anonymous {
+  .avatar {
     height: var(--medium-size);
     width: var(--medium-size);
   }
@@ -170,10 +161,7 @@
 
 .is-large {
   &.wrapper,
-  .avatar-image,
-  .avatar-initials,
-  .avatar-add,
-  .avatar-anonymous {
+  .avatar {
     height: var(--large-size);
     width: var(--large-size);
   }
@@ -197,10 +185,7 @@
 
 .is-hero {
   &.wrapper,
-  .avatar-image,
-  .avatar-initials,
-  .avatar-add,
-  .avatar-anonymous {
+  .avatar {
     height: var(--hero-size);
     width: var(--hero-size);
   }
@@ -223,20 +208,14 @@
 }
 
 .is-circle {
-  .avatar-image,
-  .avatar-initials,
-  .avatar-anonymous,
-  .avatar-add,
+  .avatar,
   .overlay {
     border-radius: var(--shape-circle-image-border-radius);
   }
 }
 
 .is-rounded {
-  .avatar-image,
-  .avatar-initials,
-  .avatar-anonymous,
-  .avatar-add {
+  .avatar {
     border-radius: var(--shape-rounded-image-border-radius);
   }
 
@@ -251,19 +230,13 @@
 
 .is-selectable {
   &:not(.is-hero):hover {
-    .avatar-image,
-    .avatar-initials,
-    .avatar-add,
-    .avatar-anonymous {
+    .avatar {
       box-shadow: 0 0 0 3px var(--color-aqua-light);
     }
   }
 
   &.is-hero:hover {
-    .avatar-image,
-    .avatar-initials,
-    .avatar-add,
-    .avatar-anonymous {
+    .avatar {
       box-shadow: 0 0 0 6px var(--color-aqua-light);
     }
   }
@@ -271,19 +244,13 @@
 
 .is-selected {
   &:not(.is-hero) {
-    .avatar-image,
-    .avatar-initials,
-    .avatar-anonymous,
-    .avatar-add {
+    .avatar {
       box-shadow: 0 0 0 3px var(--color-aqua-dark) !important;
     }
   }
 
   &.is-hero {
-    .avatar-image,
-    .avatar-initials,
-    .avatar-anonymous,
-    .avatar-add {
+    .avatar {
       box-shadow: 0 0 0 6px var(--color-aqua-dark) !important;
     }
   }

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -251,7 +251,7 @@
 
 .is-selectable {
   &:not(.is-hero):hover {
-    .avatar-image .image,
+    .avatar-image,
     .avatar-initials,
     .avatar-add,
     .avatar-anonymous {
@@ -260,7 +260,7 @@
   }
 
   &.is-hero:hover {
-    .avatar-image .image,
+    .avatar-image,
     .avatar-initials,
     .avatar-add,
     .avatar-anonymous {
@@ -271,7 +271,7 @@
 
 .is-selected {
   &:not(.is-hero) {
-    .avatar-image .image,
+    .avatar-image,
     .avatar-initials,
     .avatar-anonymous,
     .avatar-add {
@@ -280,7 +280,7 @@
   }
 
   &.is-hero {
-    .avatar-image .image,
+    .avatar-image,
     .avatar-initials,
     .avatar-anonymous,
     .avatar-add {

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -44,11 +44,8 @@
 }
 
 .overflow {
-  align-items: center;
   align-self: center;
-  display: flex;
   font-family: var(--font-family-medium);
-  justify-content: center;
   line-height: 1;
   padding: 0 var(--overflow-padding-horizontal);
 }

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -20,11 +20,6 @@
   position: relative;
 }
 
-/* AvatarImage */
-.avatar-image {
-  display: flex;
-}
-
 .children {
   position: absolute;
   z-index: 1;

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -40,12 +40,6 @@
   width: inherit;
 }
 
-/* AvatarStack */
-.stack {
-  align-items: center;
-  display: flex;
-}
-
 .overflow {
   font-family: var(--font-family-medium);
   line-height: 1;

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -294,15 +294,3 @@
     }
   }
 }
-
-.has-overflow {
-  .is-selectable,
-  .is-selected {
-    &:not(.is-hero) + .overflow {
-      margin: 3px;
-    }
-    &.is-hero + .overflow {
-      margin: 6px;
-    }
-  }
-}

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -16,7 +16,7 @@
   --shape-rounded-image-border-radius: 4px;
 }
 
-.avatar {
+.wrapper {
   position: relative;
 }
 
@@ -96,7 +96,7 @@
 }
 
 .is-tiny {
-  &.avatar,
+  &.wrapper,
   .avatar-image,
   .avatar-initials,
   .avatar-add,
@@ -123,7 +123,7 @@
 }
 
 .is-small {
-  &.avatar,
+  &.wrapper,
   .avatar-image,
   .avatar-initials,
   .avatar-add,
@@ -146,7 +146,7 @@
 }
 
 .is-medium {
-  &.avatar,
+  &.wrapper,
   .avatar-image,
   .avatar-initials,
   .avatar-add,
@@ -169,7 +169,7 @@
 }
 
 .is-large {
-  &.avatar,
+  &.wrapper,
   .avatar-image,
   .avatar-initials,
   .avatar-add,
@@ -196,7 +196,7 @@
 }
 
 .is-hero {
-  &.avatar,
+  &.wrapper,
   .avatar-image,
   .avatar-initials,
   .avatar-add,

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -34,7 +34,9 @@
 
 .image {
   display: block;
+  height: inherit;
   overflow: hidden;
+  width: inherit;
 }
 
 /* AvatarStack */
@@ -103,8 +105,7 @@
   .avatar-image,
   .avatar-initials,
   .avatar-add,
-  .avatar-anonymous,
-  .image {
+  .avatar-anonymous {
     height: var(--tiny-size);
     width: var(--tiny-size);
   }
@@ -131,8 +132,7 @@
   .avatar-image,
   .avatar-initials,
   .avatar-add,
-  .avatar-anonymous,
-  .image {
+  .avatar-anonymous {
     height: var(--small-size);
     width: var(--small-size);
   }
@@ -155,8 +155,7 @@
   .avatar-image,
   .avatar-initials,
   .avatar-add,
-  .avatar-anonymous,
-  .image {
+  .avatar-anonymous {
     height: var(--medium-size);
     width: var(--medium-size);
   }
@@ -179,8 +178,7 @@
   .avatar-image,
   .avatar-initials,
   .avatar-add,
-  .avatar-anonymous,
-  .image {
+  .avatar-anonymous {
     height: var(--large-size);
     width: var(--large-size);
   }
@@ -207,8 +205,7 @@
   .avatar-image,
   .avatar-initials,
   .avatar-add,
-  .avatar-anonymous,
-  .image {
+  .avatar-anonymous {
     height: var(--hero-size);
     width: var(--hero-size);
   }

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -33,6 +33,7 @@
 }
 
 .image {
+  border-radius: inherit;
   display: block;
   height: inherit;
   overflow: hidden;
@@ -228,7 +229,7 @@
 }
 
 .is-circle {
-  .avatar-image .image,
+  .avatar-image,
   .avatar-initials,
   .avatar-anonymous,
   .avatar-add,
@@ -238,7 +239,7 @@
 }
 
 .is-rounded {
-  .avatar-image .image,
+  .avatar-image,
   .avatar-initials,
   .avatar-anonymous,
   .avatar-add {

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -122,7 +122,7 @@
     border-radius: var(--tiny-size);
     font-size: calc(1.2 * var(--unit));
     height: var(--tiny-size);
-    min-width: calc(var(--tiny-size) - var(--overflow-padding-horizontal) * 2);
+    min-width: var(--tiny-size);
   }
 }
 
@@ -146,7 +146,7 @@
     border-radius: var(--small-size);
     font-size: calc(1.4 * var(--unit));
     height: var(--small-size);
-    min-width: calc(var(--small-size) - var(--overflow-padding-horizontal) * 2);
+    min-width: var(--small-size);
   }
 }
 
@@ -170,7 +170,7 @@
     border-radius: var(--medium-size);
     font-size: calc(1.6 * var(--unit));
     height: var(--medium-size);
-    min-width: calc(var(--medium-size) - var(--overflow-padding-horizontal) * 2);
+    min-width: var(--medium-size);
   }
 }
 
@@ -198,7 +198,7 @@
     border-radius: var(--large-size);
     font-size: calc(1.8 * var(--unit));
     height: var(--large-size);
-    min-width: calc(var(--large-size) - var(--overflow-padding-horizontal) * 2);
+    min-width: var(--large-size);
   }
 }
 
@@ -226,7 +226,7 @@
     border-radius: var(--hero-size);
     font-size: calc(3.6 * var(--unit));
     height: var(--hero-size);
-    min-width: calc(var(--hero-size) - var(--overflow-padding-horizontal) * 2);
+    min-width: var(--hero-size);
   }
 }
 


### PR DESCRIPTION
### Description

This PR refactors and simplifies our `Avatar` and `AvatarStack` component. We do this in order to implement overlapping avatars later on.

#### Screenshot before this PR
![Screenshot 2020-03-12 09 09 44](https://user-images.githubusercontent.com/5336831/76501201-21729d00-6442-11ea-9aae-460e488f3a94.png)

#### Screenshot after this PR
![Screenshot 2020-03-12 09 10 10](https://user-images.githubusercontent.com/5336831/76501223-2afc0500-6442-11ea-880a-dba1ed9e5266.png)

### Breaking changes

The result should be exactly the same `except for the 3px margin around the avatar`, which is now removed. Please check your Avatar implementations. Their position could be 3px off.