### PR TITLE
Avatar stack: fix wrapper bounding box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - `AvatarStack`: fixed an error when containing only one Avatar. ([@driesd](https://github.com/driesd) in [#938](https://github.com/teamleadercrm/ui/pull/938)
+- `AvatarStack`: fixes the bounding box of the wrapper. ([@driesd](https://github.com/driesd) in [#939](https://github.com/teamleadercrm/ui/pull/939)
 
 ### Dependency updates
 

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -49,6 +49,11 @@ class AvatarStack extends PureComponent {
       ...(direction === 'vertical' && { marginBottom: selectable ? SPACING : OVERLAP_SPACINGS[size] }),
     };
 
+    const wrapperPaddingStyles = {
+      ...(direction === 'horizontal' && { paddingRight: Math.abs(OVERLAP_SPACINGS[size]) }),
+      ...(direction === 'vertical' && { paddingBottom: Math.abs(OVERLAP_SPACINGS[size]) }),
+    };
+
     return (
       <Box
         {...others}
@@ -57,6 +62,7 @@ class AvatarStack extends PureComponent {
         alignItems="center"
         display="flex"
         flexDirection={direction === 'horizontal' ? 'row' : 'column'}
+        style={!selectable && !hasOverflow && wrapperPaddingStyles}
       >
         {childrenToDisplay.map((child, index) => {
           return cloneElement(child, {


### PR DESCRIPTION
### Description

This PR fixes the `AvatarStack`'s bounding box by compensating the negative margin of the last avatar with padding on the right or bottom of the wrapper.

#### Screenshot before this PR
![Screenshot 2020-03-21 16 25 40](https://user-images.githubusercontent.com/5336831/77230329-b8063300-6b93-11ea-924b-d16e94b2f79e.png)

#### Screenshot after this PR
![Screenshot 2020-03-21 16 26 09](https://user-images.githubusercontent.com/5336831/77230330-bf2d4100-6b93-11ea-97e0-84ac83ce69ee.png)

### Breaking changes

None.
