### PR TITLE
DetailPage.Header: fix adding a className

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - `Avatar`: fixed a react-dom warning where the team prop was put onto a div. ([@lowiebenoot](https://github.com/lowiebenoot) in [#1000](https://github.com/teamleadercrm/ui/pull/1005))
+- `DetailPage.Header`: adding a className was not possible. ([@lowiebenoot](https://github.com/lowiebenoot) in [#1008](https://github.com/teamleadercrm/ui/pull/1008))
 
 ### Dependency updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixed
 
-- `Avatar`: fixed a react-dom warning where the team prop was put onto a div. ([@lowiebenoot](https://github.com/lowiebenoot) in [#1000](https://github.com/teamleadercrm/ui/pull/1005))
+- `Avatar`: fixed a react-dom warning where the team prop was put onto a div. ([@lowiebenoot](https://github.com/lowiebenoot) in [#1005](https://github.com/teamleadercrm/ui/pull/1005))
 - `DetailPage.Header`: adding a className was not possible. ([@lowiebenoot](https://github.com/lowiebenoot) in [#1008](https://github.com/teamleadercrm/ui/pull/1008))
 
 ### Dependency updates

--- a/src/components/detailPage/DetailPageHeader.js
+++ b/src/components/detailPage/DetailPageHeader.js
@@ -10,7 +10,7 @@ import Container from '../container';
 
 class DetailPageHeader extends PureComponent {
   render() {
-    const { backLinkProps, children, className, title, titleSuffix, ...others } = this.props;
+    const { backLinkProps, children, title, titleSuffix, ...others } = this.props;
 
     return (
       <Container {...others} element={Section}>


### PR DESCRIPTION
### Description

We can't add a className to the DetailPage.Header component, because the className is destructured (but not used), and thus not spread onto the Container element.

