### PR TITLE
WysiwygEditor: List styling

### DIFF
--- a/src/components/wysiwygEditor/WysiwygEditor.js
+++ b/src/components/wysiwygEditor/WysiwygEditor.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Editor } from 'react-draft-wysiwyg';
 import cx from 'classnames';
-import { IconTextBoldMediumOutline, IconTextItalicMediumOutline } from '@teamleader/ui-icons';
+import { IconTextBoldMediumOutline, IconTextItalicMediumOutline, IconListNumeredMediumOutline, IconListMediumOutline } from '@teamleader/ui-icons';
 
 import Box from '../box';
 import IconButton from '../iconButton';
@@ -25,7 +25,7 @@ const InlineStyling = ({
   };
 
   return (
-    <Box display="flex" borderRightWidth={1}>
+    <Box display="flex" borderRightWidth={1} marginRight={2}>
       {options.map((optionType) => (
         <IconButton
           icon={iconsByOptionType[optionType]}
@@ -41,13 +41,50 @@ const InlineStyling = ({
   );
 };
 
+const ListStyling = ({
+    config: {
+      options,
+      unordered: { icon: unorderedIcon },
+      ordered: { icon: orderedIcon },
+    },
+    currentState,
+    onChange,
+  }) => {
+    const iconsByOptionType = {
+      unordered: unorderedIcon,
+      ordered: orderedIcon,
+    };
+  
+    return (
+      <Box display="flex" borderRightWidth={1} marginRight={2}>
+        {options.map((optionType) => (
+          <IconButton
+            icon={iconsByOptionType[optionType]}
+            color="black"
+            key={optionType}
+            title={optionType}
+            onClick={() => onChange(optionType)}
+            selected={currentState.listType === optionType}
+            marginRight={2}
+          />
+        ))}
+      </Box>
+    );
+  };
+
 const toolbar = {
-  options: ['inline'],
+  options: ['inline', 'list'],
   inline: {
     options: ['bold', 'italic'],
     bold: { icon: <IconTextBoldMediumOutline /> },
     italic: { icon: <IconTextItalicMediumOutline /> },
     component: InlineStyling,
+  },
+  list: {
+    component: ListStyling,
+    options: ['unordered', 'ordered'],
+    unordered: { icon: <IconListMediumOutline /> },
+    ordered: { icon: <IconListNumeredMediumOutline /> },
   },
 };
 

--- a/src/components/wysiwygEditor/WysiwygEditor.js
+++ b/src/components/wysiwygEditor/WysiwygEditor.js
@@ -2,7 +2,12 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Editor } from 'react-draft-wysiwyg';
 import cx from 'classnames';
-import { IconTextBoldMediumOutline, IconTextItalicMediumOutline, IconListNumeredMediumOutline, IconListMediumOutline } from '@teamleader/ui-icons';
+import {
+  IconTextBoldMediumOutline,
+  IconTextItalicMediumOutline,
+  IconListNumeredMediumOutline,
+  IconListMediumOutline,
+} from '@teamleader/ui-icons';
 
 import Box from '../box';
 import IconButton from '../iconButton';
@@ -42,35 +47,35 @@ const InlineStyling = ({
 };
 
 const ListStyling = ({
-    config: {
-      options,
-      unordered: { icon: unorderedIcon },
-      ordered: { icon: orderedIcon },
-    },
-    currentState,
-    onChange,
-  }) => {
-    const iconsByOptionType = {
-      unordered: unorderedIcon,
-      ordered: orderedIcon,
-    };
-  
-    return (
-      <Box display="flex" borderRightWidth={1} marginRight={2}>
-        {options.map((optionType) => (
-          <IconButton
-            icon={iconsByOptionType[optionType]}
-            color="black"
-            key={optionType}
-            title={optionType}
-            onClick={() => onChange(optionType)}
-            selected={currentState.listType === optionType}
-            marginRight={2}
-          />
-        ))}
-      </Box>
-    );
+  config: {
+    options,
+    unordered: { icon: unorderedIcon },
+    ordered: { icon: orderedIcon },
+  },
+  currentState,
+  onChange,
+}) => {
+  const iconsByOptionType = {
+    unordered: unorderedIcon,
+    ordered: orderedIcon,
   };
+
+  return (
+    <Box display="flex" borderRightWidth={1} marginRight={2}>
+      {options.map((optionType) => (
+        <IconButton
+          icon={iconsByOptionType[optionType]}
+          color="black"
+          key={optionType}
+          title={optionType}
+          onClick={() => onChange(optionType)}
+          selected={currentState.listType === optionType}
+          marginRight={2}
+        />
+      ))}
+    </Box>
+  );
+};
 
 const toolbar = {
   options: ['inline', 'list'],
@@ -96,6 +101,7 @@ const customStyleMap = {
 
 const WysiwygEditor = ({ className, error, onFocus, onBlur, success, warning, helpText, width, ...others }) => {
   const [isFocused, setIsFocused] = useState(false);
+  const [isPlaceholderShown, setIsPlaceholderShown] = useState(true);
 
   const handleBlur = (event) => {
     setIsFocused(false);
@@ -111,6 +117,14 @@ const WysiwygEditor = ({ className, error, onFocus, onBlur, success, warning, he
     }
   };
 
+  const handleContentStateChange = ({ blocks: [{ type }] }) => {
+    if (type === 'unstyled') {
+      setIsPlaceholderShown(true);
+      return;
+    }
+    setIsPlaceholderShown(false);
+  };
+
   const wrapperClassNames = cx(
     theme['wrapper'],
     {
@@ -118,6 +132,7 @@ const WysiwygEditor = ({ className, error, onFocus, onBlur, success, warning, he
       [theme['has-error']]: error,
       [theme['has-success']]: success,
       [theme['has-warning']]: warning,
+      [theme['has-placeholder']]: isPlaceholderShown,
     },
     className,
   );
@@ -131,6 +146,7 @@ const WysiwygEditor = ({ className, error, onFocus, onBlur, success, warning, he
         toolbarClassName={theme['toolbar']}
         onFocus={handleFocus}
         onBlur={handleBlur}
+        onContentStateChange={handleContentStateChange}
         customStyleMap={customStyleMap}
         {...others}
       />

--- a/src/components/wysiwygEditor/theme.css
+++ b/src/components/wysiwygEditor/theme.css
@@ -30,17 +30,21 @@
   &:hover {
     cursor: text;
   }
-
-  & div[id*='placeholder'] {
-    position: absolute;
-    color: var(--color-neutral-darkest);
-    pointer-events: none;
-  }
 }
 
 .wrapper {
   width: 100%;
   border-radius: var(--input-border-radius);
+
+  &:not(.has-placeholder) :global(.public-DraftEditorPlaceholder-root) {
+    display: none;
+  }
+
+  :global(.public-DraftEditorPlaceholder-root) {
+    position: absolute;
+    color: var(--color-neutral-darkest);
+    pointer-events: none;
+  }
 }
 
 .toolbar {

--- a/src/components/wysiwygEditor/theme.css
+++ b/src/components/wysiwygEditor/theme.css
@@ -35,6 +35,10 @@
 .wrapper {
   width: 100%;
   border-radius: var(--input-border-radius);
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-smoothing: antialiased;
+  text-size-adjust: 100%;
 
   &:not(.has-placeholder) :global(.public-DraftEditorPlaceholder-root) {
     display: none;

--- a/src/components/wysiwygEditor/theme.css
+++ b/src/components/wysiwygEditor/theme.css
@@ -45,6 +45,10 @@
     color: var(--color-neutral-darkest);
     pointer-events: none;
   }
+
+  :global(.public-DraftEditorPlaceholder-hasFocus) {
+    color: var(--color-neutral-dark);
+  }
 }
 
 .toolbar {

--- a/src/components/wysiwygEditor/theme.css
+++ b/src/components/wysiwygEditor/theme.css
@@ -11,7 +11,7 @@
   --input-error-border: var(--color-ruby-dark);
   --input-success-border: var(--color-mint-dark);
   --input-warning-border: var(--color-gold-dark);
-  --input-min-height: calc(15.4 * var(--unit));
+  --input-min-height: calc(9.3 * var(--unit));
   --input-spacing: calc(0.5 * var(--unit));
 }
 


### PR DESCRIPTION
### Description

- Added `ListStyling` component for Wysiwyg toolbar; you can now add ordered and unordered lists with the component.
- Added font-smoothing to the text of the editor
- Set min-height to design expectations
- Make placeholder a tint lighter on focus for better contrast

#### Screenshot before this PR

![](https://user-images.githubusercontent.com/19315705/79433937-06a9c000-7fce-11ea-96d9-6cbecca3fae4.png)


#### Screenshot after this PR

![Screenshot 2020-04-16 at 17 05 29](https://user-images.githubusercontent.com/19315705/79472742-818dcd80-8004-11ea-935d-066c7f41fcc7.png)


### Breaking changes

None
