### PR TITLE
Avatar: omit the team prop, otherwise it's spread onto the box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Avatar`: fixed a react-dom warning where the team prop was put onto a div. ([@lowiebenoot](https://github.com/lowiebenoot) in [#1000](https://github.com/teamleadercrm/ui/pull/1005))
+
 ### Dependency updates
 
 ## [0.40.2] - 2020-04-08

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -104,6 +104,7 @@ class Avatar extends PureComponent {
       'fullName',
       'id',
       'onImageChange',
+      'team',
     ]);
 
     return (


### PR DESCRIPTION
### Description

In development, the Avatar component was always giving a warning, because it was trying to put the `team` prop onto a div.

Example:

```
react-dom.development.js:89 Warning: Received `false` for a non-boolean attribute `team`.

If you want to write it to the DOM, pass a string instead: team="false" or team={value.toString()}.

If you used to conditionally omit it with team={condition && value}, pass team={condition ? value : undefined} instead.
    in div (created by Box)
    in Box (created by Avatar)
    in Avatar (created by UserAvatar)
    in UserAvatar
```

