### PR TITLE
StatusLabel: refactor and apply lighter background colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `StatusLabel`: changed background colors to their lighter variant for better contrast. ([@driesd](https://github.com/driesd) in [#937](https://github.com/teamleadercrm/ui/pull/937)
+
 ### Deprecated
 
 ### Removed

--- a/src/components/statusLabel/StatusLabel.js
+++ b/src/components/statusLabel/StatusLabel.js
@@ -16,6 +16,8 @@ class StatusLabel extends PureComponent {
         element="span"
         {...others}
         alignItems="center"
+        backgroundColor={color}
+        backgroundTint={color === 'neutral' ? 'light' : 'lightest'}
         borderColor={color}
         borderTint={color === 'neutral' ? 'dark' : 'light'}
         borderWidth={1}

--- a/src/components/statusLabel/StatusLabel.js
+++ b/src/components/statusLabel/StatusLabel.js
@@ -16,9 +16,12 @@ class StatusLabel extends PureComponent {
         element="span"
         {...others}
         alignItems="center"
+        borderColor={color}
+        borderTint={color === 'neutral' ? 'dark' : 'light'}
+        borderWidth={1}
         className={classNames}
-        display="inline-flex"
         data-teamleader-ui="status-label"
+        display="inline-flex"
         paddingHorizontal={2}
       >
         {children}

--- a/src/components/statusLabel/StatusLabel.js
+++ b/src/components/statusLabel/StatusLabel.js
@@ -12,7 +12,14 @@ class StatusLabel extends PureComponent {
     const classNames = cx(uiUtilities['reset-font-smoothing'], theme['label'], theme[color], theme[size], className);
 
     return (
-      <Box className={classNames} element="span" {...others} data-teamleader-ui="status-label">
+      <Box
+        element="span"
+        {...others}
+        alignItems="center"
+        className={classNames}
+        display="inline-flex"
+        data-teamleader-ui="status-label"
+      >
         {children}
       </Box>
     );

--- a/src/components/statusLabel/StatusLabel.js
+++ b/src/components/statusLabel/StatusLabel.js
@@ -19,6 +19,7 @@ class StatusLabel extends PureComponent {
         className={classNames}
         display="inline-flex"
         data-teamleader-ui="status-label"
+        paddingHorizontal={2}
       >
         {children}
       </Box>

--- a/src/components/statusLabel/theme.css
+++ b/src/components/statusLabel/theme.css
@@ -5,7 +5,6 @@
 .label {
   border-style: solid;
   border-width: 1px;
-  display: inline-block;
   font-family: var(--font-family-medium);
   text-transform: none;
   vertical-align: middle;

--- a/src/components/statusLabel/theme.css
+++ b/src/components/statusLabel/theme.css
@@ -28,14 +28,14 @@
   font-size: calc(1.4 * var(--unit));
   line-height: calc(1.8 * var(--unit));
   border-radius: 14px;
-  padding: 3px 6px;
+  height: 24px;
 }
 
 .small {
   font-size: calc(1.2 * var(--unit));
   line-height: calc(1.4 * var(--unit));
   border-radius: 11px;
-  padding: 2px 6px;
+  height: 18px;
 }
 
 h1,

--- a/src/components/statusLabel/theme.css
+++ b/src/components/statusLabel/theme.css
@@ -3,8 +3,6 @@
 @import '@teamleader/ui-utilities';
 
 .label {
-  border-style: solid;
-  border-width: 1px;
   font-family: var(--font-family-medium);
   text-transform: none;
   vertical-align: middle;
@@ -12,14 +10,12 @@
 
 .neutral {
   background-color: color(var(--color-neutral) a(48%));
-  border-color: color(var(--color-neutral-dark) a(48%));
   color: var(--color-teal-darkest);
 }
 
 @each $color in (mint, violet, ruby, gold, aqua) {
   .$(color) {
     background-color: color(var(--color-$(color)-light) a(48%));
-    border-color: color(var(--color-$(color)-light) a(48%));
     color: var(--color-$(color)-darkest);
   }
 }

--- a/src/components/statusLabel/theme.css
+++ b/src/components/statusLabel/theme.css
@@ -27,14 +27,14 @@
 .medium {
   font-size: calc(1.4 * var(--unit));
   line-height: calc(1.8 * var(--unit));
-  border-radius: 14px;
+  border-radius: 12px;
   height: 24px;
 }
 
 .small {
   font-size: calc(1.2 * var(--unit));
   line-height: calc(1.4 * var(--unit));
-  border-radius: 11px;
+  border-radius: 9px;
   height: 18px;
 }
 

--- a/src/components/statusLabel/theme.css
+++ b/src/components/statusLabel/theme.css
@@ -9,13 +9,11 @@
 }
 
 .neutral {
-  background-color: color(var(--color-neutral) a(48%));
   color: var(--color-teal-darkest);
 }
 
 @each $color in (mint, violet, ruby, gold, aqua) {
   .$(color) {
-    background-color: color(var(--color-$(color)-light) a(48%));
     color: var(--color-$(color)-darkest);
   }
 }

--- a/src/components/statusLabel/theme.css
+++ b/src/components/statusLabel/theme.css
@@ -27,7 +27,7 @@
 
 .small {
   font-size: calc(1.2 * var(--unit));
-  line-height: calc(1.4 * var(--unit));
+  line-height: calc(1.8 * var(--unit));
   border-radius: 9px;
   height: 18px;
 }


### PR DESCRIPTION
### Description

This PR adjusts the background colors of our `StatusLabel` to their lighter variant. I also refactored a little bit to use more `Box` props instead of custom CSS.

#### Screenshot before this PR
![Screenshot 2020-03-20 15 53 33](https://user-images.githubusercontent.com/5336831/77175449-f7188380-6ac2-11ea-8adb-fc964b12660b.png)

#### Screenshot after this PR
![Screenshot 2020-03-20 15 48 21](https://user-images.githubusercontent.com/5336831/77175201-81acb300-6ac2-11ea-9125-982dee5d4d28.png)

### Breaking changes

None.
