### PR TITLE
DataGrid: decrease cell paddings with 6px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 
+- `DataGrid`: decreased cell paddings with 6px. ([@driesd](https://github.com/driesd) in [#1003](https://github.com/teamleadercrm/ui/pull/1003))
 - `Statuslabel`: changed internally to use `UIText components` instead of CSS styles. ([@driesd](https://github.com/driesd) in [#989](https://github.com/teamleadercrm/ui/pull/989))
 
 ### Deprecated

--- a/src/components/datagrid/BodyRow.js
+++ b/src/components/datagrid/BodyRow.js
@@ -46,7 +46,7 @@ class BodyRow extends PureComponent {
         {...others}
       >
         {selectable && (
-          <Cell align="center" flex="min-width" onClick={(event) => event.stopPropagation()}>
+          <Cell flex="min-width" onClick={(event) => event.stopPropagation()}>
             <Checkbox checked={selected} onChange={onSelectionChange} size={checkboxSize} />
           </Cell>
         )}

--- a/src/components/datagrid/HeaderRow.js
+++ b/src/components/datagrid/HeaderRow.js
@@ -27,7 +27,7 @@ class HeaderRow extends PureComponent {
     return (
       <Row backgroundColor="neutral" className={classNames} data-teamleader-ui="datagrid-header-row" {...others}>
         {selectable && (
-          <HeaderCell align="center" flex="min-width">
+          <HeaderCell flex="min-width">
             <Checkbox checked={selected} onChange={onSelectionChange} size={checkboxSize} />
           </HeaderCell>
         )}

--- a/src/components/datagrid/theme.css
+++ b/src/components/datagrid/theme.css
@@ -3,7 +3,7 @@
 @import '@teamleader/ui-typography';
 
 :root {
-  --datagrid-blend-width: 12px;
+  --datagrid-blend-width: 6px;
   --datagrid-cell-width-base: 80px;
 }
 
@@ -24,11 +24,11 @@
   flex-direction: column;
 
   &:first-child .row .cell:first-child {
-    padding-left: var(--spacer-medium);
+    padding-left: var(--spacer-regular);
   }
 
   &:last-child .row .cell:last-child {
-    padding-right: var(--spacer-medium);
+    padding-right: var(--spacer-regular);
   }
 }
 
@@ -51,7 +51,7 @@
   flex: 1;
   font-family: var(--font-family-regular);
   min-height: 36px;
-  padding: var(--spacer-smaller) var(--spacer-small);
+  padding: var(--spacer-smaller);
   position: relative;
   white-space: nowrap;
 }


### PR DESCRIPTION
### Description

This PR decreases the `Cell padding` of our `DataGrid` with `6px`. We do this to save some valuable screen width and to align cell content with our Widget header.

#### Screenshot before this PR
![Screenshot 2020-04-08 09 14 53](https://user-images.githubusercontent.com/5336831/78755511-95d52900-7979-11ea-8177-d9b3885dcfdb.png)

#### Screenshot after this PR
![Screenshot 2020-04-08 09 14 03](https://user-images.githubusercontent.com/5336831/78755524-9bcb0a00-7979-11ea-9386-ad19b6ae084e.png)

### Breaking changes

None.
