### PR TITLE
Island: use Box props instead off CSS styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - `Avatar`: removed 3px spacing around avatars. ([@driesd](https://github.com/driesd) in [#914](https://github.com/teamleadercrm/ui/pull/914)
-- `IslandGroup`: removed center alignment of the content inside an `Island` within an `IslandGroup`. ([@driesd](https://github.com/driesd) in [#921](https://github.com/teamleadercrm/ui/pull/921)
+- [Breaking] `IslandGroup`: removed center alignment of the content inside an `Island` within an `IslandGroup`. ([@driesd](https://github.com/driesd) in [#921](https://github.com/teamleadercrm/ui/pull/921)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - `Avatar`: removed 3px spacing around avatars. ([@driesd](https://github.com/driesd) in [#914](https://github.com/teamleadercrm/ui/pull/914)
+- `IslandGroup`: removed center alignment of the content inside an `Island` within an `IslandGroup`. ([@driesd](https://github.com/driesd) in [#921](https://github.com/teamleadercrm/ui/pull/921)
 
 ### Deprecated
 

--- a/src/components/island/Island.js
+++ b/src/components/island/Island.js
@@ -25,6 +25,8 @@ class Island extends PureComponent {
     return (
       <Box
         data-teamleader-ui="island"
+        backgroundColor={color === 'white' ? 'neutral' : color}
+        backgroundTint={color === 'neutral' ? 'light' : 'lightest'}
         borderRadius="rounded"
         borderColor={color === 'white' ? 'neutral' : color}
         borderTint={isDark ? 'dark' : 'normal'}

--- a/src/components/island/Island.js
+++ b/src/components/island/Island.js
@@ -1,8 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Box from '../box';
+import Box, { pickBoxProps } from '../box';
 import cx from 'classnames';
-import omit from 'lodash.omit';
 import theme from './theme.css';
 import { elementIsDark } from '../utils/utils';
 
@@ -18,7 +17,7 @@ class Island extends PureComponent {
 
     const classNames = cx(theme[color], className);
     const isDark = elementIsDark(color, dark);
-    const rest = omit(others, ['dark']);
+    const boxProps = pickBoxProps(others);
 
     return (
       <Box
@@ -34,7 +33,7 @@ class Island extends PureComponent {
         borderTopWidth={1}
         className={classNames}
         padding={SIZES[size]}
-        {...rest}
+        {...boxProps}
       >
         {children}
       </Box>

--- a/src/components/island/Island.js
+++ b/src/components/island/Island.js
@@ -25,7 +25,7 @@ class Island extends PureComponent {
     const rest = omit(others, ['dark']);
 
     return (
-      <Box data-teamleader-ui="island" className={classNames} padding={SIZES[size]} {...rest}>
+      <Box data-teamleader-ui="island" borderRadius="rounded" className={classNames} padding={SIZES[size]} {...rest}>
         {children}
       </Box>
     );

--- a/src/components/island/Island.js
+++ b/src/components/island/Island.js
@@ -28,7 +28,10 @@ class Island extends PureComponent {
         borderRadius="rounded"
         borderColor={color === 'white' ? 'neutral' : color}
         borderTint={isDark ? 'dark' : 'normal'}
-        borderWidth={1}
+        borderBottomWidth={1}
+        borderLeftWidth={1}
+        borderRightWidth={1}
+        borderTopWidth={1}
         className={classNames}
         padding={SIZES[size]}
         {...rest}

--- a/src/components/island/Island.js
+++ b/src/components/island/Island.js
@@ -18,14 +18,21 @@ class Island extends PureComponent {
 
     const isDark = elementIsDark(color, dark);
 
-    const classNames = cx(theme['island'], className, theme[color], {
-      [theme['dark']]: isDark,
-    });
+    const classNames = cx(theme['island'], className, theme[color]);
 
     const rest = omit(others, ['dark']);
 
     return (
-      <Box data-teamleader-ui="island" borderRadius="rounded" className={classNames} padding={SIZES[size]} {...rest}>
+      <Box
+        data-teamleader-ui="island"
+        borderRadius="rounded"
+        borderColor={color === 'white' ? 'neutral' : color}
+        borderTint={isDark ? 'dark' : 'normal'}
+        borderWidth={1}
+        className={classNames}
+        padding={SIZES[size]}
+        {...rest}
+      >
         {children}
       </Box>
     );

--- a/src/components/island/Island.js
+++ b/src/components/island/Island.js
@@ -16,10 +16,8 @@ class Island extends PureComponent {
   render() {
     const { children, className, color, dark, size, ...others } = this.props;
 
+    const classNames = cx(theme[color], className);
     const isDark = elementIsDark(color, dark);
-
-    const classNames = cx(theme['island'], className, theme[color]);
-
     const rest = omit(others, ['dark']);
 
     return (

--- a/src/components/island/IslandGroup.js
+++ b/src/components/island/IslandGroup.js
@@ -23,7 +23,7 @@ class IslandGroup extends PureComponent {
           return React.cloneElement(child, {
             ...(!isFirstChild &&
               !isLastChild && {
-                borderRadius: 'none',
+                borderRadius: 'square',
               }),
             ...(direction === 'horizontal' &&
               hasMoreThanOneChild &&

--- a/src/components/island/IslandGroup.js
+++ b/src/components/island/IslandGroup.js
@@ -1,21 +1,21 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import cx from 'classnames';
 import Box, { pickBoxProps } from '../box';
-import theme from './theme.css';
 
 class IslandGroup extends PureComponent {
   render() {
     const { children, className, color, dark, direction, size, ...otherProps } = this.props;
 
     const boxProps = pickBoxProps(otherProps);
-
-    const classNames = cx(theme[`direction-${direction}`], theme['island-group'], className);
-
     const hasMoreThanOneChild = children.length > 1;
 
     return (
-      <Box {...boxProps} className={classNames}>
+      <Box
+        {...boxProps}
+        className={className}
+        display="flex"
+        flexDirection={direction === 'horizontal' ? 'row' : 'column'}
+      >
         {React.Children.map(children, (child, index) => {
           const isFirstChild = index === 0;
           const isLastChild = index === children.length - 1;

--- a/src/components/island/IslandGroup.js
+++ b/src/components/island/IslandGroup.js
@@ -26,6 +26,10 @@ class IslandGroup extends PureComponent {
                 borderRadius: 'square',
               }),
             ...(direction === 'horizontal' &&
+              !isFirstChild && {
+                borderLeftWidth: 0,
+              }),
+            ...(direction === 'horizontal' &&
               hasMoreThanOneChild &&
               isFirstChild && {
                 borderBottomRightRadius: 'square',
@@ -36,6 +40,10 @@ class IslandGroup extends PureComponent {
               isLastChild && {
                 borderBottomLeftRadius: 'square',
                 borderTopLeftRadius: 'square',
+              }),
+            ...(direction === 'vertical' &&
+              !isFirstChild && {
+                borderTopWidth: 0,
               }),
             ...(direction === 'vertical' &&
               hasMoreThanOneChild &&

--- a/src/components/island/IslandGroup.js
+++ b/src/components/island/IslandGroup.js
@@ -12,10 +12,43 @@ class IslandGroup extends PureComponent {
 
     const classNames = cx(theme[`direction-${direction}`], theme['island-group'], className);
 
+    const hasMoreThanOneChild = children.length > 1;
+
     return (
       <Box {...boxProps} className={classNames}>
-        {React.Children.map(children, child => {
+        {React.Children.map(children, (child, index) => {
+          const isFirstChild = index === 0;
+          const isLastChild = index === children.length - 1;
+
           return React.cloneElement(child, {
+            ...(!isFirstChild &&
+              !isLastChild && {
+                borderRadius: 'none',
+              }),
+            ...(direction === 'horizontal' &&
+              hasMoreThanOneChild &&
+              isFirstChild && {
+                borderBottomRightRadius: 'square',
+                borderTopRightRadius: 'square',
+              }),
+            ...(direction === 'horizontal' &&
+              hasMoreThanOneChild &&
+              isLastChild && {
+                borderBottomLeftRadius: 'square',
+                borderTopLeftRadius: 'square',
+              }),
+            ...(direction === 'vertical' &&
+              hasMoreThanOneChild &&
+              isFirstChild && {
+                borderBottomLeftRadius: 'square',
+                borderBottomRightRadius: 'square',
+              }),
+            ...(direction === 'vertical' &&
+              hasMoreThanOneChild &&
+              isLastChild && {
+                borderTopLeftRadius: 'square',
+                borderTopRightRadius: 'square',
+              }),
             ...child.props,
             color: color || child.props.color,
             dark: dark || child.props.dark,

--- a/src/components/island/island.stories.js
+++ b/src/components/island/island.stories.js
@@ -79,7 +79,7 @@ export const group = () => (
     {islandData
       .slice(0, number('Island amount', 3, islandAmountOptions))
       .map(({ illustration, title, text }, index) => (
-        <Island key={index}>
+        <Island key={index} alignItems="center" display="flex" flex={1} flexDirection="column" textAlign="center">
           {illustration}
           <Heading3 marginBottom={3}>{title}</Heading3>
           <TextBody>{text}</TextBody>

--- a/src/components/island/island.stories.js
+++ b/src/components/island/island.stories.js
@@ -1,16 +1,48 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { boolean, select } from '@storybook/addon-knobs/react';
+import { boolean, number, select } from '@storybook/addon-knobs/react';
 import {
   IllustrationInvoices120X120Static,
   IllustrationMeetings120X120Static,
   IllustrationDeals120X120Static,
+  IllustrationContacts120X120Static,
 } from '@teamleader/ui-illustrations';
 import { Island, IslandGroup, Link, TextBody, TextSmall, Heading3 } from '../../index';
 import { IconChevronRightSmallOutline } from '@teamleader/ui-icons';
 
 const colors = ['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'white'];
+const directions = ['horizontal', 'vertical'];
 const sizes = ['small', 'medium', 'large'];
+
+const islandData = [
+  {
+    illustration: <IllustrationContacts120X120Static />,
+    title: 'Contacts',
+    text: 'Manage your clients directly in Teamleader',
+  },
+  {
+    illustration: <IllustrationInvoices120X120Static />,
+    title: 'Invoices',
+    text: 'Send invoices to your clients straight from Teamleader.',
+  },
+  {
+    illustration: <IllustrationMeetings120X120Static />,
+    title: 'Meetings',
+    text: 'Plan meetings and see them straight away in your favourite calendar.',
+  },
+  {
+    illustration: <IllustrationDeals120X120Static />,
+    title: 'Deals',
+    text: 'Keep track of all your deals with our fully integrated module.',
+  },
+];
+
+const islandAmountOptions = {
+  range: true,
+  min: 1,
+  max: islandData.length,
+  step: 1,
+};
 
 export default {
   title: addStoryInGroup(LOW_LEVEL_BLOCKS, 'Island'),
@@ -37,56 +69,25 @@ export const basic = () => (
   </Island>
 );
 
-export const segmentedHorizontal = () => (
+export const group = () => (
   <IslandGroup
     dark={boolean('Dark', false)}
     color={select('Color', colors, 'white')}
+    direction={select('Direction', directions, directions[0])}
     size={select('Size', sizes, 'medium')}
   >
-    <Island>
-      <IllustrationInvoices120X120Static />
-      <Heading3 marginBottom={3}>Invoices</Heading3>
-      <TextBody>Send invoices to your clients straight from Teamleader.</TextBody>
-    </Island>
-    <Island>
-      <IllustrationMeetings120X120Static />
-      <Heading3 marginBottom={3}>Meetings</Heading3>
-      <TextBody>Plan meetings and see them straight away in your favourite calendar.</TextBody>
-    </Island>
-    <Island>
-      <IllustrationDeals120X120Static />
-      <Heading3 marginBottom={3}>Deals</Heading3>
-      <TextBody>Keep track of all your deals with our fully integrated module.</TextBody>
-    </Island>
+    {islandData
+      .slice(0, number('Island amount', 3, islandAmountOptions))
+      .map(({ illustration, title, text }, index) => (
+        <Island key={index}>
+          {illustration}
+          <Heading3 marginBottom={3}>{title}</Heading3>
+          <TextBody>{text}</TextBody>
+        </Island>
+      ))}
   </IslandGroup>
 );
 
-segmentedHorizontal.story = {
-  name: 'Segmented horizontal',
-};
-
-export const segmentedVertical = () => (
-  <IslandGroup
-    dark={boolean('Dark', false)}
-    color={select('Color', colors, 'neutral')}
-    direction="vertical"
-    size={select('Size', sizes, 'medium')}
-  >
-    <Island>
-      <TextBody>kanye.west@goodmusic.com</TextBody>
-    </Island>
-    <Island display="flex" alignItems="center">
-      <IconChevronRightSmallOutline />
-      <TextBody marginHorizontal={2}>
-        <Link href="https://www.teamleader.be" target="_blank" inherit={false}>
-          Good music Ltd.
-        </Link>
-      </TextBody>
-      <TextSmall color="neutral">Company</TextSmall>
-    </Island>
-  </IslandGroup>
-);
-
-segmentedVertical.story = {
-  name: 'Segmented vertical',
+group.story = {
+  name: 'IslandGroup',
 };

--- a/src/components/island/theme.css
+++ b/src/components/island/theme.css
@@ -1,5 +1,4 @@
 @import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
 
 .white {
   color: var(--color-teal-darkest);

--- a/src/components/island/theme.css
+++ b/src/components/island/theme.css
@@ -7,7 +7,6 @@
 
 .island {
   border: 1px solid;
-  border-radius: var(--border-radius);
 }
 
 .white {

--- a/src/components/island/theme.css
+++ b/src/components/island/theme.css
@@ -1,57 +1,38 @@
 @import '@teamleader/ui-colors';
 @import '@teamleader/ui-utilities';
 
-.island {
-  border: 1px solid;
-}
-
 .white {
   background-color: var(--color-white);
-  border-color: var(--color-neutral);
   color: var(--color-teal-darkest);
-
-  &.dark {
-    border-color: var(--color-neutral-dark);
-  }
 }
 
 .neutral {
   background-color: var(--color-neutral-light);
-  border-color: var(--color-neutral);
   color: var(--color-teal-darkest);
-
-  &.dark {
-    border-color: var(--color-neutral-dark);
-  }
 }
 
 .mint {
   background-color: var(--color-mint-lightest);
-  border-color: var(--color-mint);
   color: var(--color-mint-darkest);
 }
 
 .violet {
   background-color: var(--color-violet-lightest);
-  border-color: var(--color-violet);
   color: var(--color-violet-darkest);
 }
 
 .ruby {
   background-color: var(--color-ruby-lightest);
-  border-color: var(--color-ruby);
   color: var(--color-ruby-darkest);
 }
 
 .gold {
   background-color: var(--color-gold-lightest);
-  border-color: var(--color-gold);
   color: var(--color-gold-darkest);
 }
 
 .aqua {
   background-color: var(--color-aqua-lightest);
-  border-color: var(--color-aqua);
   color: var(--color-aqua-darkest);
 }
 

--- a/src/components/island/theme.css
+++ b/src/components/island/theme.css
@@ -2,36 +2,29 @@
 @import '@teamleader/ui-utilities';
 
 .white {
-  background-color: var(--color-white);
   color: var(--color-teal-darkest);
 }
 
 .neutral {
-  background-color: var(--color-neutral-light);
   color: var(--color-teal-darkest);
 }
 
 .mint {
-  background-color: var(--color-mint-lightest);
   color: var(--color-mint-darkest);
 }
 
 .violet {
-  background-color: var(--color-violet-lightest);
   color: var(--color-violet-darkest);
 }
 
 .ruby {
-  background-color: var(--color-ruby-lightest);
   color: var(--color-ruby-darkest);
 }
 
 .gold {
-  background-color: var(--color-gold-lightest);
   color: var(--color-gold-darkest);
 }
 
 .aqua {
-  background-color: var(--color-aqua-lightest);
   color: var(--color-aqua-darkest);
 }

--- a/src/components/island/theme.css
+++ b/src/components/island/theme.css
@@ -35,17 +35,3 @@
   background-color: var(--color-aqua-lightest);
   color: var(--color-aqua-darkest);
 }
-
-.island-group {
-  &.direction-horizontal {
-    display: flex;
-
-    .island {
-      align-items: center;
-      display: flex;
-      flex: 1;
-      flex-direction: column;
-      text-align: center;
-    }
-  }
-}

--- a/src/components/island/theme.css
+++ b/src/components/island/theme.css
@@ -42,33 +42,10 @@
 
     .island {
       align-items: center;
-      border-width: 1px 1px 1px 0;
       display: flex;
       flex: 1;
       flex-direction: column;
       text-align: center;
-
-      &:first-child {
-        border-width: 1px;
-      }
-
-      &:last-child:not(:only-child) {
-        border-width: 1px 1px 1px 0;
-      }
-    }
-  }
-
-  &.direction-vertical {
-    .island {
-      border-width: 0 1px 1px 1px;
-
-      &:first-child {
-        border-width: 1px;
-      }
-
-      &:last-child:not(:only-child) {
-        border-width: 0 1px 1px 1px;
-      }
     }
   }
 }

--- a/src/components/island/theme.css
+++ b/src/components/island/theme.css
@@ -1,10 +1,6 @@
 @import '@teamleader/ui-colors';
 @import '@teamleader/ui-utilities';
 
-:root {
-  --border-radius: 4px;
-}
-
 .island {
   border: 1px solid;
 }
@@ -60,14 +56,6 @@
 }
 
 .island-group {
-  .island {
-    border-radius: 0;
-
-    &:only-child {
-      border-radius: var(--border-radius);
-    }
-  }
-
   &.direction-horizontal {
     display: flex;
 
@@ -83,12 +71,7 @@
         border-width: 1px;
       }
 
-      &:first-child:not(:only-child) {
-        border-radius: var(--border-radius) 0 0 var(--border-radius);
-      }
-
       &:last-child:not(:only-child) {
-        border-radius: 0 var(--border-radius) var(--border-radius) 0;
         border-width: 1px 1px 1px 0;
       }
     }
@@ -102,12 +85,7 @@
         border-width: 1px;
       }
 
-      &:first-child:not(:only-child) {
-        border-radius: var(--border-radius) var(--border-radius) 0 0;
-      }
-
       &:last-child:not(:only-child) {
-        border-radius: 0 0 var(--border-radius) var(--border-radius);
         border-width: 0 1px 1px 1px;
       }
     }


### PR DESCRIPTION
### Description

This PR refactors our `Island` & `IslandGroup` to use `Box` props instead of CSS styles.

### Breaking changes

🔥We do not center align the content inside an `Island` within an `IslandGroup` anymore.