### PR TITLE
Button: outline colors instead of inverse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Button`: added `color` prop which to combine with button level `outline`. ([@driesd](https://github.com/driesd) in [#925](https://github.com/teamleadercrm/ui/pull/925)
+
 ### Changed
 
 - `Avatar`: removed 3px spacing around avatars. ([@driesd](https://github.com/driesd) in [#914](https://github.com/teamleadercrm/ui/pull/914)
@@ -10,6 +12,8 @@
 ### Deprecated
 
 ### Removed
+
+- [Breaking] `Button`: removed the `inverse` prop for `outline` buttons. Use `color="white"` instead. ([@driesd](https://github.com/driesd) in [#925](https://github.com/teamleadercrm/ui/pull/925)
 
 ### Fixed
 

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -7,13 +7,13 @@ import theme from './theme.css';
 
 class Button extends PureComponent {
   getSpinnerColor() {
-    const { inverse, level } = this.props;
+    const { color, inverse, level } = this.props;
 
     switch (level) {
       case 'secondary':
         return 'teal';
       case 'outline':
-        return inverse ? 'neutral' : 'teal';
+        return color === 'white' ? 'neutral' : color;
       case 'link':
         return inverse ? 'neutral' : 'aqua';
       default:
@@ -22,13 +22,13 @@ class Button extends PureComponent {
   }
 
   getSpinnerTint() {
-    const { inverse, level } = this.props;
+    const { color, inverse, level } = this.props;
 
     switch (level) {
       case 'secondary':
         return 'darkest';
       case 'outline':
-        return inverse ? 'lightest' : 'darkest';
+        return color === 'white' ? 'lightest' : 'darkest';
       case 'link':
         return inverse ? 'lightest' : 'dark';
       default:
@@ -60,6 +60,7 @@ class Button extends PureComponent {
     const {
       children,
       className,
+      color,
       level,
       disabled,
       element,
@@ -84,7 +85,8 @@ class Button extends PureComponent {
       theme[size],
       {
         [theme['has-icon-only']]: (!children && !label) || (Array.isArray(children) && !children[0] && !label),
-        [theme['is-inverse']]: inverse && (level === 'outline' || level === 'link'),
+        [theme[color]]: level === 'outline',
+        [theme['is-inverse']]: inverse && level === 'link',
         [theme['is-disabled']]: disabled,
         [theme['is-full-width']]: fullWidth,
         [theme['is-processing']]: processing,
@@ -135,6 +137,8 @@ Button.propTypes = {
   children: PropTypes.any,
   /** A class name for the button to give custom styles. */
   className: PropTypes.string,
+  /** The color which the button should have when 'level' is set to 'outline' */
+  color: PropTypes.oneOf(['teal', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'white']),
   /** A custom element to be rendered */
   element: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   /** Determines which kind of button to be rendered. */
@@ -167,6 +171,7 @@ Button.propTypes = {
 
 Button.defaultProps = {
   className: '',
+  color: 'teal',
   element: 'button',
   fullWidth: false,
   level: 'secondary',

--- a/src/components/button/button.stories.js
+++ b/src/components/button/button.stories.js
@@ -4,6 +4,7 @@ import { boolean, select } from '@storybook/addon-knobs/react';
 import { IconAddMediumOutline, IconAddSmallOutline } from '@teamleader/ui-icons';
 import { Button } from '../../index';
 
+const colors = ['teal', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'white'];
 const elements = ['a', 'button'];
 const iconPositions = ['left', 'right'];
 const levels = ['primary', 'secondary', 'outline', 'destructive', 'link', 'timer'];
@@ -16,6 +17,7 @@ export default {
 export const withText = () => (
   <Button
     active={boolean('Active', false)}
+    color={select('Color', colors, 'teal')}
     label="Button"
     level={select('Level', levels, 'secondary')}
     disabled={boolean('Disabled', false)}
@@ -33,6 +35,7 @@ withText.story = {
 export const withIcon = () => (
   <Button
     active={boolean('Active', false)}
+    color={select('Color', colors, 'teal')}
     icon={select('Size', sizes, 'medium') === 'small' ? <IconAddSmallOutline /> : <IconAddMediumOutline />}
     level={select('Level', levels, 'secondary')}
     disabled={boolean('Disabled', false)}
@@ -50,6 +53,7 @@ withIcon.story = {
 export const withTextAndIcon = () => (
   <Button
     active={boolean('Active', false)}
+    color={select('Color', colors, 'teal')}
     icon={select('Size', sizes, 'medium') === 'small' ? <IconAddSmallOutline /> : <IconAddMediumOutline />}
     iconPlacement={select('Icon placement', iconPositions, 'left')}
     label="Button"
@@ -69,6 +73,7 @@ withTextAndIcon.story = {
 export const withCustomElement = () => (
   <Button
     active={boolean('Active', false)}
+    color={select('Color', colors, 'teal')}
     element={select('Element', elements, 'a')}
     label="Button"
     level={select('Level', levels, 'secondary')}

--- a/src/components/button/theme.css
+++ b/src/components/button/theme.css
@@ -200,36 +200,34 @@
 }
 
 .outline {
-  &:not(.is-inverse) {
-    color: var(--color-teal-darkest);
+  @each $color in (aqua, gold, mint, neutral, ruby, teal, violet) {
+    &.$(color) {
+      color: var(--color-$(color)-darkest);
 
-    &.is-disabled {
-      background-color: color(var(--color-teal-darkest) a(12%));
-      border: 1px solid color(var(--color-teal-darkest) a(12%));
-      color: color(var(--color-teal-darkest) a(36%));
-    }
-
-    &:not(.is-disabled) {
-      background-color: transparent;
-      border: 1px solid color(var(--color-teal-darkest) a(72%));
-
-      &:hover {
-        background-color: color(var(--color-teal-darkest) a(6%));
-        border: 1px solid var(--color-teal-darkest);
+      &.is-disabled {
+        background-color: color(var(--color-$(color)-darkest) a(12%));
+        border: 1px solid color(var(--color-$(color)-darkest) a(12%));
+        color: color(var(--color-$(color)-darkest) a(36%));
       }
 
-      &:focus {
-        border: 1px solid var(--color-teal-darkest);
-        box-shadow: 0 0 0 1px var(--color-teal-darkest);
-      }
-    }
+      &:not(.is-disabled) {
+        background-color: transparent;
+        border: 1px solid color(var(--color-$(color)-darkest) a(72%));
 
-    &.is-processing {
-      color: transparent;
+        &:hover {
+          background-color: color(var(--color-$(color)-darkest) a(6%));
+          border: 1px solid var(--color-$(color)-darkest);
+        }
+
+        &:focus {
+          border: 1px solid var(--color-$(color)-darkest);
+          box-shadow: 0 0 0 1px var(--color-$(color)-darkest);
+        }
+      }
     }
   }
 
-  &.is-inverse {
+  &.white {
     color: var(--color-neutral-lightest);
 
     &.is-disabled {
@@ -252,10 +250,10 @@
         box-shadow: 0 0 0 1px var(--color-neutral-lightest);
       }
     }
+  }
 
-    &.is-processing {
-      color: transparent;
-    }
+  &.is-processing {
+    color: transparent;
   }
 }
 


### PR DESCRIPTION
### Description

This PR adds a `color` prop to our `Button` component, which to combine with button level `outline`. This color prop replaces the `inverse` prop for outline buttons only.

#### Screenshot after this PR
![Screenshot 2020-03-17 08 55 18](https://user-images.githubusercontent.com/5336831/76835299-14cdba80-682f-11ea-928d-e049be580810.png)

![Screenshot 2020-03-17 08 55 30](https://user-images.githubusercontent.com/5336831/76835306-19926e80-682f-11ea-9698-83ad7266299b.png)

![Screenshot 2020-03-17 08 55 43](https://user-images.githubusercontent.com/5336831/76835315-1d25f580-682f-11ea-8036-792673a740b6.png)

###  🔥 Breaking changes

`Button`: removed the `inverse` prop for `outline` buttons. Use `color="white"` instead.
