### PR TITLE
OverviewPage, OverviewPage.Header & OverviewPage.Body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Added
 
-- `Container`: added as a new component. Fluid width by default. Fixed width when passing `fixed` as boolean prop. ([@driesd](https://github.com/driesd) in [#977](https://github.com/teamleadercrm/ui/pull/977)
+- `Container`: added as a new component. Fluid width by default. Fixed width when passing `fixed` as boolean prop. ([@driesd](https://github.com/driesd) in [#977](https://github.com/teamleadercrm/ui/pull/977))
+- `OverviewPage`, `OverviewPageBody` & `OverviewPageHeader`: added as new components. ([@driesd](https://github.com/driesd) in [#982](https://github.com/teamleadercrm/ui/pull/982))
 
 ### Changed
 

--- a/src/components/overviewPage/OverviewPage.js
+++ b/src/components/overviewPage/OverviewPage.js
@@ -17,6 +17,8 @@ OverviewPage.propTypes = {
 };
 
 OverviewPage.Body = OverviewPageBody;
+OverviewPage.Body.displayName = 'OverviewPage.Body';
 OverviewPage.Header = OverviewPageHeader;
+OverviewPage.Header.displayName = 'OverviewPage.Header';
 
 export default OverviewPage;

--- a/src/components/overviewPage/OverviewPage.js
+++ b/src/components/overviewPage/OverviewPage.js
@@ -1,0 +1,22 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import OverviewPageBody from './OverviewPageBody';
+import OverviewPageHeader from './OverviewPageHeader';
+import Box from '../box';
+
+class OverviewPage extends PureComponent {
+  render() {
+    const { children, className, ...others } = this.props;
+
+    return <Box {...others}>{children}</Box>;
+  }
+}
+
+OverviewPage.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+OverviewPage.Body = OverviewPageBody;
+OverviewPage.Header = OverviewPageHeader;
+
+export default OverviewPage;

--- a/src/components/overviewPage/OverviewPageBody.js
+++ b/src/components/overviewPage/OverviewPageBody.js
@@ -1,0 +1,21 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import Container from '../container';
+
+class OverviewPageBody extends PureComponent {
+  render() {
+    const { children, ...others } = this.props;
+
+    return (
+      <Container paddingBottom={8} {...others}>
+        {children}
+      </Container>
+    );
+  }
+}
+
+OverviewPageBody.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default OverviewPageBody;

--- a/src/components/overviewPage/OverviewPageHeader.js
+++ b/src/components/overviewPage/OverviewPageHeader.js
@@ -1,0 +1,25 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import Box from '../box';
+import Container from '../container';
+import { Heading1 } from '../typography';
+
+class OverviewPageHeader extends PureComponent {
+  render() {
+    const { children, title, ...others } = this.props;
+
+    return (
+      <Container {...others} display="flex" marginBottom={5} paddingTop={7} justifyContent="space-between">
+        <Heading1 color="teal">{title}</Heading1>
+        {children && <Box>{children}</Box>}
+      </Container>
+    );
+  }
+}
+
+OverviewPageHeader.propTypes = {
+  children: PropTypes.node,
+  title: PropTypes.string.isRequired,
+};
+
+export default OverviewPageHeader;

--- a/src/components/overviewPage/OverviewPageHeader.js
+++ b/src/components/overviewPage/OverviewPageHeader.js
@@ -19,7 +19,7 @@ class OverviewPageHeader extends PureComponent {
 
 OverviewPageHeader.propTypes = {
   children: PropTypes.node,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.oneOf([PropTypes.string, PropTypes.node]).isRequired,
 };
 
 export default OverviewPageHeader;

--- a/src/components/overviewPage/index.js
+++ b/src/components/overviewPage/index.js
@@ -1,0 +1,6 @@
+import OverviewPage from './OverviewPage';
+import OverviewPageBody from './OverviewPageBody';
+import OverviewPageHeader from './OverviewPageHeader';
+
+export default OverviewPage;
+export { OverviewPageBody, OverviewPageHeader };

--- a/src/components/overviewPage/overviewPage.stories.js
+++ b/src/components/overviewPage/overviewPage.stories.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import { text } from '@storybook/addon-knobs/react';
+import { addStoryInGroup, COMPOSITIONS } from '../../../.storybook/utils';
+import { IconChevronDownSmallOutline } from '@teamleader/ui-icons';
+import Button, { ButtonGroup } from '../button';
+import OverviewPage from './OverviewPage';
+import { COLOR } from '../../constants';
+import { TextBody } from '../typography';
+
+export default {
+  title: addStoryInGroup(COMPOSITIONS, 'OverviewPage'),
+
+  parameters: {
+    backgrounds: [
+      { name: 'Neutral lightest', value: COLOR.NEUTRAL.LIGHTEST },
+      { name: 'Neutral light', value: COLOR.NEUTRAL.LIGHT, default: true },
+    ],
+    info: {
+      propTables: false,
+    },
+  },
+};
+
+export const composition = () => (
+  <OverviewPage>
+    {header()}
+    {body()}
+  </OverviewPage>
+);
+
+composition.story = {
+  name: 'Composition',
+  parameters: {
+    info: {
+      propTables: [OverviewPage],
+    },
+  },
+};
+
+export const body = () => (
+  <OverviewPage.Body>
+    <TextBody>Here you can add arbitrary content.</TextBody>
+  </OverviewPage.Body>
+);
+
+body.story = {
+  name: 'Body',
+  parameters: {
+    info: {
+      propTables: [OverviewPage.Body],
+    },
+  },
+};
+
+export const header = () => <OverviewPage.Header title={text('title', 'I am the overview page title')} />;
+
+header.story = {
+  name: 'Header',
+  parameters: {
+    info: {
+      propTables: [OverviewPage.Header],
+    },
+  },
+};
+
+export const headerWithActions = () => (
+  <OverviewPage.Header title={text('title', 'I am the overview page title')}>
+    <ButtonGroup>
+      <Button>Export</Button>
+      <Button icon={<IconChevronDownSmallOutline />} iconPlacement="right">
+        Import
+      </Button>
+      <Button level="primary">Add item</Button>
+    </ButtonGroup>
+  </OverviewPage.Header>
+);
+
+headerWithActions.story = {
+  name: 'Header with actions',
+  parameters: {
+    info: {
+      propTables: [OverviewPage.Header],
+    },
+  },
+};

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ import Menu, { IconMenu, MenuItem, MenuDivider, MenuTitle } from './components/m
 import Link from './components/link';
 import Message from './components/message';
 import Overlay from './components/overlay';
+import OverviewPage, { OverviewPageBody, OverviewPageHeader } from './components/overviewPage';
 import LoadingBar from './components/loadingBar';
 import LoadingMolecule from './components/loadingMolecule';
 import LoadingSpinner from './components/loadingSpinner';
@@ -124,6 +125,9 @@ export {
   Monospaced,
   NumericInput,
   Overlay,
+  OverviewPage,
+  OverviewPageBody,
+  OverviewPageHeader,
   Passport,
   Pagination,
   Popover,


### PR DESCRIPTION
### Description

This PR adds the `OverviewPage` component. Subcomponents are `OverviewPage.Header` and `OverviewPage.Body`.

![Screenshot 2020-04-01 20 12 28](https://user-images.githubusercontent.com/5336831/78171714-2d57ea80-7455-11ea-8e1f-ebce2ca10e35.png)

### Breaking changes

None.