### PR TITLE
Badge: visual state updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,24 @@
 
 ### Added
 
+- `Badge`: added `size` prop with `small`, `medium` (default) & `large` as possible values. ([@driesd](https://github.com/driesd) in [#1014](https://github.com/teamleadercrm/ui/pull/1014))
+- `Badge`: added `selected` boolean prop which shows the badge in a selected state. ([@driesd](https://github.com/driesd) in [#1014](https://github.com/teamleadercrm/ui/pull/1014))
 - `IconButton`: added `large` size variation. ([@driesd](https://github.com/driesd) in [#1009](https://github.com/teamleadercrm/ui/pull/1009))
 - `IconButton`: added `selected` boolean prop which shows the button in a selected state. ([@driesd](https://github.com/driesd) in [#1009](https://github.com/teamleadercrm/ui/pull/1009))
 
 ### Changed
 
+- `Badge`: adjusted visual states. ([@driesd](https://github.com/driesd) in [#1014](https://github.com/teamleadercrm/ui/pull/1014))
 - `IconButton`: adjusted visual states. ([@driesd](https://github.com/driesd) in [#1009](https://github.com/teamleadercrm/ui/pull/1009))
 - [Breaking] `IconButton`: changed attribute `data-teamleader-ui` value from `button` to `icon-button`. ([@driesd](https://github.com/driesd) in [#1009](https://github.com/teamleadercrm/ui/pull/1009))
 
 ### Deprecated
 
 ### Removed
+
+- [Breaking] `Badge`: removed `inherit` mode. ([@driesd](https://github.com/driesd) in [#1014](https://github.com/teamleadercrm/ui/pull/1014))
+- [Breaking] `Badge`: removed `inverse` mode. ([@driesd](https://github.com/driesd) in [#1014](https://github.com/teamleadercrm/ui/pull/1014))
+- [Breaking] `Badge`: removed `color` variants. ([@driesd](https://github.com/driesd) in [#1014](https://github.com/teamleadercrm/ui/pull/1014))
 
 ### Fixed
 

--- a/src/components/badge/Badge.js
+++ b/src/components/badge/Badge.js
@@ -36,12 +36,13 @@ class Badge extends PureComponent {
   };
 
   render() {
-    const { children, className, disabled, element, icon, iconPlacement, ...others } = this.props;
+    const { children, className, disabled, element, icon, iconPlacement, selected, ...others } = this.props;
 
     const classNames = cx(
       theme['badge'],
       {
         [theme['is-disabled']]: disabled,
+        [theme['is-selected']]: selected,
       },
       className,
     );
@@ -85,6 +86,8 @@ Badge.propTypes = {
   onMouseLeave: PropTypes.func,
   /** Callback function that is fired when the mouse button is released. */
   onMouseUp: PropTypes.func,
+  /** If true, component will be shown in a selected state */
+  selected: PropTypes.bool,
 };
 
 Badge.defaultProps = {

--- a/src/components/badge/Badge.js
+++ b/src/components/badge/Badge.js
@@ -27,32 +27,17 @@ class Badge extends PureComponent {
   };
 
   renderIcon = () => {
-    const { color, icon, inverse } = this.props;
+    const { color, icon } = this.props;
 
     return (
-      <Icon
-        className={theme['icon']}
-        color={color === 'neutral' ? 'teal' : color}
-        tint={inverse ? 'lightest' : 'darkest'}
-      >
+      <Icon className={theme['icon']} color={color === 'neutral' ? 'teal' : color} tint="darkest">
         {icon}
       </Icon>
     );
   };
 
   render() {
-    const {
-      children,
-      className,
-      disabled,
-      element,
-      icon,
-      iconPlacement,
-      inherit,
-      inverse,
-      color,
-      ...others
-    } = this.props;
+    const { children, className, disabled, element, icon, iconPlacement, inherit, color, ...others } = this.props;
 
     const classNames = cx(
       theme['badge'],
@@ -60,7 +45,6 @@ class Badge extends PureComponent {
       {
         [theme['is-disabled']]: disabled,
         [theme['is-inherit']]: inherit,
-        [theme['is-inverse']]: inverse,
       },
       className,
     );
@@ -106,8 +90,6 @@ Badge.propTypes = {
   iconPlacement: PropTypes.oneOf(['left', 'right']),
   /** If true, component will adapt styles from it's parent component. */
   inherit: PropTypes.bool,
-  /** If true, component will be rendered in inverse mode. */
-  inverse: PropTypes.bool,
   /** Callback function that is fired when mouse leaves the component. */
   onMouseLeave: PropTypes.func,
   /** Callback function that is fired when the mouse button is released. */
@@ -121,7 +103,6 @@ Badge.defaultProps = {
   element: 'button',
   iconPlacement: 'left',
   inherit: true,
-  inverse: false,
   color: 'neutral',
 };
 

--- a/src/components/badge/Badge.js
+++ b/src/components/badge/Badge.js
@@ -2,7 +2,6 @@ import React, { createRef, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Box from '../box';
 import Icon from '../icon';
-import { colorsWithout } from '../../constants';
 import { TextBody } from '../typography';
 import cx from 'classnames';
 import theme from './theme.css';
@@ -27,21 +26,20 @@ class Badge extends PureComponent {
   };
 
   renderIcon = () => {
-    const { color, icon } = this.props;
+    const { icon } = this.props;
 
     return (
-      <Icon className={theme['icon']} color={color === 'neutral' ? 'teal' : color} tint="darkest">
+      <Icon className={theme['icon']} color="teal" tint="darkest">
         {icon}
       </Icon>
     );
   };
 
   render() {
-    const { children, className, disabled, element, icon, iconPlacement, inherit, color, ...others } = this.props;
+    const { children, className, disabled, element, icon, iconPlacement, inherit, ...others } = this.props;
 
     const classNames = cx(
       theme['badge'],
-      theme[color],
       {
         [theme['is-disabled']]: disabled,
         [theme['is-inherit']]: inherit,
@@ -94,8 +92,6 @@ Badge.propTypes = {
   onMouseLeave: PropTypes.func,
   /** Callback function that is fired when the mouse button is released. */
   onMouseUp: PropTypes.func,
-  /** Add a color theme to the badge */
-  color: PropTypes.oneOf(colorsWithout(['teal'])),
 };
 
 Badge.defaultProps = {
@@ -103,7 +99,6 @@ Badge.defaultProps = {
   element: 'button',
   iconPlacement: 'left',
   inherit: true,
-  color: 'neutral',
 };
 
 export default Badge;

--- a/src/components/badge/Badge.js
+++ b/src/components/badge/Badge.js
@@ -2,7 +2,7 @@ import React, { createRef, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Box from '../box';
 import Icon from '../icon';
-import { TextBody } from '../typography';
+import { TextSmall, TextBody, TextDisplay } from '../typography';
 import cx from 'classnames';
 import theme from './theme.css';
 
@@ -36,7 +36,7 @@ class Badge extends PureComponent {
   };
 
   render() {
-    const { children, className, disabled, element, icon, iconPlacement, selected, ...others } = this.props;
+    const { children, className, disabled, element, icon, iconPlacement, selected, size, ...others } = this.props;
 
     const classNames = cx(
       theme['badge'],
@@ -46,6 +46,8 @@ class Badge extends PureComponent {
       },
       className,
     );
+
+    const TextElement = size === 'small' ? TextSmall : size === 'large' ? TextDisplay : TextBody;
 
     return (
       <Box
@@ -60,9 +62,9 @@ class Badge extends PureComponent {
         {...others}
       >
         {icon && iconPlacement === 'left' && this.renderIcon()}
-        <TextBody className={theme['label']} element="span">
+        <TextElement className={theme['label']} element="span">
           {children}
-        </TextBody>
+        </TextElement>
         {icon && iconPlacement === 'right' && this.renderIcon()}
       </Box>
     );
@@ -88,12 +90,15 @@ Badge.propTypes = {
   onMouseUp: PropTypes.func,
   /** If true, component will be shown in a selected state */
   selected: PropTypes.bool,
+  /** Size of the button. */
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
 };
 
 Badge.defaultProps = {
   disabled: false,
   element: 'button',
   iconPlacement: 'left',
+  size: 'medium',
 };
 
 export default Badge;

--- a/src/components/badge/Badge.js
+++ b/src/components/badge/Badge.js
@@ -36,13 +36,12 @@ class Badge extends PureComponent {
   };
 
   render() {
-    const { children, className, disabled, element, icon, iconPlacement, inherit, ...others } = this.props;
+    const { children, className, disabled, element, icon, iconPlacement, ...others } = this.props;
 
     const classNames = cx(
       theme['badge'],
       {
         [theme['is-disabled']]: disabled,
-        [theme['is-inherit']]: inherit,
       },
       className,
     );
@@ -60,13 +59,9 @@ class Badge extends PureComponent {
         {...others}
       >
         {icon && iconPlacement === 'left' && this.renderIcon()}
-        {inherit ? (
-          <span className={theme['label']}>{children}</span>
-        ) : (
-          <TextBody className={theme['label']} element="span">
-            {children}
-          </TextBody>
-        )}
+        <TextBody className={theme['label']} element="span">
+          {children}
+        </TextBody>
         {icon && iconPlacement === 'right' && this.renderIcon()}
       </Box>
     );
@@ -86,8 +81,6 @@ Badge.propTypes = {
   icon: PropTypes.element,
   /** The position of the icon inside the badge. */
   iconPlacement: PropTypes.oneOf(['left', 'right']),
-  /** If true, component will adapt styles from it's parent component. */
-  inherit: PropTypes.bool,
   /** Callback function that is fired when mouse leaves the component. */
   onMouseLeave: PropTypes.func,
   /** Callback function that is fired when the mouse button is released. */
@@ -98,7 +91,6 @@ Badge.defaultProps = {
   disabled: false,
   element: 'button',
   iconPlacement: 'left',
-  inherit: true,
 };
 
 export default Badge;

--- a/src/components/badge/badge.stories.js
+++ b/src/components/badge/badge.stories.js
@@ -5,6 +5,7 @@ import { IconBuildingSmallOutline } from '@teamleader/ui-icons';
 import { Badge, TextDisplay } from '../../index';
 
 const iconPositions = ['left', 'right'];
+const sizes = ['small', 'medium', 'large'];
 
 export default {
   title: addStoryInGroup(LOW_LEVEL_BLOCKS, 'Badge'),
@@ -16,7 +17,11 @@ export default {
   },
 };
 
-export const basic = () => <Badge disabled={boolean('Disabled', false)}>I'm a badge</Badge>;
+export const basic = () => (
+  <Badge disabled={boolean('Disabled', false)} size={select('Size', sizes, 'medium')}>
+    I'm a badge
+  </Badge>
+);
 
 export const withIcon = () => (
   <Badge
@@ -24,6 +29,7 @@ export const withIcon = () => (
     icon={<IconBuildingSmallOutline />}
     iconPlacement={select('Icon placement', iconPositions, 'left')}
     selected={boolean('Selected', false)}
+    size={select('Size', sizes, 'medium')}
   >
     I'm a badge
   </Badge>
@@ -39,6 +45,7 @@ export const withCustomElement = () => (
     element="a"
     href="https://teamleader.eu"
     selected={boolean('Selected', false)}
+    size={select('Size', sizes, 'medium')}
   >
     I'm a badge
   </Badge>

--- a/src/components/badge/badge.stories.js
+++ b/src/components/badge/badge.stories.js
@@ -24,7 +24,6 @@ export const inline = () => (
       color={select('Color', colors, 'neutral')}
       disabled={boolean('Disabled', false)}
       inherit={boolean('Inherit', true)}
-      inverse={boolean('Inverse', false)}
       marginHorizontal={1}
     >
       badge
@@ -38,7 +37,6 @@ export const standalone = () => (
     color={select('Color', colors, 'neutral')}
     disabled={boolean('Disabled', false)}
     inherit={boolean('Inherit', false)}
-    inverse={boolean('Inverse', false)}
   >
     I'm a badge
   </Badge>
@@ -51,7 +49,6 @@ export const withIcon = () => (
     icon={<IconBuildingSmallOutline />}
     iconPlacement={select('Icon placement', iconPositions, 'left')}
     inherit={boolean('Inherit', false)}
-    inverse={boolean('Inverse', false)}
   >
     I'm a badge
   </Badge>
@@ -68,7 +65,6 @@ export const withCustomElement = () => (
     element="a"
     href="https://teamleader.eu"
     inherit={boolean('Inherit', false)}
-    inverse={boolean('Inverse', false)}
   >
     I'm a badge
   </Badge>

--- a/src/components/badge/badge.stories.js
+++ b/src/components/badge/badge.stories.js
@@ -23,6 +23,7 @@ export const withIcon = () => (
     disabled={boolean('Disabled', false)}
     icon={<IconBuildingSmallOutline />}
     iconPlacement={select('Icon placement', iconPositions, 'left')}
+    selected={boolean('Selected', false)}
   >
     I'm a badge
   </Badge>
@@ -33,7 +34,12 @@ withIcon.story = {
 };
 
 export const withCustomElement = () => (
-  <Badge disabled={boolean('Disabled', false)} element="a" href="https://teamleader.eu">
+  <Badge
+    disabled={boolean('Disabled', false)}
+    element="a"
+    href="https://teamleader.eu"
+    selected={boolean('Selected', false)}
+  >
     I'm a badge
   </Badge>
 );

--- a/src/components/badge/badge.stories.js
+++ b/src/components/badge/badge.stories.js
@@ -2,9 +2,8 @@ import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
 import { boolean, select } from '@storybook/addon-knobs/react';
 import { IconBuildingSmallOutline } from '@teamleader/ui-icons';
-import { colorsWithout, Badge, TextDisplay } from '../../index';
+import { Badge, TextDisplay } from '../../index';
 
-const colors = colorsWithout(['teal']);
 const iconPositions = ['left', 'right'];
 
 export default {
@@ -20,12 +19,7 @@ export default {
 export const inline = () => (
   <TextDisplay>
     I'm display text with a
-    <Badge
-      color={select('Color', colors, 'neutral')}
-      disabled={boolean('Disabled', false)}
-      inherit={boolean('Inherit', true)}
-      marginHorizontal={1}
-    >
+    <Badge disabled={boolean('Disabled', false)} inherit={boolean('Inherit', true)} marginHorizontal={1}>
       badge
     </Badge>
     inside.
@@ -33,18 +27,13 @@ export const inline = () => (
 );
 
 export const standalone = () => (
-  <Badge
-    color={select('Color', colors, 'neutral')}
-    disabled={boolean('Disabled', false)}
-    inherit={boolean('Inherit', false)}
-  >
+  <Badge disabled={boolean('Disabled', false)} inherit={boolean('Inherit', false)}>
     I'm a badge
   </Badge>
 );
 
 export const withIcon = () => (
   <Badge
-    color={select('Color', colors, 'neutral')}
     disabled={boolean('Disabled', false)}
     icon={<IconBuildingSmallOutline />}
     iconPlacement={select('Icon placement', iconPositions, 'left')}
@@ -60,7 +49,6 @@ withIcon.story = {
 
 export const withCustomElement = () => (
   <Badge
-    color={select('Color', colors, 'neutral')}
     disabled={boolean('Disabled', false)}
     element="a"
     href="https://teamleader.eu"

--- a/src/components/badge/badge.stories.js
+++ b/src/components/badge/badge.stories.js
@@ -16,28 +16,13 @@ export default {
   },
 };
 
-export const inline = () => (
-  <TextDisplay>
-    I'm display text with a
-    <Badge disabled={boolean('Disabled', false)} inherit={boolean('Inherit', true)} marginHorizontal={1}>
-      badge
-    </Badge>
-    inside.
-  </TextDisplay>
-);
-
-export const standalone = () => (
-  <Badge disabled={boolean('Disabled', false)} inherit={boolean('Inherit', false)}>
-    I'm a badge
-  </Badge>
-);
+export const basic = () => <Badge disabled={boolean('Disabled', false)}>I'm a badge</Badge>;
 
 export const withIcon = () => (
   <Badge
     disabled={boolean('Disabled', false)}
     icon={<IconBuildingSmallOutline />}
     iconPlacement={select('Icon placement', iconPositions, 'left')}
-    inherit={boolean('Inherit', false)}
   >
     I'm a badge
   </Badge>
@@ -48,12 +33,7 @@ withIcon.story = {
 };
 
 export const withCustomElement = () => (
-  <Badge
-    disabled={boolean('Disabled', false)}
-    element="a"
-    href="https://teamleader.eu"
-    inherit={boolean('Inherit', false)}
-  >
+  <Badge disabled={boolean('Disabled', false)} element="a" href="https://teamleader.eu">
     I'm a badge
   </Badge>
 );

--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -9,9 +9,10 @@
 }
 
 .badge {
+  background-color: color(var(--color-neutral-darkest) a(12%));
+  border: var(--badge-border-width) solid color(var(--color-neutral-darkest) a(12%));
   border-radius: var(--badge-border-radius);
-  border-style: solid;
-  border-width: var(--badge-border-width);
+  color: var(--color-teal-darkest);
   display: inline-flex;
   align-items: center;
   outline: none;
@@ -34,10 +35,6 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-
-  background-color: color(var(--color-neutral-darkest) a(12%));
-  border-color: color(var(--color-neutral-darkest) a(12%));
-  color: var(--color-teal-darkest);
 
   &:not(.is-disabled) {
     &:hover,

--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -35,60 +35,30 @@
     white-space: nowrap;
   }
 
-  &.neutral {
-    background-color: color(var(--color-neutral-darkest) a(12%));
-    border-color: color(var(--color-neutral-darkest) a(12%));
-    color: var(--color-teal-darkest);
+  background-color: color(var(--color-neutral-darkest) a(12%));
+  border-color: color(var(--color-neutral-darkest) a(12%));
+  color: var(--color-teal-darkest);
 
-    &:not(.is-disabled) {
-      &:hover,
-      &:active {
-        background-color: color(var(--color-neutral-darkest) a(24%));
-      }
+  &:not(.is-disabled) {
+    &:hover,
+    &:active {
+      background-color: color(var(--color-neutral-darkest) a(24%));
+    }
 
-      &:focus {
-        background-color: color(var(--color-teal-darkest) a(6%));
-        border-color: color(var(--color-neutral-darkest) a(24%));
-        box-shadow: 0 0 0 var(--badge-border-width) color(var(--color-neutral-darkest) a(24%));
-      }
+    &:focus {
+      background-color: color(var(--color-teal-darkest) a(6%));
+      border-color: color(var(--color-neutral-darkest) a(24%));
+      box-shadow: 0 0 0 var(--badge-border-width) color(var(--color-neutral-darkest) a(24%));
+    }
 
-      &:active {
-        box-shadow: inset 0 1px 3px 0 color(var(--color-teal-darkest) a(12%));
+    &:active {
+      box-shadow: inset 0 1px 3px 0 color(var(--color-teal-darkest) a(12%));
 
-        .icon {
-          opacity: 1;
-        }
+      .icon {
+        opacity: 1;
       }
     }
   }
-  /* prettier-ignore */
-  @each
-    $color in (mint, violet, ruby, gold, aqua) {
-      &.$(color) {
-        background-color: color(var(--color-$(color)-light) a(48%));
-        border-color: color(var(--color-$(color)-light) a(48%));
-        color: var(--color-$(color)-darkest);
-
-        &:not(.is-disabled) {
-          &:hover {
-            border-color: color(var(--color-$(color)-light) a(100%));
-          }
-
-          &:focus {
-            border-color: color(var(--color-$(color)-light) a(100%));
-            box-shadow: 0 0 0 var(--badge-border-width) color(var(--color-$(color)-light) a(100%));
-          }
-
-          &:active {
-            box-shadow: inset 0 1px 3px 0 var(--color-$(color)-light);
-
-            .icon {
-              opacity: 1;
-            }
-          }
-        }
-      }
-    }
 
   &:not(.is-disabled) {
     cursor: pointer;

--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -81,12 +81,4 @@
     opacity: 0.48;
     pointer-events: none;
   }
-
-  &.is-inherit {
-    font-family: inherit;
-    font-size: inherit;
-    font-weight: inherit;
-    letter-spacing: inherit;
-    text-transform: inherit;
-  }
 }

--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -58,4 +58,8 @@
     opacity: 0.48;
     pointer-events: none;
   }
+
+  &.is-selected {
+    background-color: color(var(--color-neutral-darkest) a(24%)) !important;
+  }
 }

--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -13,6 +13,7 @@
   border: var(--badge-border-width) solid color(var(--color-neutral-darkest) a(12%));
   border-radius: var(--badge-border-radius);
   color: var(--color-teal-darkest);
+  cursor: pointer;
   display: inline-flex;
   align-items: center;
   outline: none;
@@ -48,28 +49,8 @@
     }
 
     &:active {
-      box-shadow: inset 0 1px 3px 0 color(var(--color-teal-darkest) a(12%));
-
-      .icon {
-        opacity: 1;
-      }
-    }
-  }
-
-  &:not(.is-disabled) {
-    cursor: pointer;
-
-    &:active {
-      &:before {
-        background: linear-gradient(to bottom, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0) 100%);
-        content: '';
-        height: 10px;
-        left: 0;
-        position: absolute;
-        opacity: 0.05;
-        top: 0;
-        width: 100%;
-      }
+      box-shadow: inset 0 2px 3px color(var(--color-neutral-darkest) a(12%));
+      background-color: color(var(--color-neutral-darkest) a(18%));
     }
   }
 

--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -42,7 +42,7 @@
     }
 
     &:focus {
-      background-color: color(var(--color-teal-darkest) a(6%));
+      background-color: color(var(--color-neutral-darkest) a(12%));
       border-color: color(var(--color-neutral-darkest) a(24%));
       box-shadow: 0 0 0 var(--badge-border-width) color(var(--color-neutral-darkest) a(24%));
     }

--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -36,56 +36,27 @@
   }
 
   &.neutral {
-    &:not(.is-inverse) {
-      background-color: color(var(--color-neutral-darkest) a(12%));
-      border-color: color(var(--color-neutral-darkest) a(12%));
-      color: var(--color-teal-darkest);
+    background-color: color(var(--color-neutral-darkest) a(12%));
+    border-color: color(var(--color-neutral-darkest) a(12%));
+    color: var(--color-teal-darkest);
 
-      &:not(.is-disabled) {
-        &:hover,
-        &:active {
-          background-color: color(var(--color-neutral-darkest) a(24%));
-        }
-
-        &:focus {
-          background-color: color(var(--color-teal-darkest) a(6%));
-          border-color: color(var(--color-neutral-darkest) a(24%));
-          box-shadow: 0 0 0 var(--badge-border-width) color(var(--color-neutral-darkest) a(24%));
-        }
-
-        &:active {
-          box-shadow: inset 0 1px 3px 0 color(var(--color-teal-darkest) a(12%));
-
-          .icon {
-            opacity: 1;
-          }
-        }
+    &:not(.is-disabled) {
+      &:hover,
+      &:active {
+        background-color: color(var(--color-neutral-darkest) a(24%));
       }
-    }
 
-    &.is-inverse {
-      background-color: color(var(--color-neutral-lightest) a(12%));
-      border-color: color(var(--color-neutral-lightest) a(12%));
-      color: var(--color-teal-lightest);
+      &:focus {
+        background-color: color(var(--color-teal-darkest) a(6%));
+        border-color: color(var(--color-neutral-darkest) a(24%));
+        box-shadow: 0 0 0 var(--badge-border-width) color(var(--color-neutral-darkest) a(24%));
+      }
 
-      &:not(.is-disabled) {
-        &:hover,
-        &:active {
-          background-color: color(var(--color-neutral-lightest) a(24%));
-        }
+      &:active {
+        box-shadow: inset 0 1px 3px 0 color(var(--color-teal-darkest) a(12%));
 
-        &:focus {
-          background-color: color(var(--color-white) a(12%));
-          border-color: color(var(--color-white: #ffffff) a(24%));
-          box-shadow: 0 0 0 var(--badge-border-width) color(var(--color-neutral-darkest) a(24%));
-        }
-
-        &:active {
-          box-shadow: inset 0 1px 3px 0 var(--color-teal-darkest);
-
-          .icon {
-            opacity: 1;
-          }
+        .icon {
+          opacity: 1;
         }
       }
     }

--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -29,10 +29,6 @@
     margin-left: var(--spacer-smaller);
   }
 
-  .icon {
-    opacity: 0.86;
-  }
-
   .label {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -37,9 +37,8 @@
   }
 
   &:not(.is-disabled) {
-    &:hover,
-    &:active {
-      background-color: color(var(--color-neutral-darkest) a(24%));
+    &:hover {
+      background-color: color(var(--color-neutral-darkest) a(18%));
     }
 
     &:focus {


### PR DESCRIPTION
### Description

Besides **adjusting** the `visual states` of our `Badge` component,  this PR is also **adding** a:

- `selected` prop, which renders the `Badge in a selected state` when `true`.
- `size` prop, with possible values: `small`, `medium` (default) & `large`

#### Screenshot after this PR
![Screenshot 2020-04-15 09 16 20](https://user-images.githubusercontent.com/5336831/79310821-d2b29a00-7efc-11ea-974d-d709b0cea383.png)
![Screenshot 2020-04-15 10 11 09](https://user-images.githubusercontent.com/5336831/79313997-74d48100-7f01-11ea-9ff6-fbbe326b4b49.png)


### Breaking changes
We also **removed** the following `Badge` props, which result in breaking changes:

- 🔥 `inherit`: used to inherit font styles from its parent
- 🔥 `inverse`: used to render the Badge in inverse mode when used on teal darkest backgrounds
- 🔥 `color`: used to render our Badge in different color variations
