### PR TITLE
Fix `SplitButton` event handler parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 - `Avatar`: removed 3px spacing around avatars. ([@driesd](https://github.com/driesd) in [#914](https://github.com/teamleadercrm/ui/pull/914)
 - [Breaking] `IslandGroup`: removed center alignment of the content inside an `Island` within an `IslandGroup`. ([@driesd](https://github.com/driesd) in [#921](https://github.com/teamleadercrm/ui/pull/921)
+- [Breaking] `onButtonClick` on `SplitButton` now passes an `event` instead of `currentTarget`. ([@mikeverf](https://github.com/mikeverf) in [#931](https://github.com/teamleadercrm/ui/pull/931)
+- [Breaking] `onClick` on child of `SplitButton` now passes the `event` instead of the `label` prop of the child. ([@mikeverf](https://github.com/mikeverf) in [#931](https://github.com/teamleadercrm/ui/pull/931)
+- Added optional `onSecondaryButtonClick` prop to `SplitButton`. ([@mikeverf](https://github.com/mikeverf) in [#931](https://github.com/teamleadercrm/ui/pull/931)
 
 ### Deprecated
 

--- a/src/components/button/SplitButton.js
+++ b/src/components/button/SplitButton.js
@@ -18,7 +18,7 @@ class SplitButton extends PureComponent {
   };
 
   handleMainButtonClick = event => {
-    this.props.onButtonClick(event.currentTarget);
+    this.props.onButtonClick(event);
   };
 
   handleSecondaryButtonClick = event => {

--- a/src/components/button/SplitButton.js
+++ b/src/components/button/SplitButton.js
@@ -22,7 +22,11 @@ class SplitButton extends PureComponent {
   };
 
   handleSecondaryButtonClick = event => {
+    const { onSecondaryButtonClick } = this.props;
     this.setState({ popoverActive: true, popoverAnchorEl: event.currentTarget });
+    if (onSecondaryButtonClick) {
+      onSecondaryButtonClick(event);
+    }
   };
 
   handleMenuItemClick = (child, event) => {
@@ -96,6 +100,8 @@ SplitButton.propTypes = {
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   /** The function executed, when we click on the main button. */
   onButtonClick: PropTypes.func.isRequired,
+  /** The function executed, when we click on the secondary button. */
+  onSecondaryButtonClick: PropTypes.func,
   /** If true, component will be disabled. */
   disabled: PropTypes.bool,
 };

--- a/src/components/button/SplitButton.js
+++ b/src/components/button/SplitButton.js
@@ -25,12 +25,12 @@ class SplitButton extends PureComponent {
     this.setState({ popoverActive: true, popoverAnchorEl: event.currentTarget });
   };
 
-  handleMenuItemClick = child => {
+  handleMenuItemClick = (child, event) => {
     const childProps = child.props;
     this.setState({
       popoverActive: false,
     });
-    childProps.onClick(childProps.label);
+    childProps.onClick(event);
   };
 
   handleCloseClick = () => {
@@ -71,7 +71,7 @@ class SplitButton extends PureComponent {
             {React.Children.map(children, child => {
               if (child.props.label !== buttonLabel) {
                 return React.cloneElement(child, {
-                  onClick: () => this.handleMenuItemClick(child),
+                  onClick: event => this.handleMenuItemClick(child, event),
                 });
               }
             })}


### PR DESCRIPTION
### Description

For some reason, in `SplitButton` the event handlers didn't actually pass the event, they either passed `currentTarget` or `label`, in this PR, this is fixed.
I couldn't think of a use case for these parameters and didn't find any in our codebases either, so I'm assuming this was a mistake.

### Breaking changes

- `onButtonClick` on `SplitButton` now passes an `event` instead of `currentTarget`
- `onClick` on child of `SplitButton` now passes the `event` instead of the `label` prop of the child

### Other changes
- Added optional `onSecondaryButtonClick` prop to `SplitButton`
