### PR TITLE
Fix: Don't limit onClick on BodyRow children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Removed
 
 - [Breaking] `Badge`: remove the hardcoded horizontal margin. You can optionally pass the `marginHorizontal` prop with a corresponding value. ([@driesd](https://github.com/driesd) in [#968](https://github.com/teamleadercrm/ui/pull/968)
+- [Breaking] `BodyRow`: Removed check that stops `onClick` of `BodyRow` to be triggered when it's child `onClick` is triggered. Add `event.stopPropagation()` to the `onClick` of any children of `BodyRow` to ensure same behaviour. ([@mikeverf](https://github.com/mikeverf) in [#971](https://github.com/teamleadercrm/ui/pull/971)
 
 ### Fixed
 

--- a/src/components/datagrid/BodyRow.js
+++ b/src/components/datagrid/BodyRow.js
@@ -46,7 +46,7 @@ class BodyRow extends PureComponent {
         {...others}
       >
         {selectable && (
-          <Cell align="center" flex="min-width">
+          <Cell align="center" flex="min-width" onClick={(event) => event.stopPropagation()}>
             <Checkbox checked={selected} onChange={onSelectionChange} size={checkboxSize} />
           </Cell>
         )}

--- a/src/components/datagrid/BodyRow.js
+++ b/src/components/datagrid/BodyRow.js
@@ -6,14 +6,10 @@ import Row from './Row';
 import cx from 'classnames';
 import theme from './theme.css';
 
-const allowedParentNodes = ['datagrid-body-row', 'datagrid-cell'];
-
 class BodyRow extends PureComponent {
   handleClick = (event) => {
-    if (allowedParentNodes.includes(event.target.parentNode.dataset.teamleaderUi)) {
-      const { onClick } = this.props;
-      onClick && onClick(event);
-    }
+    const { onClick } = this.props;
+    onClick && onClick(event);
   };
 
   render() {

--- a/src/components/datagrid/datagrid.stories.js
+++ b/src/components/datagrid/datagrid.stories.js
@@ -79,7 +79,7 @@ export const basic = () => (
             />
           </DataGrid.Cell>
           <DataGrid.Cell>
-            <Link href="#" inherit={false}>
+            <Link href="#" onClick={(event) => event.stopPropagation()} inherit={false}>
               {row.column5}
             </Link>{' '}
           </DataGrid.Cell>
@@ -146,7 +146,7 @@ export const withFooter = () => (
             />
           </DataGrid.Cell>
           <DataGrid.Cell>
-            <Link href="#" inherit={false}>
+            <Link href="#" onClick={(event) => event.stopPropagation()} inherit={false}>
               {row.column5}
             </Link>{' '}
           </DataGrid.Cell>
@@ -222,7 +222,7 @@ export const withStickyColumns = () => (
             />
           </DataGrid.Cell>
           <DataGrid.Cell>
-            <Link href="#" inherit={false}>
+            <Link href="#" onClick={(event) => event.stopPropagation()} inherit={false}>
               {row.column5}
             </Link>{' '}
           </DataGrid.Cell>
@@ -295,7 +295,7 @@ export const advanced = () => (
             />
           </DataGrid.Cell>
           <DataGrid.Cell>
-            <Link href="#" inherit={false}>
+            <Link href="#" onClick={(event) => event.stopPropagation()} inherit={false}>
               {row.column5}
             </Link>{' '}
           </DataGrid.Cell>

--- a/src/components/datagrid/datagrid.stories.js
+++ b/src/components/datagrid/datagrid.stories.js
@@ -90,10 +90,33 @@ export const basic = () => (
           <DataGrid.Cell flex="5">{row.column2}</DataGrid.Cell>
           <DataGrid.Cell soft>{row.column4}</DataGrid.Cell>
           <DataGrid.Cell align="right" flex="min-width" preventOverflow={false}>
-            <IconMenu position="top-right">
-              <MenuItem label="Duplicate row" onClick={() => console.log('onClick: duplicate row')} />
-              <MenuItem label="Inactive row" onClick={() => console.log('onClick: inactivate row')} />
-              <MenuItem label="Remove row" onClick={() => console.log('onClick: remove row')} />
+            <IconMenu
+              position="top-right"
+              onClick={(event) => {
+                event.stopPropagation();
+              }}
+            >
+              <MenuItem
+                label="Duplicate row"
+                onClick={(event) => {
+                  console.log('onClick: duplicate row');
+                  event.stopPropagation();
+                }}
+              />
+              <MenuItem
+                label="Inactive row"
+                onClick={(event) => {
+                  console.log('onClick: inactivate row');
+                  event.stopPropagation();
+                }}
+              />
+              <MenuItem
+                label="Remove row"
+                onClick={(event) => {
+                  console.log('onClick: remove row');
+                  event.stopPropagation();
+                }}
+              />
             </IconMenu>
           </DataGrid.Cell>
         </DataGrid.BodyRow>


### PR DESCRIPTION
### Description

This check was apparently added to prevent the onClick of `BodyRow` to be triggered when clicking on a child that triggers an onClick event.
But that check also means that when you abstract away the children of `BodyRow` into their own component, the children's `onClick` would not be called, because the immediate parent wasn't a `BodyRow`. 

Since that limits the way we compose our components and the issue it's solving is easily fixable by the user by calling `event.stopPropagation` themselves, I propose to get rid of this check.

### Breaking changes

- Removed check that stops `onClick` of `BodyRow` to be triggered when its child `onClick` is triggered. Add `event.stopPropagation()` to the onClick of any children of `BodyRow` to ensure same behaviour.
