### PR TITLE
Badge: remove hardcoded horizontal margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Removed
 
+- [Breaking] `Badge`: remove the hardcoded horizontal margin. You can optionally pass the `marginHorizontal` prop with a corresponding value. ([@driesd](https://github.com/driesd) in [#968](https://github.com/teamleadercrm/ui/pull/968)
+
 ### Fixed
 
 ### Dependency updates

--- a/src/components/badge/badge.stories.js
+++ b/src/components/badge/badge.stories.js
@@ -25,6 +25,7 @@ export const inline = () => (
       disabled={boolean('Disabled', false)}
       inherit={boolean('Inherit', true)}
       inverse={boolean('Inverse', false)}
+      marginHorizontal={1}
     >
       badge
     </Badge>

--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -150,7 +150,6 @@
     font-size: inherit;
     font-weight: inherit;
     letter-spacing: inherit;
-    margin: auto var(--spacer-smallest);
     text-transform: inherit;
   }
 }


### PR DESCRIPTION
### Breaking changes

This PR removes the hardcoded horizontal margin of our `Badge` component.
You can optionally pass the `marginHorizontal` prop with a corresponding value if needed.