### PR TITLE
Status label: remove hardcoded margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Removed
 
+- [Breaking] `StatusLabel`: remove the hardcoded horizontal margin. You can optionally pass the `marginHorizontal` prop with a corresponding value. ([@driesd](https://github.com/driesd) in [#970](https://github.com/teamleadercrm/ui/pull/970)
+
 ### Fixed
 
 ### Dependency updates

--- a/src/components/statusLabel/statusLabel.stories.js
+++ b/src/components/statusLabel/statusLabel.stories.js
@@ -36,43 +36,43 @@ export const inlineWithText = () => (
   <Box>
     <Heading1>
       I'm an Header 1 with a
-      <StatusLabel color={select('Color', colors, 'neutral')} size="medium">
+      <StatusLabel color={select('Color', colors, 'neutral')} size="medium" marginLeft={2}>
         Status label
       </StatusLabel>
     </Heading1>
     <Heading2 marginTop={4}>
       I'm an Header 2 with a
-      <StatusLabel color={select('Color', colors, 'neutral')} size="medium">
+      <StatusLabel color={select('Color', colors, 'neutral')} size="medium" marginLeft={2}>
         Status label
       </StatusLabel>
     </Heading2>
     <Heading3 marginTop={4}>
       I'm an Header 3 with a
-      <StatusLabel color={select('Color', colors, 'neutral')} size="medium">
+      <StatusLabel color={select('Color', colors, 'neutral')} size="medium" marginLeft={2}>
         Status label
       </StatusLabel>
     </Heading3>
     <Heading4 marginTop={4}>
       I'm an Header 4 with a
-      <StatusLabel color={select('Color', colors, 'neutral')} size="medium">
+      <StatusLabel color={select('Color', colors, 'neutral')} size="medium" marginLeft={2}>
         Status label
       </StatusLabel>
     </Heading4>
     <TextDisplay marginTop={4}>
       I'm an text display with a
-      <StatusLabel color={select('Color', colors, 'neutral')} size="medium">
+      <StatusLabel color={select('Color', colors, 'neutral')} size="medium" marginLeft={2}>
         Status label
       </StatusLabel>
     </TextDisplay>
     <TextBody marginTop={4}>
       I'm an text body with a
-      <StatusLabel color={select('Color', colors, 'neutral')} size="small">
+      <StatusLabel color={select('Color', colors, 'neutral')} size="small" marginLeft={2}>
         Status label
       </StatusLabel>
     </TextBody>
     <TextSmall marginTop={4}>
       I'm an text small with a
-      <StatusLabel color={select('Color', colors, 'neutral')} size="small">
+      <StatusLabel color={select('Color', colors, 'neutral')} size="small" marginLeft={2}>
         Status label
       </StatusLabel>
     </TextSmall>

--- a/src/components/statusLabel/theme.css
+++ b/src/components/statusLabel/theme.css
@@ -31,13 +31,3 @@
   border-radius: 9px;
   height: 18px;
 }
-
-h1,
-h2,
-h3,
-h4,
-p {
-  .label {
-    margin: 0 6px;
-  }
-}


### PR DESCRIPTION
### Breaking changes

This PR removes the hardcoded horizontal margin of our `StatusLabel` component.
You can optionally pass any `margin` prop with a corresponding value if needed.