### PR TITLE
Widget: Avoid error when a child is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Fixed
 
+- `Widget`: having null as a child of a Widget was causing an error. ([@lowiebenoot](https://github.com/lowiebenoot) in [#961](https://github.com/teamleadercrm/ui/pull/961))
+
 ### Dependency updates
 
 ## [0.39.0] - 2020-03-23

--- a/src/components/widget/Widget.js
+++ b/src/components/widget/Widget.js
@@ -12,6 +12,10 @@ class Widget extends PureComponent {
     return (
       <IslandGroup direction="vertical" {...others}>
         {React.Children.map(children, child => {
+          if (!child) {
+            return child;
+          }
+
           return React.cloneElement(child, {
             ...child.props,
             size,


### PR DESCRIPTION
### Description

Having null as a child of a Widget was causing an error. Example:

```js
<Widget>
  <Widget.Header>Hello World</Widget.Header>
  <Widget.Body>Child 1</Widget.Body>
  <Widget.Body>Child 2</Widget.Body>
  {false && <Widget.Body>Child 3</Widget.Body>}
</Widget>
```


