### PR TITLE
AvatarStack: only render `+` sign when displayMax is greater than zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `AvatarStack`: only show a `+` sign in front of the overflow number when `displayMax` is greater than zero. ([@driesd](https://github.com/driesd) in [#949](https://github.com/teamleadercrm/ui/pull/949)
+
 ### Deprecated
 
 ### Removed

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -85,7 +85,8 @@ class AvatarStack extends PureComponent {
             justifyContent="center"
             onClick={onOverflowClick}
           >
-            {`+${overflowAmount}`}
+            {displayMax > 0 && `+`}
+            {overflowAmount}
           </Box>
         )}
       </Box>


### PR DESCRIPTION
### Description

This PR changes the `AvatarStack` overflow circle to only show the `+` sign when `displayMax` is greater than zero.

### Screenshot before this PR
#### displayMax={1}
![Screenshot 2020-03-23 15 27 57](https://user-images.githubusercontent.com/5336831/77327096-0c87ea80-6d1b-11ea-915f-7d4ea0ce034a.png)

#### displayMax={0}
![Screenshot 2020-03-23 15 28 32](https://user-images.githubusercontent.com/5336831/77327110-13aef880-6d1b-11ea-89cb-ce7bde893f80.png)

#### Screenshot after this PR
#### displayMax={1}
![Screenshot 2020-03-23 15 27 57](https://user-images.githubusercontent.com/5336831/77327181-2cb7a980-6d1b-11ea-9225-b80db7fd4754.png)

#### displayMax={0}
![Screenshot 2020-03-23 15 27 31](https://user-images.githubusercontent.com/5336831/77327209-36411180-6d1b-11ea-9261-1a8f9a2bad16.png)

### Breaking changes

None.
