### PR TITLE
Avatar stack: overlapping avatars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ### Added
 
+- `AvatarStack`: added `selectable` prop (default `false`). ([@driesd](https://github.com/driesd) in [#933](https://github.com/teamleadercrm/ui/pull/933)
 - `Link`: added `badged` prop (default `false`) which renders a semi-transparent background color on hover. ([@driesd](https://github.com/driesd) in [#928](https://github.com/teamleadercrm/ui/pull/928)
 
 ### Changed
+
+- [Breaking] `AvatarStack`: changed so that the avatars now overlap each other by default. ([@driesd](https://github.com/driesd) in [#933](https://github.com/teamleadercrm/ui/pull/933)
 
 ### Deprecated
 

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -78,14 +78,14 @@ class Avatar extends PureComponent {
   };
 
   render() {
-    const { className, onClick, selected, size, shape, ...others } = this.props;
+    const { className, selectable, selected, size, shape, ...others } = this.props;
 
     const avatarClassNames = cx(
       theme['wrapper'],
       theme[`is-${size}`],
       theme[`is-${shape}`],
       {
-        [theme['is-selectable']]: onClick,
+        [theme['is-selectable']]: selectable,
         [theme['is-selected']]: selected,
       },
       className,
@@ -124,8 +124,6 @@ Avatar.propTypes = {
   fullName: PropTypes.string,
   /** Expects a uuid to determine the avatar initials background color. */
   id: PropTypes.string,
-  /** Callback function that is fired when user clicks the avatar. */
-  onClick: PropTypes.func,
   /** Callback function that is fired when user clicks the edit icon. */
   onImageChange: PropTypes.func,
   /** If true, the avatar will have a selected state. */

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -102,7 +102,11 @@ class Avatar extends PureComponent {
     ]);
 
     return (
-      <Box {...restProps} className={avatarClassNames}>
+      <Box
+        {...restProps}
+        {...(selectable && { boxSizing: 'content-box', padding: size === 'hero' ? 2 : 1 })}
+        className={avatarClassNames}
+      >
         {this.renderComponent()}
       </Box>
     );

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -130,6 +130,8 @@ Avatar.propTypes = {
   id: PropTypes.string,
   /** Callback function that is fired when user clicks the edit icon. */
   onImageChange: PropTypes.func,
+  /** If true, avatars will become interactive. */
+  selectable: PropTypes.bool,
   /** If true, the avatar will have a selected state. */
   selected: PropTypes.bool,
   /** The shape of the avatar. */
@@ -141,6 +143,7 @@ Avatar.propTypes = {
 Avatar.defaultProps = {
   creatable: false,
   editable: false,
+  selectable: false,
   selected: false,
   shape: 'circle',
   size: 'medium',

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -23,7 +23,14 @@ class AvatarStack extends PureComponent {
       className,
     );
     return (
-      <Box data-teamleader-ui="avatar-stack" className={classNames} {...others} alignItems="center" display="flex">
+      <Box
+        {...others}
+        data-teamleader-ui="avatar-stack"
+        className={classNames}
+        alignItems="center"
+        display="flex"
+        flexDirection={direction === 'horizontal' ? 'row' : 'column'}
+      >
         {childrenToDisplay.map((child, index) => cloneElement(child, { key: index, ...child.props, size }))}
         {hasOverflow && (
           <Box

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -17,7 +17,17 @@ const SPACING = 6;
 
 class AvatarStack extends PureComponent {
   render() {
-    const { children, className, direction, displayMax, inverse, onOverflowClick, size, ...others } = this.props;
+    const {
+      children,
+      className,
+      direction,
+      displayMax,
+      inverse,
+      onOverflowClick,
+      selectable,
+      size,
+      ...others
+    } = this.props;
 
     const childrenToDisplay = displayMax > 0 ? children.slice(0, displayMax) : children;
     const overflowAmount = children.length - displayMax;
@@ -41,7 +51,14 @@ class AvatarStack extends PureComponent {
         display="flex"
         flexDirection={direction === 'horizontal' ? 'row' : 'column'}
       >
-        {childrenToDisplay.map((child, index) => cloneElement(child, { key: index, ...child.props, size }))}
+        {childrenToDisplay.map((child, index) => {
+          return cloneElement(child, {
+            key: index,
+            ...child.props,
+            selectable,
+            size,
+          });
+        })}
         {hasOverflow && (
           <Box
             alignItems="center"

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -39,6 +39,7 @@ class AvatarStack extends PureComponent {
       inverse ? [theme['light']] : [theme['dark']],
       {
         [theme['has-overflow']]: hasOverflow,
+        [theme['has-overlapping-avatars']]: !selectable,
       },
       className,
     );

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -42,6 +42,12 @@ class AvatarStack extends PureComponent {
       },
       className,
     );
+
+    const spacingStyles = {
+      ...(direction === 'horizontal' && { marginRight: selectable ? SPACING : OVERLAP_SPACINGS[size] }),
+      ...(direction === 'vertical' && { marginBottom: selectable ? SPACING : OVERLAP_SPACINGS[size] }),
+    };
+
     return (
       <Box
         {...others}
@@ -57,6 +63,10 @@ class AvatarStack extends PureComponent {
             ...child.props,
             selectable,
             size,
+            style: {
+              ...spacingStyles,
+              ...child.props.style,
+            },
           });
         })}
         {hasOverflow && (

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -5,6 +5,16 @@ import cx from 'classnames';
 import theme from './theme.css';
 import uiUtilities from '@teamleader/ui-utilities';
 
+const OVERLAP_SPACINGS = {
+  tiny: -6,
+  small: -6,
+  medium: -18,
+  large: -24,
+  hero: -48,
+};
+
+const SPACING = 6;
+
 class AvatarStack extends PureComponent {
   render() {
     const { children, className, direction, displayMax, inverse, onOverflowClick, size, ...others } = this.props;

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -100,7 +100,7 @@ AvatarStack.propTypes = {
   inverse: PropTypes.bool,
   /** Callback function that is fired when the overflow circle is clicked. */
   onOverflowClick: PropTypes.func,
-  /** If true, avatars will not be overlapping each other. */
+  /** If true, avatars will not be overlapping each other and will become interactive. */
   selectable: PropTypes.bool,
   /** The size of the avatar stack. */
   size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'hero']),

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -61,6 +61,8 @@ AvatarStack.propTypes = {
   inverse: PropTypes.bool,
   /** Callback function that is fired when the overflow circle is clicked. */
   onOverflowClick: PropTypes.func,
+  /** If true, avatars will not be overlapping each other. */
+  selectable: PropTypes.bool,
   /** The size of the avatar stack. */
   size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'hero']),
 };
@@ -69,6 +71,7 @@ AvatarStack.defaultProps = {
   direction: 'horizontal',
   displayMax: 0,
   inverse: false,
+  selectable: false,
   size: 'medium',
 };
 

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -65,6 +65,7 @@ class AvatarStack extends PureComponent {
             size,
             style: {
               ...spacingStyles,
+              zIndex: childrenToDisplay.length - index,
               ...child.props.style,
             },
           });

--- a/src/components/avatar/avatar.stories.js
+++ b/src/components/avatar/avatar.stories.js
@@ -78,26 +78,6 @@ withBullet.story = {
   name: 'With bullet',
 };
 
-export const withCounter = () => (
-  <Avatar
-    creatable={boolean('Creatable', false)}
-    editable={boolean('Editable', false)}
-    fullName={text('Full name', 'John Doe')}
-    id={text('Id', '63227a3c-c80b-11e9-a32f-2a2ae2dbcce4')}
-    imageUrl={boolean('Image available', false) ? avatars[0].image : null}
-    onImageChange={() => console.log('Change image')}
-    selected={boolean('Selected', false)}
-    size={select('Size', sizes, 'large')}
-    shape={select('Shape', shapes, 'circle')}
-  >
-    <Counter color="ruby" count={15} maxCount={6} borderColor="neutral" borderTint="lightest" />
-  </Avatar>
-);
-
-withCounter.story = {
-  name: 'With counter',
-};
-
 export const withTooltip = () => (
   <TooltippedAvatar
     creatable={boolean('Creatable', false)}

--- a/src/components/avatar/avatar.stories.js
+++ b/src/components/avatar/avatar.stories.js
@@ -40,6 +40,7 @@ export const avatarStack = () => (
     direction={select('Direction', directions, 'horizontal')}
     displayMax={number('Display max', 5)}
     inverse={boolean('Inverse', false)}
+    selectable={boolean('Selectable', false)}
     size={select('Size', sizes, 'large')}
   >
     {avatars.map(({ image }, index) => (

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -80,16 +80,12 @@
 }
 
 .horizontal {
-  flex-direction: row;
-
   > *:not(:last-child) {
     margin-right: var(--stacked-avatars-spacing);
   }
 }
 
 .vertical {
-  flex-direction: column;
-
   > *:not(:last-child) {
     margin-bottom: var(--stacked-avatars-spacing);
   }

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -44,6 +44,7 @@
   font-family: var(--font-family-medium);
   line-height: 1;
   padding: 0 var(--overflow-padding-horizontal);
+  user-select: none;
 }
 
 .overlay {
@@ -79,15 +80,21 @@
   }
 }
 
-.horizontal {
-  > *:not(:last-child) {
-    margin-right: var(--stacked-avatars-spacing);
+.has-overlapping-avatars {
+  .is-tiny .avatar {
+    box-shadow: 0 0 0 1px var(--color-neutral-lightest);
   }
-}
-
-.vertical {
-  > *:not(:last-child) {
-    margin-bottom: var(--stacked-avatars-spacing);
+  .is-small .avatar {
+    box-shadow: 0 0 0 2px var(--color-neutral-lightest);
+  }
+  .is-medium .avatar {
+    box-shadow: 0 0 0 2px var(--color-neutral-lightest);
+  }
+  .is-large .avatar {
+    box-shadow: 0 0 0 4px var(--color-neutral-lightest);
+  }
+  .is-hero .avatar {
+    box-shadow: 0 0 0 6px var(--color-neutral-lightest);
   }
 }
 


### PR DESCRIPTION
### Description

This PR introduces overlapping avatars in an `AvatarStack`. They stop overlapping when `selectable` prop is `true`.

#### AvatarStack (overlapping by default)
![Screenshot 2020-03-19 12 49 07](https://user-images.githubusercontent.com/5336831/77064726-5487d400-69e0-11ea-90d3-62410e1d49b9.png)

#### AvatarStack with selectable avatars
![Screenshot 2020-03-19 12 49 26](https://user-images.githubusercontent.com/5336831/77064862-8d27ad80-69e0-11ea-88b3-e79d9609e274.png)

#### AvatarStack with selected avatars
![Screenshot 2020-03-19 12 49 47](https://user-images.githubusercontent.com/5336831/77064936-ad576c80-69e0-11ea-9e20-cc9080468d51.png)

### Breaking changes

🔥 `AvatarStack`: changed so that the avatars now overlap each other by default, until `selected` is `true`.
