### PR TITLE
Tag: visual state updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@
 - `Badge`: added `selected` boolean prop which shows the badge in a selected state. ([@driesd](https://github.com/driesd) in [#1014](https://github.com/teamleadercrm/ui/pull/1014))
 - `IconButton`: added `large` size variation. ([@driesd](https://github.com/driesd) in [#1009](https://github.com/teamleadercrm/ui/pull/1009))
 - `IconButton`: added `selected` boolean prop which shows the button in a selected state. ([@driesd](https://github.com/driesd) in [#1009](https://github.com/teamleadercrm/ui/pull/1009))
+- `Tag`: added `selected` boolean prop which shows the tag in a selected state. ([@driesd](https://github.com/driesd) in [#1020](https://github.com/teamleadercrm/ui/pull/1020))
 
 ### Changed
 
 - `Badge`: adjusted visual states. ([@driesd](https://github.com/driesd) in [#1014](https://github.com/teamleadercrm/ui/pull/1014))
 - `IconButton`: adjusted visual states. ([@driesd](https://github.com/driesd) in [#1009](https://github.com/teamleadercrm/ui/pull/1009))
 - [Breaking] `IconButton`: changed attribute `data-teamleader-ui` value from `button` to `icon-button`. ([@driesd](https://github.com/driesd) in [#1009](https://github.com/teamleadercrm/ui/pull/1009))
+- `Tag`: adjusted visual states. ([@driesd](https://github.com/driesd) in [#1020](https://github.com/teamleadercrm/ui/pull/1020))
 
 ### Deprecated
 
@@ -20,6 +22,9 @@
 - [Breaking] `Badge`: removed `inherit` mode. ([@driesd](https://github.com/driesd) in [#1014](https://github.com/teamleadercrm/ui/pull/1014))
 - [Breaking] `Badge`: removed `inverse` mode. ([@driesd](https://github.com/driesd) in [#1014](https://github.com/teamleadercrm/ui/pull/1014))
 - [Breaking] `Badge`: removed `color` variants. ([@driesd](https://github.com/driesd) in [#1014](https://github.com/teamleadercrm/ui/pull/1014))
+- [Breaking] `Tag`: removed `inverse` mode. ([@driesd](https://github.com/driesd) in [#1020](https://github.com/teamleadercrm/ui/pull/1020))
+- [Breaking] `Tag`: removed `color` variants. ([@driesd](https://github.com/driesd) in [#1020](https://github.com/teamleadercrm/ui/pull/1020))
+- [Breaking] `Tag`: removed `onLabelClick` prop. Use `onClick` instead ([@driesd](https://github.com/driesd) in [#1020](https://github.com/teamleadercrm/ui/pull/1020))
 
 ### Fixed
 

--- a/src/components/tag/Tag.js
+++ b/src/components/tag/Tag.js
@@ -10,7 +10,7 @@ import { UITextBody, UITextDisplay, UITextSmall } from '../typography';
 
 class Tag extends PureComponent {
   render() {
-    const { children, className, onLabelClick, onRemoveClick, size, disabled, ...others } = this.props;
+    const { children, className, onRemoveClick, size, disabled, ...others } = this.props;
 
     const classNames = cx(
       theme['tag'],
@@ -25,7 +25,7 @@ class Tag extends PureComponent {
     const TextElement = size === 'small' ? UITextSmall : size === 'large' ? UITextDisplay : UITextBody;
 
     return (
-      <Box className={classNames} data-teamleader-ui="tag" onClick={onLabelClick} {...others}>
+      <Box className={classNames} data-teamleader-ui="tag" {...others}>
         <TextElement marginHorizontal={2}>{children}</TextElement>
         {onRemoveClick && (
           <IconButton
@@ -46,7 +46,6 @@ Tag.propTypes = {
   children: PropTypes.any.isRequired,
   className: PropTypes.string,
   disabled: PropTypes.bool,
-  onLabelClick: PropTypes.func,
   onRemoveClick: PropTypes.func,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
 };

--- a/src/components/tag/Tag.js
+++ b/src/components/tag/Tag.js
@@ -10,7 +10,7 @@ import uiUtilities from '@teamleader/ui-utilities';
 
 class Tag extends PureComponent {
   render() {
-    const { children, className, inverse, onLabelClick, onRemoveClick, size, color, disabled, ...others } = this.props;
+    const { children, className, onLabelClick, onRemoveClick, size, color, disabled, ...others } = this.props;
 
     const classNames = cx(
       theme['tag'],
@@ -18,25 +18,18 @@ class Tag extends PureComponent {
       theme[color],
       {
         [theme['is-removable']]: onRemoveClick,
-        [theme['is-inverse']]: inverse,
         [theme['is-disabled']]: disabled,
       },
       className,
     );
 
-    const closeButtonColor = inverse ? 'white' : 'neutral';
+    const closeButtonColor = 'neutral';
     const closeButtonIcon = <IconCloseSmallOutline />;
 
     return (
       <Box className={classNames} data-teamleader-ui="tag" {...others}>
         {onLabelClick ? (
-          <Button
-            className={theme['label-button']}
-            onClick={onLabelClick}
-            level="outline"
-            inverse={inverse}
-            disabled={disabled}
-          >
+          <Button className={theme['label-button']} onClick={onLabelClick} level="outline" disabled={disabled}>
             {children}
           </Button>
         ) : (
@@ -62,7 +55,6 @@ Tag.propTypes = {
   children: PropTypes.any.isRequired,
   className: PropTypes.string,
   disabled: PropTypes.bool,
-  inverse: PropTypes.bool,
   onLabelClick: PropTypes.func,
   onRemoveClick: PropTypes.func,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
@@ -70,7 +62,6 @@ Tag.propTypes = {
 };
 
 Tag.defaultProps = {
-  inverse: false,
   size: 'medium',
   color: 'neutral',
 };

--- a/src/components/tag/Tag.js
+++ b/src/components/tag/Tag.js
@@ -6,7 +6,7 @@ import IconButton from '../iconButton';
 import cx from 'classnames';
 import theme from './theme.css';
 import { IconCloseSmallOutline } from '@teamleader/ui-icons';
-import uiUtilities from '@teamleader/ui-utilities';
+import { UITextBody, UITextDisplay, UITextSmall } from '../typography';
 
 class Tag extends PureComponent {
   render() {
@@ -22,6 +22,8 @@ class Tag extends PureComponent {
       className,
     );
 
+    const TextElement = size === 'small' ? UITextSmall : size === 'large' ? UITextDisplay : UITextBody;
+
     return (
       <Box className={classNames} data-teamleader-ui="tag" {...others}>
         {onLabelClick ? (
@@ -29,7 +31,7 @@ class Tag extends PureComponent {
             {children}
           </Button>
         ) : (
-          <span className={cx(uiUtilities['reset-font-smoothing'], theme['label'])}>{children}</span>
+          <TextElement marginHorizontal={2}>{children}</TextElement>
         )}
 
         {onRemoveClick && (

--- a/src/components/tag/Tag.js
+++ b/src/components/tag/Tag.js
@@ -10,12 +10,11 @@ import uiUtilities from '@teamleader/ui-utilities';
 
 class Tag extends PureComponent {
   render() {
-    const { children, className, onLabelClick, onRemoveClick, size, color, disabled, ...others } = this.props;
+    const { children, className, onLabelClick, onRemoveClick, size, disabled, ...others } = this.props;
 
     const classNames = cx(
       theme['tag'],
       theme[`is-${size}`],
-      theme[color],
       {
         [theme['is-removable']]: onRemoveClick,
         [theme['is-disabled']]: disabled,
@@ -58,12 +57,10 @@ Tag.propTypes = {
   onLabelClick: PropTypes.func,
   onRemoveClick: PropTypes.func,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
-  color: PropTypes.oneOf(['neutral', 'mint', 'gold', 'ruby', 'violet', 'aqua']),
 };
 
 Tag.defaultProps = {
   size: 'medium',
-  color: 'neutral',
 };
 
 export default Tag;

--- a/src/components/tag/Tag.js
+++ b/src/components/tag/Tag.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Box from '../box';
-import Button from '../button';
 import IconButton from '../iconButton';
 import cx from 'classnames';
 import theme from './theme.css';
@@ -10,7 +9,7 @@ import { UITextBody, UITextDisplay, UITextSmall } from '../typography';
 
 class Tag extends PureComponent {
   render() {
-    const { children, className, onRemoveClick, size, disabled, ...others } = this.props;
+    const { children, className, onRemoveClick, selected, size, disabled, ...others } = this.props;
 
     const classNames = cx(
       theme['tag'],
@@ -18,6 +17,7 @@ class Tag extends PureComponent {
       {
         [theme['is-removable']]: onRemoveClick,
         [theme['is-disabled']]: disabled,
+        [theme['is-selected']]: selected,
       },
       className,
     );
@@ -47,6 +47,8 @@ Tag.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
   onRemoveClick: PropTypes.func,
+  /** If true, component will be shown in a selected state */
+  selected: PropTypes.bool,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
 };
 

--- a/src/components/tag/Tag.js
+++ b/src/components/tag/Tag.js
@@ -25,15 +25,8 @@ class Tag extends PureComponent {
     const TextElement = size === 'small' ? UITextSmall : size === 'large' ? UITextDisplay : UITextBody;
 
     return (
-      <Box className={classNames} data-teamleader-ui="tag" {...others}>
-        {onLabelClick ? (
-          <Button className={theme['label-button']} onClick={onLabelClick} level="outline" disabled={disabled}>
-            {children}
-          </Button>
-        ) : (
-          <TextElement marginHorizontal={2}>{children}</TextElement>
-        )}
-
+      <Box className={classNames} data-teamleader-ui="tag" onClick={onLabelClick} {...others}>
+        <TextElement marginHorizontal={2}>{children}</TextElement>
         {onRemoveClick && (
           <IconButton
             className={theme['remove-button']}

--- a/src/components/tag/Tag.js
+++ b/src/components/tag/Tag.js
@@ -9,12 +9,13 @@ import { UITextBody, UITextDisplay, UITextSmall } from '../typography';
 
 class Tag extends PureComponent {
   render() {
-    const { children, className, onRemoveClick, selected, size, disabled, ...others } = this.props;
+    const { children, className, onClick, onRemoveClick, selected, size, disabled, ...others } = this.props;
 
     const classNames = cx(
       theme['tag'],
       theme[`is-${size}`],
       {
+        [theme['is-clickable']]: onClick,
         [theme['is-removable']]: onRemoveClick,
         [theme['is-disabled']]: disabled,
         [theme['is-selected']]: selected,

--- a/src/components/tag/Tag.js
+++ b/src/components/tag/Tag.js
@@ -22,9 +22,6 @@ class Tag extends PureComponent {
       className,
     );
 
-    const closeButtonColor = 'neutral';
-    const closeButtonIcon = <IconCloseSmallOutline />;
-
     return (
       <Box className={classNames} data-teamleader-ui="tag" {...others}>
         {onLabelClick ? (
@@ -38,8 +35,8 @@ class Tag extends PureComponent {
         {onRemoveClick && (
           <IconButton
             className={theme['remove-button']}
-            color={closeButtonColor}
-            icon={closeButtonIcon}
+            color="teal"
+            icon={<IconCloseSmallOutline />}
             onClick={onRemoveClick}
             size="small"
             disabled={disabled}

--- a/src/components/tag/tag.stories.js
+++ b/src/components/tag/tag.stories.js
@@ -21,6 +21,7 @@ export const clickable = () => (
   <Tag
     element="button"
     onClick={() => console.log('Tag label clicked')}
+    selected={boolean('Selected', false)}
     size={select('Size', sizes, 'medium')}
     disabled={boolean('Disabled', false)}
   >
@@ -31,6 +32,7 @@ export const clickable = () => (
 export const closable = () => (
   <Tag
     onRemoveClick={() => console.log('Tag removed')}
+    selected={boolean('Selected', false)}
     size={select('Size', sizes, 'medium')}
     disabled={boolean('Disabled', false)}
   >
@@ -43,6 +45,7 @@ export const clickableClosable = () => (
     element="button"
     onClick={() => console.log('Tag label clicked')}
     onRemoveClick={() => console.log('Tag removed')}
+    selected={boolean('Selected', false)}
     size={select('Size', sizes, 'medium')}
     disabled={boolean('Disabled', false)}
   >
@@ -55,7 +58,11 @@ clickableClosable.story = {
 };
 
 export const withTooltip = () => (
-  <TooltippedTag tooltip={<TextBody>I am the tooltip</TextBody>} disabled={boolean('Disabled', false)}>
+  <TooltippedTag
+    tooltip={<TextBody>I am the tooltip</TextBody>}
+    disabled={boolean('Disabled', false)}
+    selected={boolean('Selected', false)}
+  >
     Tag with tooltip
   </TooltippedTag>
 );

--- a/src/components/tag/tag.stories.js
+++ b/src/components/tag/tag.stories.js
@@ -19,7 +19,8 @@ export const basic = () => (
 
 export const clickable = () => (
   <Tag
-    onLabelClick={() => console.log('Tag label clicked')}
+    element="button"
+    onClick={() => console.log('Tag label clicked')}
     size={select('Size', sizes, 'medium')}
     disabled={boolean('Disabled', false)}
   >
@@ -39,7 +40,8 @@ export const closable = () => (
 
 export const clickableClosable = () => (
   <Tag
-    onLabelClick={() => console.log('Tag label clicked')}
+    element="button"
+    onClick={() => console.log('Tag label clicked')}
     onRemoveClick={() => console.log('Tag removed')}
     size={select('Size', sizes, 'medium')}
     disabled={boolean('Disabled', false)}

--- a/src/components/tag/tag.stories.js
+++ b/src/components/tag/tag.stories.js
@@ -16,7 +16,6 @@ export const basic = () => (
   <Tag
     color={select('Color', colors, 'neutral')}
     size={select('Size', sizes, 'medium')}
-    inverse={boolean('Inverse', false)}
     disabled={boolean('Disabled', false)}
   >
     I am a tag
@@ -26,7 +25,6 @@ export const basic = () => (
 export const clickable = () => (
   <Tag
     color={select('Color', colors, 'neutral')}
-    inverse={boolean('Inverse', false)}
     onLabelClick={() => console.log('Tag label clicked')}
     size={select('Size', sizes, 'medium')}
     disabled={boolean('Disabled', false)}
@@ -38,7 +36,6 @@ export const clickable = () => (
 export const closable = () => (
   <Tag
     color={select('Color', colors, 'neutral')}
-    inverse={boolean('Inverse', false)}
     onRemoveClick={() => console.log('Tag removed')}
     size={select('Size', sizes, 'medium')}
     disabled={boolean('Disabled', false)}
@@ -50,7 +47,6 @@ export const closable = () => (
 export const clickableClosable = () => (
   <Tag
     color={select('Color', colors, 'neutral')}
-    inverse={boolean('Inverse', false)}
     onLabelClick={() => console.log('Tag label clicked')}
     onRemoveClick={() => console.log('Tag removed')}
     size={select('Size', sizes, 'medium')}
@@ -67,7 +63,6 @@ clickableClosable.story = {
 export const withTooltip = () => (
   <TooltippedTag
     color={select('Color', colors, 'neutral')}
-    inverse={boolean('Inverse', false)}
     tooltip={<TextBody>I am the tooltip</TextBody>}
     disabled={boolean('Disabled', false)}
   >

--- a/src/components/tag/tag.stories.js
+++ b/src/components/tag/tag.stories.js
@@ -4,7 +4,6 @@ import { boolean, select } from '@storybook/addon-knobs/react';
 import { Tag, TextBody, Tooltip } from '../../index';
 
 const sizes = ['small', 'medium', 'large'];
-const colors = ['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua'];
 
 const TooltippedTag = Tooltip(Tag);
 
@@ -13,18 +12,13 @@ export default {
 };
 
 export const basic = () => (
-  <Tag
-    color={select('Color', colors, 'neutral')}
-    size={select('Size', sizes, 'medium')}
-    disabled={boolean('Disabled', false)}
-  >
+  <Tag size={select('Size', sizes, 'medium')} disabled={boolean('Disabled', false)}>
     I am a tag
   </Tag>
 );
 
 export const clickable = () => (
   <Tag
-    color={select('Color', colors, 'neutral')}
     onLabelClick={() => console.log('Tag label clicked')}
     size={select('Size', sizes, 'medium')}
     disabled={boolean('Disabled', false)}
@@ -35,7 +29,6 @@ export const clickable = () => (
 
 export const closable = () => (
   <Tag
-    color={select('Color', colors, 'neutral')}
     onRemoveClick={() => console.log('Tag removed')}
     size={select('Size', sizes, 'medium')}
     disabled={boolean('Disabled', false)}
@@ -46,7 +39,6 @@ export const closable = () => (
 
 export const clickableClosable = () => (
   <Tag
-    color={select('Color', colors, 'neutral')}
     onLabelClick={() => console.log('Tag label clicked')}
     onRemoveClick={() => console.log('Tag removed')}
     size={select('Size', sizes, 'medium')}
@@ -61,11 +53,7 @@ clickableClosable.story = {
 };
 
 export const withTooltip = () => (
-  <TooltippedTag
-    color={select('Color', colors, 'neutral')}
-    tooltip={<TextBody>I am the tooltip</TextBody>}
-    disabled={boolean('Disabled', false)}
-  >
+  <TooltippedTag tooltip={<TextBody>I am the tooltip</TextBody>} disabled={boolean('Disabled', false)}>
     Tag with tooltip
   </TooltippedTag>
 );

--- a/src/components/tag/theme.css
+++ b/src/components/tag/theme.css
@@ -18,44 +18,21 @@
   &.neutral {
     border-style: solid;
     border-width: 1px;
+    background-color: color(var(--color-neutral-darkest) a(12%));
+    border-color: color(var(--color-neutral-darkest) a(12%));
 
-    &:not(.is-inverse) {
-      background-color: color(var(--color-neutral-darkest) a(12%));
-      border-color: color(var(--color-neutral-darkest) a(12%));
-
-      .label {
-        color: var(--color-teal-darkest);
-      }
-
-      .label-button:not(:disabled) {
-        &:focus {
-          box-shadow: 0 0 0 var(--tag-border-width) color(var(--color-teal-darkest) a(36%)) !important;
-        }
-
-        &:active {
-          background-color: color(var(--color-teal-darkest) a(6%));
-          box-shadow: inset 0 2px 3px 0 color(var(--color-teal-darkest) a(12%)) !important;
-        }
-      }
+    .label {
+      color: var(--color-teal-darkest);
     }
 
-    &.is-inverse {
-      background: color(var(--color-neutral-lightest) a(12%));
-      border-color: color(var(--color-neutral-lightest) a(12%));
-
-      .label {
-        color: var(--color-neutral-lightest);
+    .label-button:not(:disabled) {
+      &:focus {
+        box-shadow: 0 0 0 var(--tag-border-width) color(var(--color-teal-darkest) a(36%)) !important;
       }
 
-      .label-button:not(:disabled) {
-        &:focus {
-          box-shadow: 0 0 0 var(--tag-border-width) color(var(--color-white) a(50%)) !important;
-        }
-
-        &:active {
-          background-color: color(var(--color-white) a(12%));
-          box-shadow: inset 0 2px 3px 0 color(var(--color-teal-darkest) a(12%)) !important;
-        }
+      &:active {
+        background-color: color(var(--color-teal-darkest) a(6%));
+        box-shadow: inset 0 2px 3px 0 color(var(--color-teal-darkest) a(12%)) !important;
       }
     }
   }

--- a/src/components/tag/theme.css
+++ b/src/components/tag/theme.css
@@ -19,7 +19,7 @@
   background-color: color(var(--color-neutral-darkest) a(12%));
   border-color: color(var(--color-neutral-darkest) a(12%));
 
-  .label-button:not(:disabled) {
+  &:not(.is-disabled) {
     &:focus {
       box-shadow: 0 0 0 var(--tag-border-width) color(var(--color-teal-darkest) a(36%)) !important;
     }
@@ -32,14 +32,8 @@
 
   &.is-disabled {
     opacity: 0.48;
-
-    button {
-      background-color: transparent !important;
-      opacity: 1 !important;
-    }
   }
 
-  .button-label,
   .remove-button {
     transition: background-color 0.2s var(--animation-curve-fast-out-slow-in),
       border-color var(--animation-duration) var(--animation-curve-fast-out-slow-in),
@@ -52,33 +46,13 @@
   padding: 0 var(--spacer-smaller) !important;
 }
 
-.label-button {
-  border: 0 !important;
-}
-
-.is-removable {
-  .label-button {
-    border-radius: var(--tag-border-radius) 0 0 var(--tag-border-radius);
-  }
-}
-
 /* Tag sizes */
 .is-small {
   height: var(--tag-size-small);
 
   .remove-button {
-    margin-left: calc(-1 * var(--spacer-smallest));
-  }
-
-  .label-button {
-    font-size: calc(1.2 * var(--unit));
-    line-height: var(--tag-size-small);
-    padding: 0 var(--spacer-smaller);
-  }
-
-  .label-button,
-  .remove-button {
     height: var(--tag-size-small);
+    margin-left: calc(-1 * var(--spacer-smallest));
   }
 }
 
@@ -86,18 +60,8 @@
   height: var(--tag-size-medium);
 
   .remove-button {
-    margin-left: calc(-1 * var(--spacer-smaller));
-  }
-
-  .label-button {
-    font-size: calc(1.4 * var(--unit));
-    line-height: var(--tag-size-medium);
-    padding: 0 var(--spacer-small);
-  }
-
-  .label-button,
-  .remove-button {
     height: var(--tag-size-medium);
+    margin-left: calc(-1 * var(--spacer-smaller));
   }
 }
 
@@ -105,17 +69,7 @@
   height: var(--tag-size-large);
 
   .remove-button {
-    margin-left: calc(-1 * var(--spacer-smaller));
-  }
-
-  .label-button {
-    font-size: calc(1.4 * var(--unit));
-    line-height: var(--tag-size-large);
-    padding: 0 var(--spacer-small);
-  }
-
-  .label-button,
-  .remove-button {
     height: var(--tag-size-large);
+    margin-left: calc(-1 * var(--spacer-smaller));
   }
 }

--- a/src/components/tag/theme.css
+++ b/src/components/tag/theme.css
@@ -25,7 +25,9 @@
     }
 
     &:focus {
-      box-shadow: 0 0 0 var(--tag-border-width) color(var(--color-teal-darkest) a(36%)) !important;
+      background-color: color(var(--color-neutral-darkest) a(12%));
+      border-color: color(var(--color-neutral-darkest) a(24%));
+      box-shadow: 0 0 0 var(--tag-border-width) color(var(--color-neutral-darkest) a(24%));
     }
 
     &:active {

--- a/src/components/tag/theme.css
+++ b/src/components/tag/theme.css
@@ -6,8 +6,8 @@
   --tag-border-radius: calc(0.4 * var(--unit));
   --tag-border-width: 2px;
   --tag-size-small: 24px;
-  --tag-size-medium: 30px;
-  --tag-size-large: 36px;
+  --tag-size-medium: 24px;
+  --tag-size-large: 30px;
 }
 
 .tag {
@@ -65,7 +65,7 @@
   height: var(--tag-size-small);
 
   .remove-button {
-    height: var(--tag-size-small);
+    height: calc(var(--tag-size-small) - 2px);
   }
 }
 
@@ -73,7 +73,7 @@
   height: var(--tag-size-medium);
 
   .remove-button {
-    height: var(--tag-size-medium);
+    height: calc(var(--tag-size-medium) - 2px);
   }
 }
 
@@ -81,6 +81,6 @@
   height: var(--tag-size-large);
 
   .remove-button {
-    height: var(--tag-size-large);
+    height: calc(var(--tag-size-large) - 2px);
   }
 }

--- a/src/components/tag/theme.css
+++ b/src/components/tag/theme.css
@@ -14,59 +14,23 @@
   border-radius: var(--tag-border-radius);
   display: inline-flex;
   align-items: center;
+  border-style: solid;
+  border-width: 1px;
+  background-color: color(var(--color-neutral-darkest) a(12%));
+  border-color: color(var(--color-neutral-darkest) a(12%));
 
-  &.neutral {
-    border-style: solid;
-    border-width: 1px;
-    background-color: color(var(--color-neutral-darkest) a(12%));
-    border-color: color(var(--color-neutral-darkest) a(12%));
-
-    .label {
-      color: var(--color-teal-darkest);
-    }
-
-    .label-button:not(:disabled) {
-      &:focus {
-        box-shadow: 0 0 0 var(--tag-border-width) color(var(--color-teal-darkest) a(36%)) !important;
-      }
-
-      &:active {
-        background-color: color(var(--color-teal-darkest) a(6%));
-        box-shadow: inset 0 2px 3px 0 color(var(--color-teal-darkest) a(12%)) !important;
-      }
-    }
+  .label {
+    color: var(--color-teal-darkest);
   }
 
-  @each $color in (mint, violet, ruby, gold, aqua) {
-    &.$(color) {
-      background-color: color(var(--color-$(color)-light) a(48%));
-      border: 1px solid color(var(--color-$(color)-light) a(48%));
+  .label-button:not(:disabled) {
+    &:focus {
+      box-shadow: 0 0 0 var(--tag-border-width) color(var(--color-teal-darkest) a(36%)) !important;
+    }
 
-      .label,
-      .label-button,
-      .remove-button {
-        color: var(--color-$(color)-darkest);
-      }
-
-      &:not(.is-disabled) {
-        .label-button,
-        .remove-button {
-          &:hover {
-            background-color: transparent;
-            box-shadow: 0 0 0 var(--tag-border-width) color(var(--color-$(color)-light) a(100%)) !important;
-          }
-
-          &:active {
-            box-shadow: inset 0 1px 3px 0 var(--color-$(color)-light) !important;
-            background-color: color(var(--color-$(color)-light) a(48%));
-          }
-
-          &:focus {
-            background-color: color(var(--color-$(color)-light) a(48%));
-            box-shadow: 0 0 0 var(--tag-border-width) color(var(--color-$(color)-light) a(100%)) !important;
-          }
-        }
-      }
+    &:active {
+      background-color: color(var(--color-teal-darkest) a(6%));
+      box-shadow: inset 0 2px 3px 0 color(var(--color-teal-darkest) a(12%)) !important;
     }
   }
 

--- a/src/components/tag/theme.css
+++ b/src/components/tag/theme.css
@@ -18,8 +18,11 @@
   border-width: 1px;
   background-color: color(var(--color-neutral-darkest) a(12%));
   border-color: color(var(--color-neutral-darkest) a(12%));
+  outline: none;
 
-  &:not(.is-disabled) {
+  &.is-clickable:not(.is-disabled) {
+    cursor: pointer;
+
     &:hover {
       background-color: color(var(--color-neutral-darkest) a(18%));
     }
@@ -38,6 +41,7 @@
 
   &.is-disabled {
     opacity: 0.48;
+    pointer-events: none;
   }
 
   &.is-selected {

--- a/src/components/tag/theme.css
+++ b/src/components/tag/theme.css
@@ -20,6 +20,10 @@
   border-color: color(var(--color-neutral-darkest) a(12%));
 
   &:not(.is-disabled) {
+    &:hover {
+      background-color: color(var(--color-neutral-darkest) a(18%));
+    }
+
     &:focus {
       box-shadow: 0 0 0 var(--tag-border-width) color(var(--color-teal-darkest) a(36%)) !important;
     }

--- a/src/components/tag/theme.css
+++ b/src/components/tag/theme.css
@@ -40,6 +40,10 @@
     opacity: 0.48;
   }
 
+  &.is-selected {
+    background-color: color(var(--color-neutral-darkest) a(24%)) !important;
+  }
+
   .remove-button {
     transition: background-color 0.2s var(--animation-curve-fast-out-slow-in),
       border-color var(--animation-duration) var(--animation-curve-fast-out-slow-in),

--- a/src/components/tag/theme.css
+++ b/src/components/tag/theme.css
@@ -19,10 +19,6 @@
   background-color: color(var(--color-neutral-darkest) a(12%));
   border-color: color(var(--color-neutral-darkest) a(12%));
 
-  .label {
-    color: var(--color-teal-darkest);
-  }
-
   .label-button:not(:disabled) {
     &:focus {
       box-shadow: 0 0 0 var(--tag-border-width) color(var(--color-teal-darkest) a(36%)) !important;
@@ -51,10 +47,6 @@
   }
 }
 
-.label {
-  font-family: var(--font-family-medium);
-}
-
 .remove-button {
   border-radius: 0 var(--tag-border-radius) var(--tag-border-radius) 0;
   padding: 0 var(--spacer-smaller) !important;
@@ -78,7 +70,6 @@
     margin-left: calc(-1 * var(--spacer-smallest));
   }
 
-  .label,
   .label-button {
     font-size: calc(1.2 * var(--unit));
     line-height: var(--tag-size-small);
@@ -98,7 +89,6 @@
     margin-left: calc(-1 * var(--spacer-smaller));
   }
 
-  .label,
   .label-button {
     font-size: calc(1.4 * var(--unit));
     line-height: var(--tag-size-medium);
@@ -118,7 +108,6 @@
     margin-left: calc(-1 * var(--spacer-smaller));
   }
 
-  .label,
   .label-button {
     font-size: calc(1.4 * var(--unit));
     line-height: var(--tag-size-large);

--- a/src/components/tag/theme.css
+++ b/src/components/tag/theme.css
@@ -52,7 +52,6 @@
 
   .remove-button {
     height: var(--tag-size-small);
-    margin-left: calc(-1 * var(--spacer-smallest));
   }
 }
 
@@ -61,7 +60,6 @@
 
   .remove-button {
     height: var(--tag-size-medium);
-    margin-left: calc(-1 * var(--spacer-smaller));
   }
 }
 
@@ -70,6 +68,5 @@
 
   .remove-button {
     height: var(--tag-size-large);
-    margin-left: calc(-1 * var(--spacer-smaller));
   }
 }

--- a/src/components/tag/theme.css
+++ b/src/components/tag/theme.css
@@ -31,8 +31,8 @@
     }
 
     &:active {
-      background-color: color(var(--color-teal-darkest) a(6%));
-      box-shadow: inset 0 2px 3px 0 color(var(--color-teal-darkest) a(12%)) !important;
+      box-shadow: inset 0 2px 3px color(var(--color-neutral-darkest) a(12%));
+      background-color: color(var(--color-neutral-darkest) a(18%));
     }
   }
 


### PR DESCRIPTION
### Description

Besides **adjusting** the `visual states` of our `Tag` component,  this PR is also **adding** a `selected` prop, which renders the `Tag in a selected state` when `true`.

#### Screenshot after this PR
![Screenshot 2020-04-16 11 43 23](https://user-images.githubusercontent.com/5336831/79462346-a596e200-7ff7-11ea-812e-11c8e01c4853.png)

### Breaking changes
We also **removed** the following `Tag` props, which result in breaking changes:

- 🔥 `inverse`: used to render the Tag in inverse mode when used on teal darkest backgrounds
- 🔥 `color`: used to render our Tag in different color variations
- 🔥 `onLabelClick`:  please use `onClick` from now on
