### PR TITLE
Avatar: add AvatarTeam component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Added
 
+- `Avatar`: added `team` prop (default `false`). ([@driesd](https://github.com/driesd) in [#953](https://github.com/teamleadercrm/ui/pull/953)
+- `AvatarTeam`: rendered by the `Avatar` component when its `team` prop is `true`. ([@driesd](https://github.com/driesd) in [#953](https://github.com/teamleadercrm/ui/pull/953)
+
 ### Changed
 
 ### Deprecated

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@babel/runtime": "^7.8.3",
     "@teamleader/ui-animations": "^0.0.3",
     "@teamleader/ui-colors": "^0.1.0",
-    "@teamleader/ui-icons": "^0.2.17",
+    "@teamleader/ui-icons": "0.2.25",
     "@teamleader/ui-illustrations": "0.0.26",
     "@teamleader/ui-typography": "^0.2.3",
     "@teamleader/ui-utilities": "^0.2.0",

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -138,6 +138,8 @@ Avatar.propTypes = {
   shape: PropTypes.oneOf(['circle', 'rounded']),
   /** The size of the avatar. */
   size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'hero']),
+  /** If true, a team icon will be shown. */
+  team: PropTypes.bool,
 };
 
 Avatar.defaultProps = {
@@ -147,6 +149,7 @@ Avatar.defaultProps = {
   selected: false,
   shape: 'circle',
   size: 'medium',
+  team: false,
 };
 
 export default Avatar;

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -4,6 +4,7 @@ import AvatarAdd from './AvatarAdd';
 import AvatarAnonymous from './AvatarAnonymous';
 import AvatarImage from './AvatarImage';
 import AvatarInitials from './AvatarInitials';
+import AvatarTeam from './AvatarTeam';
 import Box from '../box';
 import Icon from '../icon';
 import cx from 'classnames';
@@ -24,7 +25,7 @@ class Avatar extends PureComponent {
 
   renderComponent = () => {
     const { failedToLoadImage } = this.state;
-    const { creatable, children, editable, imageUrl, fullName, id, onImageChange, selected, size } = this.props;
+    const { creatable, children, editable, imageUrl, fullName, id, onImageChange, selected, size, team } = this.props;
 
     const childrenToRender = selected ? (
       <Icon
@@ -42,6 +43,10 @@ class Avatar extends PureComponent {
     ) : (
       children
     );
+
+    if (team) {
+      return <AvatarTeam size={size} />;
+    }
 
     if (creatable) {
       return <AvatarAdd children={children} size={size} />;

--- a/src/components/avatar/AvatarTeam.js
+++ b/src/components/avatar/AvatarTeam.js
@@ -14,13 +14,13 @@ class AvatarTeam extends PureComponent {
       <Box
         alignItems="center"
         backgroundColor="neutral"
-        backgroundTint="normal"
+        backgroundTint="darkest"
         className={cx(theme['avatar'], theme['avatar-team'])}
         data-teamleader-ui="avatar-team"
         display="flex"
         justifyContent="center"
       >
-        <Icon color="neutral" tint="darkest">
+        <Icon color="neutral" tint="light">
           {size === 'tiny' || size === 'small' ? <IconTeamSmallOutline /> : <IconTeamMediumOutline />}
         </Icon>
       </Box>

--- a/src/components/avatar/AvatarTeam.js
+++ b/src/components/avatar/AvatarTeam.js
@@ -1,0 +1,36 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import theme from './theme.css';
+import Box from '../box';
+import Icon from '../icon';
+import { IconTeamMediumOutline, IconTeamSmallOutline } from '@teamleader/ui-icons';
+
+class AvatarTeam extends PureComponent {
+  render() {
+    const { size } = this.props;
+
+    return (
+      <Box
+        alignItems="center"
+        backgroundColor="neutral"
+        backgroundTint="normal"
+        className={cx(theme['avatar'], theme['avatar-team'])}
+        data-teamleader-ui="avatar-team"
+        display="flex"
+        justifyContent="center"
+      >
+        <Icon color="neutral" tint="darkest">
+          {size === 'tiny' || size === 'small' ? <IconTeamSmallOutline /> : <IconTeamMediumOutline />}
+        </Icon>
+      </Box>
+    );
+  }
+}
+
+AvatarTeam.propTypes = {
+  /** The size of the avatar. */
+  size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'hero']),
+};
+
+export default AvatarTeam;

--- a/src/components/avatar/avatar.stories.js
+++ b/src/components/avatar/avatar.stories.js
@@ -32,6 +32,7 @@ export const avatar = () => (
     selected={boolean('Selected', false)}
     size={select('Size', sizes, 'large')}
     shape={select('Shape', shapes, 'circle')}
+    team={boolean('Team', false)}
   />
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1706,10 +1706,10 @@
   resolved "https://registry.yarnpkg.com/@teamleader/ui-colors/-/ui-colors-0.1.0.tgz#78b55444659f9f735a6bc2aa5070bce51f41e9bd"
   integrity sha512-sAofd7VtphJXfYHw0QY94tPKtlb78/qBOySkcq9g0CUWn3AUJtetNs+H+hFwqiLdod/h0Pz1m1EqKpiZdX9/vg==
 
-"@teamleader/ui-icons@^0.2.17":
-  version "0.2.24"
-  resolved "https://registry.yarnpkg.com/@teamleader/ui-icons/-/ui-icons-0.2.24.tgz#86b576cfd611aa6a7244cc11b19202d6bc0c8ca5"
-  integrity sha512-cHdusXs4knLUn1EExbxr7yfDaq48ybNwBwJsmEp2KWsy7V3OGnBZZAs8cDA9N1ujCoOLRM6lOfUPttIrYxcIbA==
+"@teamleader/ui-icons@0.2.25":
+  version "0.2.25"
+  resolved "https://registry.yarnpkg.com/@teamleader/ui-icons/-/ui-icons-0.2.25.tgz#5bcc4467fa75bf74a242ee50b385c282c00c27e7"
+  integrity sha512-tSlagN+4VRRWhaAh0VovfV+9+WEvfpV+1WwBZAeRsdZiueUG/3jYOe+E0OR6uYkdcniN4YeHFxPd+dB3t9vy2g==
 
 "@teamleader/ui-illustrations@0.0.26":
   version "0.0.26"


### PR DESCRIPTION
### Description

This PR adds the `AvatarTeam` component and will be rendered by the `Avatar` component when its `team` prop is `true`.

#### Screenshots
![Screenshot 2020-03-23 16 36 28](https://user-images.githubusercontent.com/5336831/77334124-af913200-6d24-11ea-9878-695517b23171.png)

![Screenshot 2020-03-23 16 36 39](https://user-images.githubusercontent.com/5336831/77334135-b3bd4f80-6d24-11ea-8466-11ac77cfecf4.png)

### Breaking changes

None.
