### PR TITLE
Data grid: breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,22 @@
 
 ### Added
 
+- `DataGrid`: added a `sortable` prop to the `HeaderCell`. ([@driesd](https://github.com/driesd) in [#1007](https://github.com/teamleadercrm/ui/pull/1007))
+
 ### Changed
+
+- [Breaking] `DataGrid`: rendering of the sorting arrows now depends on the `sortable` prop instead of `onClick`. ([@driesd](https://github.com/driesd) in [#1007](https://github.com/teamleadercrm/ui/pull/1007))
 
 ### Deprecated
 
 ### Removed
 
+- [Breaking] `DataGrid`: removed `checkboxSize` prop, the `Checkbox` size will always be `small`. ([@driesd](https://github.com/driesd) in [#1007](https://github.com/teamleadercrm/ui/pull/1007))
+
 ### Fixed
+
+- `DataGrid`: fixed unwanted overflow prevention for `Cells` containing a `Checkbox`. ([@driesd](https://github.com/driesd) in [#1007](https://github.com/teamleadercrm/ui/pull/1007))
+- `DataGrid`: fixed `Cell` padding along each side of the vertical separator line. ([@driesd](https://github.com/driesd) in [#1007](https://github.com/teamleadercrm/ui/pull/1007))
 
 ### Dependency updates
 

--- a/src/components/datagrid/BodyRow.js
+++ b/src/components/datagrid/BodyRow.js
@@ -15,7 +15,6 @@ class BodyRow extends PureComponent {
   render() {
     const {
       className,
-      checkboxSize,
       children,
       hovered,
       sliceFrom,
@@ -47,7 +46,7 @@ class BodyRow extends PureComponent {
       >
         {selectable && (
           <Cell flex="min-width" onClick={(event) => event.stopPropagation()}>
-            <Checkbox checked={selected} onChange={onSelectionChange} size={checkboxSize} />
+            <Checkbox checked={selected} onChange={onSelectionChange} size="small" />
           </Cell>
         )}
         {childrenSliced}
@@ -57,8 +56,6 @@ class BodyRow extends PureComponent {
 }
 
 BodyRow.propTypes = {
-  /** The size of the checkbox rendered on the left side of the row. */
-  checkboxSize: PropTypes.oneOf(['small', 'medium', 'large']),
   /** A class name for the row to give custom styles. */
   className: PropTypes.string,
   /** The cells to display inside the row. */

--- a/src/components/datagrid/BodyRow.js
+++ b/src/components/datagrid/BodyRow.js
@@ -45,7 +45,7 @@ class BodyRow extends PureComponent {
         {...others}
       >
         {selectable && (
-          <Cell flex="checkbox-width" onClick={(event) => event.stopPropagation()}>
+          <Cell flex="checkbox-width" onClick={(event) => event.stopPropagation()} preventOverflow={false}>
             <Checkbox checked={selected} onChange={onSelectionChange} size="small" />
           </Cell>
         )}

--- a/src/components/datagrid/BodyRow.js
+++ b/src/components/datagrid/BodyRow.js
@@ -45,7 +45,7 @@ class BodyRow extends PureComponent {
         {...others}
       >
         {selectable && (
-          <Cell flex="min-width" onClick={(event) => event.stopPropagation()}>
+          <Cell flex="checkbox-width" onClick={(event) => event.stopPropagation()}>
             <Checkbox checked={selected} onChange={onSelectionChange} size="small" />
           </Cell>
         )}

--- a/src/components/datagrid/Cell.js
+++ b/src/components/datagrid/Cell.js
@@ -54,7 +54,7 @@ Cell.propTypes = {
   /** A class name for the cell to give custom styles. */
   className: PropTypes.string,
   /** The width proportion of the cell against the others. */
-  flex: PropTypes.oneOf(['min-width', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']),
+  flex: PropTypes.oneOf(['checkbox-width', 'min-width', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']),
   /** If true, an ellipsis will be shown when the cell content is too long. */
   preventOverflow: PropTypes.bool,
   /** If true, the text inside the cell will be bold */

--- a/src/components/datagrid/DataGrid.js
+++ b/src/components/datagrid/DataGrid.js
@@ -124,7 +124,6 @@ class DataGrid extends PureComponent {
   render() {
     const {
       bordered,
-      checkboxSize,
       children,
       className,
       processing,
@@ -163,7 +162,6 @@ class DataGrid extends PureComponent {
             if (isComponentOfType(HeaderRowOverlay, child)) {
               return React.cloneElement(child, {
                 numSelectedRows: selectedRows.length,
-                headerCellCheckboxSize: checkboxSize,
               });
             }
           })}
@@ -173,7 +171,6 @@ class DataGrid extends PureComponent {
               {React.Children.map(children, (child) => {
                 if (isComponentOfType(HeaderRow, child)) {
                   return React.cloneElement(child, {
-                    checkboxSize,
                     onSelectionChange: this.handleHeaderRowSelectionChange,
                     selected: selectedRows.length === children.find((child) => Array.isArray(child)).length,
                     selectable,
@@ -181,7 +178,6 @@ class DataGrid extends PureComponent {
                   });
                 } else if (isComponentOfType(BodyRow, child)) {
                   return React.cloneElement(child, {
-                    checkboxSize,
                     hovered: hoveredRow === child.key,
                     onMouseEnter: (event) => this.handleBodyRowMouseEnter(child, event),
                     onMouseLeave: (event) => this.handleBodyRowMouseLeave(child, event),
@@ -245,8 +241,6 @@ class DataGrid extends PureComponent {
 DataGrid.propTypes = {
   /** If true, datagrid will have a border and rounded corners. */
   bordered: PropTypes.bool,
-  /** The size of the checkbox rendered on the left side of each row */
-  checkboxSize: PropTypes.oneOf(['small', 'medium', 'large']),
   /** The content to display inside the data grid. */
   children: PropTypes.node,
   /** A class name for the wrapper to give custom styles. */
@@ -267,7 +261,6 @@ DataGrid.propTypes = {
 
 DataGrid.defaultProps = {
   bordered: false,
-  checkboxSize: 'small',
   processing: false,
 };
 

--- a/src/components/datagrid/FooterRow.js
+++ b/src/components/datagrid/FooterRow.js
@@ -15,7 +15,7 @@ class FooterRow extends PureComponent {
 
     return (
       <Row className={classNames} data-teamleader-ui="datagrid-footer-row" {...others}>
-        {preserveSelectableSpace && <Cell flex="min-width" />}
+        {preserveSelectableSpace && <Cell flex="checkbox-width" />}
         {childrenSliced}
       </Row>
     );

--- a/src/components/datagrid/FooterRow.js
+++ b/src/components/datagrid/FooterRow.js
@@ -15,7 +15,7 @@ class FooterRow extends PureComponent {
 
     return (
       <Row className={classNames} data-teamleader-ui="datagrid-footer-row" {...others}>
-        {preserveSelectableSpace && <Cell flex="checkbox-width" />}
+        {preserveSelectableSpace && <Cell flex="checkbox-width" preventOverflow={false} />}
         {childrenSliced}
       </Row>
     );

--- a/src/components/datagrid/HeaderCell.js
+++ b/src/components/datagrid/HeaderCell.js
@@ -35,9 +35,9 @@ class HeaderCell extends PureComponent {
 
     return (
       <Cell align={align} className={classNames} onClick={onClick} {...others} preventOverflow={false}>
-        {align === 'right' && <Icon marginRight={1}>{this.renderSortedIndicators()}</Icon>}
+        {sortable && align === 'right' && <Icon marginRight={1}>{this.renderSortedIndicators()}</Icon>}
         <span className={theme['has-overflow-prevention']}>{children}</span>
-        {align === 'left' && <Icon marginLeft={1}>{this.renderSortedIndicators()}</Icon>}
+        {sortable && align === 'left' && <Icon marginLeft={1}>{this.renderSortedIndicators()}</Icon>}
       </Cell>
     );
   }

--- a/src/components/datagrid/HeaderCell.js
+++ b/src/components/datagrid/HeaderCell.js
@@ -8,9 +8,9 @@ import { IconArrowDownSmallOutline, IconArrowUpSmallOutline } from '@teamleader/
 
 class HeaderCell extends PureComponent {
   renderSortedIndicators = () => {
-    const { onClick, sorted } = this.props;
+    const { sortable, sorted } = this.props;
 
-    if (sorted === 'asc' || (!sorted && onClick)) {
+    if (sorted === 'asc' || (!sorted && sortable)) {
       return <IconArrowDownSmallOutline />;
     }
 
@@ -22,12 +22,12 @@ class HeaderCell extends PureComponent {
   };
 
   render() {
-    const { align, children, className, onClick, sorted, ...others } = this.props;
+    const { align, children, className, onClick, sortable, sorted, ...others } = this.props;
 
     const classNames = cx(
       theme['header-cell'],
       {
-        [theme['is-sortable']]: onClick,
+        [theme['is-sortable']]: sortable,
         [theme['is-sorted']]: sorted === 'asc' || sorted === 'desc',
       },
       className,
@@ -52,6 +52,8 @@ HeaderCell.propTypes = {
   className: PropTypes.string,
   /** Callback function that is fired when clicking on the cell. */
   onClick: PropTypes.func,
+  /** If true, sorting arrows will appear next to the text */
+  sortable: PropTypes.bool,
   /** The order in which the grid rows will be sorted. */
   sorted: PropTypes.oneOf(['asc', 'desc']),
 };

--- a/src/components/datagrid/HeaderRow.js
+++ b/src/components/datagrid/HeaderRow.js
@@ -8,17 +8,7 @@ import theme from './theme.css';
 
 class HeaderRow extends PureComponent {
   render() {
-    const {
-      className,
-      checkboxSize,
-      children,
-      sliceFrom,
-      sliceTo,
-      onSelectionChange,
-      selected,
-      selectable,
-      ...others
-    } = this.props;
+    const { className, children, sliceFrom, sliceTo, onSelectionChange, selected, selectable, ...others } = this.props;
 
     const childrenArray = Array.isArray(children) ? children : [children];
     const childrenSliced = childrenArray.slice(sliceFrom, sliceTo);
@@ -28,7 +18,7 @@ class HeaderRow extends PureComponent {
       <Row backgroundColor="neutral" className={classNames} data-teamleader-ui="datagrid-header-row" {...others}>
         {selectable && (
           <HeaderCell flex="min-width">
-            <Checkbox checked={selected} onChange={onSelectionChange} size={checkboxSize} />
+            <Checkbox checked={selected} onChange={onSelectionChange} size="small" />
           </HeaderCell>
         )}
         {childrenSliced}
@@ -38,8 +28,6 @@ class HeaderRow extends PureComponent {
 }
 
 HeaderRow.propTypes = {
-  /** The size of the checkbox rendered on the left side of the row. */
-  checkboxSize: PropTypes.oneOf(['small', 'medium', 'large']),
   /** A class name for the row to give custom styles. */
   className: PropTypes.string,
   /** The cells to display inside the row. */

--- a/src/components/datagrid/HeaderRow.js
+++ b/src/components/datagrid/HeaderRow.js
@@ -17,7 +17,7 @@ class HeaderRow extends PureComponent {
     return (
       <Row backgroundColor="neutral" className={classNames} data-teamleader-ui="datagrid-header-row" {...others}>
         {selectable && (
-          <HeaderCell flex="min-width">
+          <HeaderCell flex="checkbox-width" sortable={false}>
             <Checkbox checked={selected} onChange={onSelectionChange} size="small" />
           </HeaderCell>
         )}

--- a/src/components/datagrid/datagrid.stories.js
+++ b/src/components/datagrid/datagrid.stories.js
@@ -123,16 +123,18 @@ export const withFooter = () => (
     </DataGrid.HeaderRowOverlay>
 
     <DataGrid.HeaderRow>
-      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} sorted="asc">
+      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} sortable sorted="asc">
         Invoice
       </DataGrid.HeaderCell>
-      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} align="right">
+      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} sortable align="right">
         Amount
       </DataGrid.HeaderCell>
-      <DataGrid.HeaderCell flex="2" onClick={() => console.log('onClick: column sort')}>
+      <DataGrid.HeaderCell flex="2" onClick={() => console.log('onClick: column sort')} sortable>
         Customer
       </DataGrid.HeaderCell>
-      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')}>Due date</DataGrid.HeaderCell>
+      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} sortable>
+        Due date
+      </DataGrid.HeaderCell>
       <DataGrid.HeaderCell flex="min-width" />
     </DataGrid.HeaderRow>
     {rows2.map((row, index) => {
@@ -189,16 +191,18 @@ export const withStickyColumns = () => (
     </DataGrid.HeaderRowOverlay>
 
     <DataGrid.HeaderRow>
-      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} sorted="asc">
+      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} sorted="asc" sortable>
         Invoice
       </DataGrid.HeaderCell>
-      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} align="right">
+      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} align="right" sortable>
         Amount
       </DataGrid.HeaderCell>
-      <DataGrid.HeaderCell flex="2" onClick={() => console.log('onClick: column sort')}>
+      <DataGrid.HeaderCell flex="2" onClick={() => console.log('onClick: column sort')} sortable>
         Customer
       </DataGrid.HeaderCell>
-      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')}>Due date</DataGrid.HeaderCell>
+      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} sortable>
+        Due date
+      </DataGrid.HeaderCell>
       <DataGrid.HeaderCell flex="min-width" />
     </DataGrid.HeaderRow>
     {rows1.map((row, index) => {
@@ -252,16 +256,18 @@ export const advanced = () => (
     </DataGrid.HeaderRowOverlay>
 
     <DataGrid.HeaderRow>
-      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} sorted="asc">
+      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} sorted="asc" sortable>
         Invoice
       </DataGrid.HeaderCell>
-      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} align="right">
+      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} align="right" sortable>
         Amount
       </DataGrid.HeaderCell>
-      <DataGrid.HeaderCell flex="2" onClick={() => console.log('onClick: column sort')}>
+      <DataGrid.HeaderCell flex="2" onClick={() => console.log('onClick: column sort')} sortable>
         Customer
       </DataGrid.HeaderCell>
-      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')}>Due date</DataGrid.HeaderCell>
+      <DataGrid.HeaderCell onClick={() => console.log('onClick: column sort')} sortable>
+        Due date
+      </DataGrid.HeaderCell>
       <DataGrid.HeaderCell flex="min-width" />
     </DataGrid.HeaderRow>
     {rows1.map((row, index) => {

--- a/src/components/datagrid/datagrid.stories.js
+++ b/src/components/datagrid/datagrid.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { addStoryInGroup, COMPOSITIONS } from '../../../.storybook/utils';
-import { boolean, number, select } from '@storybook/addon-knobs/react';
+import { boolean, number } from '@storybook/addon-knobs/react';
 import { DataGrid, Heading4, IconMenu, MenuItem, Link, TextSmall, Button, ButtonGroup } from '../../index';
 
 import { rows1, rows2 } from '../../static/data/datagrid';
@@ -29,7 +29,6 @@ export const basic = () => (
     selectable={boolean('Selectable', true)}
     comparableId={1}
     onSelectionChange={handleRowSelectionChange}
-    checkboxSize={select('Checkbox size', ['small', 'medium', 'large'], 'small')}
     processing={boolean('Processing', false)}
   >
     <DataGrid.HeaderRowOverlay

--- a/src/components/datagrid/theme.css
+++ b/src/components/datagrid/theme.css
@@ -221,6 +221,11 @@
 }
 
 /* Cell widths */
+.flex-checkbox-width {
+  flex: 0 0 18px;
+  min-width: 18px;
+}
+
 .flex-min-width {
   flex: 0 0 30px;
   min-width: 30px;

--- a/src/components/datagrid/theme.css
+++ b/src/components/datagrid/theme.css
@@ -32,6 +32,14 @@
   }
 }
 
+.is-sticky-left .row .cell:last-child {
+  padding-right: var(--spacer-regular);
+}
+
+.is-sticky-left + .section .row .cell:first-child {
+  padding-left: var(--spacer-regular);
+}
+
 .row {
   display: flex;
 


### PR DESCRIPTION
### Description

- removed `checkboxSize` prop, the `Checkbox` size will always be `small`.
- added a `sortable` prop to the `HeaderCell`
- rendering of the sorting arrows now depends on the `sortable` prop instead of `onClick`
- fixed unwanted overflow prevention for `Cells` containing a `Checkbox`.
- fixed `Cell` padding along each side of the vertical separator line (screenshot)

#### Screenshot before this PR
![Screenshot 2020-04-08 18 34 16](https://user-images.githubusercontent.com/5336831/78809926-eecbae00-79c7-11ea-9792-dfe71aeab0df.png)

#### Screenshot after this PR
![Screenshot 2020-04-08 18 32 47](https://user-images.githubusercontent.com/5336831/78809944-f5f2bc00-79c7-11ea-9916-963d042e5a76.png)

### 🔥 Breaking changes

-  removed `checkboxSize` prop
-  rendering of the sorting arrows now depends on the `sortable` prop instead of `onClick`
