### PR TITLE
DetailPageHeader: add titleColor prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- `DetailPage.Header`: added `titleColor` prop. Possible values are `neutral` and `teal` (default). ([@driesd](https://github.com/driesd) in [#1007](https://github.com/teamleadercrm/ui/pull/1007))
+- `DetailPage.Header`: added `titleColor` prop. Possible values are `neutral` and `teal` (default). ([@driesd](https://github.com/driesd) in [#1010](https://github.com/teamleadercrm/ui/pull/1010))
 - `DataGrid`: added a `sortable` prop to the `HeaderCell`. ([@driesd](https://github.com/driesd) in [#1007](https://github.com/teamleadercrm/ui/pull/1007))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- `DetailPage.Header`: added `titleColor` prop. Possible values are `neutral` and `teal` (default). ([@driesd](https://github.com/driesd) in [#1007](https://github.com/teamleadercrm/ui/pull/1007))
 - `DataGrid`: added a `sortable` prop to the `HeaderCell`. ([@driesd](https://github.com/driesd) in [#1007](https://github.com/teamleadercrm/ui/pull/1007))
 
 ### Changed

--- a/src/components/detailPage/DetailPageHeader.js
+++ b/src/components/detailPage/DetailPageHeader.js
@@ -10,7 +10,7 @@ import Container from '../container';
 
 class DetailPageHeader extends PureComponent {
   render() {
-    const { backLinkProps, children, title, titleSuffix, ...others } = this.props;
+    const { backLinkProps, children, title, titleColor, titleSuffix, ...others } = this.props;
 
     return (
       <Container {...others} element={Section}>
@@ -22,7 +22,7 @@ class DetailPageHeader extends PureComponent {
           )}
           <Box flex="1 0 200px" paddingTop={5} overflow="hidden">
             <Box alignItems="center" display="flex">
-              <Heading1 color="teal" ellipsis title={title}>
+              <Heading1 color={titleColor} ellipsis tint={titleColor === 'neutral' ? 'dark' : 'darkest'} title={title}>
                 {title}
               </Heading1>
               {titleSuffix && <Box marginLeft={3}>{titleSuffix}</Box>}
@@ -43,7 +43,13 @@ DetailPageHeader.propTypes = {
   backLinkProps: PropTypes.object,
   children: PropTypes.node,
   title: PropTypes.oneOf([PropTypes.string, PropTypes.node]).isRequired,
+  /** The color which the title should have */
+  titleColor: PropTypes.oneOf(['neutral', 'teal']),
   titleSuffix: PropTypes.node,
+};
+
+DetailPageHeader.defaultProps = {
+  titleColor: 'teal',
 };
 
 export default DetailPageHeader;

--- a/src/components/detailPage/detailPage.stories.js
+++ b/src/components/detailPage/detailPage.stories.js
@@ -11,6 +11,8 @@ import { Box } from '../box';
 import { Heading1, Monospaced, TextBody } from '../typography';
 import { COLOR } from '../../constants';
 
+const titleColors = ['neutral', 'teal'];
+
 const actionButtons = () => (
   <ButtonGroup marginLeft={7}>
     <IconButton icon={<IconTrashMediumOutline />} />
@@ -117,7 +119,8 @@ export const header = () => (
       element: select('Back link element', ['a', 'button'], 'button'),
       children: text('Back link label', 'Back to overview'),
     }}
-    title={text('title', 'I am the detail page title')}
+    title={text('Title', 'I am the detail page title')}
+    titleColor={select('Title color', titleColors, 'teal')}
   />
 );
 
@@ -136,7 +139,8 @@ export const headerWithTitleSuffix = () => (
       element: select('Back link element', ['a', 'button'], 'button'),
       children: text('Back link label', 'Back to overview'),
     }}
-    title={text('title', 'I am the detail page title')}
+    title={text('Title', 'I am the detail page title')}
+    titleColor={select('Title color', titleColors, 'teal')}
     titleSuffix={<StatusLabel color="violet">Draft</StatusLabel>}
   />
 );
@@ -156,7 +160,8 @@ export const headerWithActions = () => (
       element: select('Back link element', ['a', 'button'], 'button'),
       children: text('Back link label', 'Back to overview'),
     }}
-    title={text('title', 'I am the detail page title')}
+    title={text('Title', 'I am the detail page title')}
+    titleColor={select('Title color', titleColors, 'teal')}
   >
     {actionButtons()}
   </DetailPage.Header>
@@ -177,7 +182,8 @@ export const headerWithTotals = () => (
       element: select('Back link element', ['a', 'button'], 'button'),
       children: text('Back link label', 'Back to overview'),
     }}
-    title={text('title', 'I am the detail page title')}
+    title={text('Title', 'I am the detail page title')}
+    titleColor={select('Title color', titleColors, 'teal')}
   >
     {totals()}
   </DetailPage.Header>
@@ -198,7 +204,8 @@ export const headerWithTotalsAndActions = () => (
       element: select('Back link element', ['a', 'button'], 'button'),
       children: text('Back link label', 'Back to overview'),
     }}
-    title={text('title', 'I am a way too long detail page title which will overflow with an ellipsis')}
+    title={text('Title', 'I am a way too long detail page title which will overflow with an ellipsis')}
+    titleColor={select('Title color', titleColors, 'teal')}
   >
     {totals()}
     {actionButtons()}
@@ -220,7 +227,8 @@ export const headerWithEverthingTogether = () => (
       element: select('Back link element', ['a', 'button'], 'button'),
       children: text('Back link label', 'Back to overview'),
     }}
-    title={text('title', 'I am a way too long detail page title which will overflow with an ellipsis')}
+    title={text('Title', 'I am a way too long detail page title which will overflow with an ellipsis')}
+    titleColor={select('Title color', titleColors, 'teal')}
     titleSuffix={<StatusLabel color="violet">Draft</StatusLabel>}
   >
     {totals()}


### PR DESCRIPTION
### Description

This PR adds a `titleColor` prop to our `DetailPageHeader` component. Possible values are `neutral` and `teal` (default).

#### Screenshot before this PR
![Screenshot 2020-04-09 18 10 17](https://user-images.githubusercontent.com/5336831/78916358-a37bd300-7a8d-11ea-84f6-5df693099541.png)

#### Screenshot after this PR
![Screenshot 2020-04-09 18 10 35](https://user-images.githubusercontent.com/5336831/78916369-a8d91d80-7a8d-11ea-8d73-ff02c7ad0ad9.png)

### Breaking changes

None.
