### PR TITLE
Widget: update header height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- [Breaking] `Widget.Header`: decreased vertical padding and switched to min-height & flexbox alignment. ([@driesd](https://github.com/driesd) in [#940](https://github.com/teamleadercrm/ui/pull/940)
+
 ### Deprecated
 
 ### Removed

--- a/src/components/widget/Body.js
+++ b/src/components/widget/Body.js
@@ -6,11 +6,7 @@ class Body extends PureComponent {
   render() {
     const { children, ...others } = this.props;
 
-    return (
-      <Island padding={4} {...others}>
-        {children}
-      </Island>
-    );
+    return <Island {...others}>{children}</Island>;
   }
 }
 

--- a/src/components/widget/Footer.js
+++ b/src/components/widget/Footer.js
@@ -6,11 +6,7 @@ class Footer extends PureComponent {
   render() {
     const { children, ...others } = this.props;
 
-    return (
-      <Island padding={4} {...others}>
-        {children}
-      </Island>
-    );
+    return <Island {...others}>{children}</Island>;
   }
 }
 

--- a/src/components/widget/Header.js
+++ b/src/components/widget/Header.js
@@ -1,18 +1,41 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 import Island from '../island';
+import theme from './theme.css';
+
+const PADDING_VERTICAL = {
+  small: 1,
+  medium: 2,
+  large: 3,
+};
 
 class Header extends PureComponent {
   render() {
-    const { children, ...others } = this.props;
+    const { children, className, size, ...others } = this.props;
 
-    return <Island {...others}>{children}</Island>;
+    const classNames = cx(theme[`is-${size}`], className);
+
+    return (
+      <Island
+        {...others}
+        alignItems="center"
+        className={classNames}
+        display="flex"
+        size={size}
+        paddingVertical={PADDING_VERTICAL[size]}
+      >
+        {children}
+      </Island>
+    );
   }
 }
 
 Header.propTypes = {
   /** The content to display inside the widget header. */
   children: PropTypes.any,
+  /** The size which controls the horizontal padding of the Island. */
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
 };
 
 export default Header;

--- a/src/components/widget/Widget.js
+++ b/src/components/widget/Widget.js
@@ -5,12 +5,6 @@ import Footer from './Footer';
 import Header from './Header';
 import { IslandGroup } from '../island';
 
-const PADDINGS = {
-  small: 3,
-  medium: 4,
-  large: 5,
-};
-
 class Widget extends PureComponent {
   render() {
     const { children, size, ...others } = this.props;
@@ -19,8 +13,8 @@ class Widget extends PureComponent {
       <IslandGroup direction="vertical" {...others}>
         {React.Children.map(children, child => {
           return React.cloneElement(child, {
-            padding: PADDINGS[size],
             ...child.props,
+            size,
           });
         })}
       </IslandGroup>
@@ -31,8 +25,8 @@ class Widget extends PureComponent {
 Widget.propTypes = {
   /** The content to display inside the widget. */
   children: PropTypes.node,
-  /** The size wich controls the paddings passed down to the children. */
-  size: PropTypes.oneOf(Object.keys(PADDINGS)),
+  /** The size which controls the padding of the children. */
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
 };
 
 Widget.defaultProps = {

--- a/src/components/widget/theme.css
+++ b/src/components/widget/theme.css
@@ -1,0 +1,11 @@
+.is-small {
+  min-height: 36px;
+}
+
+.is-medium {
+  min-height: 48px;
+}
+
+.is-large {
+  min-height: 72px;
+}

--- a/src/components/widget/widget.stories.js
+++ b/src/components/widget/widget.stories.js
@@ -86,11 +86,11 @@ export const withHeaderAndMulipleActions = () => (
       alignItems="center"
       justifyContent="space-between"
     >
-      <Box display="flex" alignItems="center">
-        <Heading2>I am the widget header title</Heading2>
+      <Box display="flex" alignItems="center" flex={1}>
+        <Heading3>I am the widget header title</Heading3>
         <Bullet color="mint" marginLeft={3} />
       </Box>
-      <Box display="flex" alignItems="center" justifyContent="space-between" style={{ width: '130px' }}>
+      <ButtonGroup>
         <IconButton icon={<IconEditMediumOutline />} />
         <IconButton icon={<IconAddMediumOutline />} />
         <IconMenu active position="top-right">
@@ -99,7 +99,7 @@ export const withHeaderAndMulipleActions = () => (
           <MenuDivider />
           <MenuItem label="Disabled menu item..." disabled />
         </IconMenu>
-      </Box>
+      </ButtonGroup>
     </Widget.Header>
     <Widget.Body>
       <Heading3>I am the body title</Heading3>

--- a/src/components/widget/widget.stories.js
+++ b/src/components/widget/widget.stories.js
@@ -8,16 +8,16 @@ import {
   DataGrid,
   DatePicker,
   Heading3,
+  Heading5,
   IconButton,
   IconMenu,
   Link,
   MenuItem,
   StatusBullet,
-  Tooltip,
-  Widget,
   TextBody,
   TextSmall,
-  Heading2,
+  Tooltip,
+  Widget,
   MenuDivider,
   Bullet,
 } from '../../index';
@@ -35,8 +35,7 @@ export default {
 export const basic = () => (
   <Widget size={select('Size', sizes, 'medium')}>
     <Widget.Body>
-      <Heading3>I am the body title</Heading3>
-      <TextBody>I am the body content</TextBody>
+      <TextBody>Here you can add arbitrary content.</TextBody>
     </Widget.Body>
   </Widget>
 );
@@ -44,11 +43,10 @@ export const basic = () => (
 export const withHeader = () => (
   <Widget size={select('Size', sizes, 'medium')}>
     <Widget.Header color={select('Header color', colors, 'neutral')}>
-      <Heading2>I am the widget header title</Heading2>
+      <Heading3>I am the widget header title</Heading3>
     </Widget.Header>
     <Widget.Body>
-      <Heading3>I am the body title</Heading3>
-      <TextBody>I am the body content</TextBody>
+      <TextBody>Here you can add arbitrary content.</TextBody>
     </Widget.Body>
   </Widget>
 );
@@ -61,15 +59,14 @@ export const withHeaderAndAction = () => (
   <Widget size={select('Size', sizes, 'medium')}>
     <Widget.Header color={select('Header color', colors, 'neutral')} display="flex" alignItems="center">
       <Box flex={1}>
-        <Heading2>I am the widget header title</Heading2>
+        <Heading3>I am the widget header title</Heading3>
       </Box>
       <Box>
         <IconButton icon={<IconAddMediumOutline />} />
       </Box>
     </Widget.Header>
     <Widget.Body>
-      <Heading3>I am the body title</Heading3>
-      <TextBody>I am the body content</TextBody>
+      <TextBody>Here you can add arbitrary content.</TextBody>
     </Widget.Body>
   </Widget>
 );
@@ -102,8 +99,7 @@ export const withHeaderAndMulipleActions = () => (
       </ButtonGroup>
     </Widget.Header>
     <Widget.Body>
-      <Heading3>I am the body title</Heading3>
-      <TextBody>I am the body content</TextBody>
+      <TextBody>Here you can add arbitrary content.</TextBody>
     </Widget.Body>
   </Widget>
 );
@@ -115,13 +111,11 @@ withHeaderAndMulipleActions.story = {
 export const withFooter = () => (
   <Widget size={select('Size', sizes, 'medium')}>
     <Widget.Body>
-      <Heading3>I am the body title</Heading3>
-      <TextBody>I am the body content</TextBody>
+      <TextBody>Here you can add arbitrary content.</TextBody>
     </Widget.Body>
     <Widget.Footer>
       <Box display="flex" alignItems="center" justifyContent="space-between">
-        <Heading3>I am the widget footer</Heading3>
-        <TextBody>Meta information</TextBody>
+        <TextBody>I am the widget footer</TextBody>
       </Box>
     </Widget.Footer>
   </Widget>
@@ -134,16 +128,14 @@ withFooter.story = {
 export const fullWidget = () => (
   <Widget size={select('Size', sizes, 'medium')}>
     <Widget.Header color={select('Header color', colors, 'neutral')}>
-      <Heading2>I am the widget header title</Heading2>
+      <Heading3>I am the widget header title</Heading3>
     </Widget.Header>
     <Widget.Body>
-      <Heading3>I am the body title</Heading3>
-      <TextBody>I am the body content</TextBody>
+      <TextBody>Here you can add arbitrary content.</TextBody>
     </Widget.Body>
     <Widget.Footer>
       <Box display="flex" alignItems="center" justifyContent="space-between">
-        <Heading3>I am the widget footer</Heading3>
-        <TextBody>Meta information</TextBody>
+        <TextBody>I am the widget footer</TextBody>
       </Box>
     </Widget.Footer>
   </Widget>
@@ -156,22 +148,21 @@ fullWidget.story = {
 export const fullWidget2Cols = () => (
   <Widget size={select('Size', sizes, 'medium')}>
     <Widget.Header color={select('Header color', colors, 'neutral')}>
-      <Heading2>I am the widget header title</Heading2>
+      <Heading3>I am the widget header title</Heading3>
     </Widget.Header>
     <Widget.Body display="flex">
       <Box flex={1}>
-        <Heading3>Column 1 header</Heading3>
-        <TextBody>I am the body content</TextBody>
+        <Heading5>Column 1 header</Heading5>
+        <TextBody>Here you can add arbitrary content.</TextBody>
       </Box>
       <Box flex={1}>
-        <Heading3>Column 2 header</Heading3>
-        <TextBody>I am the body content</TextBody>
+        <Heading5>Column 2 header</Heading5>
+        <TextBody>Here you can add arbitrary content.</TextBody>
       </Box>
     </Widget.Body>
     <Widget.Footer>
       <Box display="flex" alignItems="center" justifyContent="space-between">
-        <Heading3>I am the widget footer</Heading3>
-        <TextBody>Meta information</TextBody>
+        <TextBody>I am the widget footer</TextBody>
       </Box>
     </Widget.Footer>
   </Widget>
@@ -184,7 +175,7 @@ fullWidget2Cols.story = {
 export const withDatePicker = () => (
   <Widget size={select('Size', sizes, 'medium')}>
     <Widget.Header color={select('Header color', colors, 'neutral')}>
-      <Heading2>I am the widget header title</Heading2>
+      <Heading3>I am the widget header title</Heading3>
     </Widget.Header>
     <Widget.Body padding={0}>
       <DatePicker
@@ -283,7 +274,7 @@ withDataGridOnly.story = {
 export const withDataGrid = () => (
   <Widget size={select('Size', sizes, 'medium')}>
     <Widget.Header color={select('Header color', colors, 'neutral')}>
-      <Heading2>I am the widget header title</Heading2>
+      <Heading3>I am the widget header title</Heading3>
     </Widget.Header>
     <Widget.Body padding={0}>
       <DataGrid
@@ -356,8 +347,7 @@ export const withDataGrid = () => (
     </Widget.Body>
     <Widget.Footer>
       <Box display="flex" alignItems="center" justifyContent="space-between">
-        <Heading3>I am the widget footer</Heading3>
-        <TextBody>Meta information</TextBody>
+        <TextBody>I am the widget footer</TextBody>
       </Box>
     </Widget.Footer>
   </Widget>


### PR DESCRIPTION
### Description

This PR lowers the height of the `Widget.Header` for all sizes (small, medium & large). Also, in stories, we use `Heading3` as the widget title instead of Heading2 (design specs).

### Screenshot before this PR
#### Small
![Screenshot 2020-03-23 09 40 10](https://user-images.githubusercontent.com/5336831/77298063-8bb0fa80-6cea-11ea-8225-5fd6cea4c71a.png)

#### Medium
![Screenshot 2020-03-23 09 39 43](https://user-images.githubusercontent.com/5336831/77298077-923f7200-6cea-11ea-8db4-3ba5c786086b.png)

#### Large
![Screenshot 2020-03-23 09 39 32](https://user-images.githubusercontent.com/5336831/77298092-9b304380-6cea-11ea-8250-edec97c6f6ad.png)

### Screenshot after this PR
#### Small
![Screenshot 2020-03-23 09 47 41](https://user-images.githubusercontent.com/5336831/77298567-696bac80-6ceb-11ea-9ead-2bc821733f00.png)

#### Medium
![Screenshot 2020-03-23 09 47 52](https://user-images.githubusercontent.com/5336831/77298577-6d97ca00-6ceb-11ea-93f1-f9189d53d3cf.png)

#### Large
![Screenshot 2020-03-23 09 48 05](https://user-images.githubusercontent.com/5336831/77298591-712b5100-6ceb-11ea-8621-6494586d89ec.png)

### Breaking changes

`Widget headers` might be less high since we decreased vertical padding and switched to min-height & flexbox alignment instead.
