### PR TITLE
Avatar stack: change display max default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Changed
 
+- `AvatarStack`: changed `displayMax` default value from `0` to `99`. ([@driesd](https://github.com/driesd) in [#938](https://github.com/teamleadercrm/ui/pull/938)
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- `AvatarStack`: fixed an error when containing only one Avatar. ([@driesd](https://github.com/driesd) in [#938](https://github.com/teamleadercrm/ui/pull/938)
 
 ### Dependency updates
 

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -29,7 +29,7 @@ class AvatarStack extends PureComponent {
       ...others
     } = this.props;
 
-    const childrenToDisplay = displayMax > 0 ? children.slice(0, displayMax) : children;
+    const childrenToDisplay = children.length > displayMax ? children.slice(0, displayMax) : children;
     const overflowAmount = children.length - displayMax;
     const hasOverflow = overflowAmount > 0;
 

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -108,7 +108,7 @@ AvatarStack.propTypes = {
 
 AvatarStack.defaultProps = {
   direction: 'horizontal',
-  displayMax: 0,
+  displayMax: 99,
   inverse: false,
   selectable: false,
   size: 'medium',


### PR DESCRIPTION
### Description

This PR changes the `displayMax` default value of our `AvatarStack` component from `0` to `99`. To have zero as a display maximum value didn't make much sense in the first place. And, it also fixes an error when the AvatarStack contains only one Avatar.

### Breaking changes

None.
