### PR TITLE
Link (badged): visual state updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `Badge`: added `selected` boolean prop which shows the badge in a selected state. ([@driesd](https://github.com/driesd) in [#1014](https://github.com/teamleadercrm/ui/pull/1014))
 - `IconButton`: added `large` size variation. ([@driesd](https://github.com/driesd) in [#1009](https://github.com/teamleadercrm/ui/pull/1009))
 - `IconButton`: added `selected` boolean prop which shows the button in a selected state. ([@driesd](https://github.com/driesd) in [#1009](https://github.com/teamleadercrm/ui/pull/1009))
+- `Link`: added `selected` boolean prop which shows the link in a selected state. ([@driesd](https://github.com/driesd) in [#1027](https://github.com/teamleadercrm/ui/pull/1027))
 - `Tag`: added `selected` boolean prop which shows the tag in a selected state. ([@driesd](https://github.com/driesd) in [#1020](https://github.com/teamleadercrm/ui/pull/1020))
 
 ### Changed
@@ -13,6 +14,7 @@
 - `Badge`: adjusted visual states. ([@driesd](https://github.com/driesd) in [#1014](https://github.com/teamleadercrm/ui/pull/1014))
 - `IconButton`: adjusted visual states. ([@driesd](https://github.com/driesd) in [#1009](https://github.com/teamleadercrm/ui/pull/1009))
 - [Breaking] `IconButton`: changed attribute `data-teamleader-ui` value from `button` to `icon-button`. ([@driesd](https://github.com/driesd) in [#1009](https://github.com/teamleadercrm/ui/pull/1009))
+- `Link`: adjusted visual states. ([@driesd](https://github.com/driesd) in [#1027](https://github.com/teamleadercrm/ui/pull/1027))
 - `Tag`: adjusted visual states. ([@driesd](https://github.com/driesd) in [#1020](https://github.com/teamleadercrm/ui/pull/1020))
 
 ### Deprecated

--- a/src/components/link/Link.js
+++ b/src/components/link/Link.js
@@ -39,6 +39,7 @@ class Link extends PureComponent {
       element,
       inherit,
       inverse,
+      selected,
       ...others
     } = this.props;
 
@@ -50,6 +51,7 @@ class Link extends PureComponent {
         [theme['is-disabled']]: disabled,
         [theme['is-inherit']]: inherit,
         [theme['is-inverse']]: inverse,
+        [theme['is-selected']]: selected,
         [theme['has-icon']]: icon,
       },
       className,
@@ -98,6 +100,8 @@ Link.propTypes = {
   onMouseLeave: PropTypes.func,
   /** Callback function that is fired when the mouse button is released. */
   onMouseUp: PropTypes.func,
+  /** If true, component will be shown in a selected state */
+  selected: PropTypes.bool,
 };
 
 Link.defaultProps = {

--- a/src/components/link/link.stories.js
+++ b/src/components/link/link.stories.js
@@ -120,6 +120,7 @@ export const badgedLink = () => (
         element={select('Element', elements, 'button')}
         inherit={boolean('Inherit', false)}
         inverse={boolean('Inverse', false)}
+        selected={boolean('Selected', false)}
         marginLeft={-2}
       >
         Badged link
@@ -132,6 +133,7 @@ export const badgedLink = () => (
         element={select('Element', elements, 'button')}
         inherit={boolean('Inherit', false)}
         inverse={boolean('Inverse', false)}
+        selected={boolean('Selected', false)}
         marginLeft={-2}
       >
         Badged link
@@ -144,6 +146,7 @@ export const badgedLink = () => (
         element={select('Element', elements, 'button')}
         inherit={boolean('Inherit', false)}
         inverse={boolean('Inverse', false)}
+        selected={boolean('Selected', false)}
         marginLeft={-2}
       >
         Badged link
@@ -157,6 +160,7 @@ export const badgedLink = () => (
         element={select('Element', elements, 'button')}
         inherit={boolean('Inherit', false)}
         inverse={boolean('Inverse', false)}
+        selected={boolean('Selected', false)}
       >
         badged link
       </Link>
@@ -170,6 +174,7 @@ export const badgedLink = () => (
         element={select('Element', elements, 'button')}
         inherit={boolean('Inherit', false)}
         inverse={boolean('Inverse', false)}
+        selected={boolean('Selected', false)}
       >
         badged link
       </Link>
@@ -183,6 +188,7 @@ export const badgedLink = () => (
         element={select('Element', elements, 'button')}
         inherit={boolean('Inherit', false)}
         inverse={boolean('Inverse', false)}
+        selected={boolean('Selected', false)}
       >
         badged link
       </Link>

--- a/src/components/link/theme.css
+++ b/src/components/link/theme.css
@@ -108,6 +108,7 @@
   }
 
   &:active {
-    box-shadow: inset 0 1px 3px 0 color(var(--color-teal-darkest) a(12%));
+    box-shadow: inset 0 2px 3px color(var(--color-neutral-darkest) a(12%));
+    background-color: color(var(--color-neutral-darkest) a(18%));
   }
 }

--- a/src/components/link/theme.css
+++ b/src/components/link/theme.css
@@ -20,7 +20,7 @@
   }
 
   &.is-disabled {
-    opacity: 0.36;
+    opacity: 0.48;
     pointer-events: none;
   }
 

--- a/src/components/link/theme.css
+++ b/src/components/link/theme.css
@@ -111,4 +111,8 @@
     box-shadow: inset 0 2px 3px color(var(--color-neutral-darkest) a(12%));
     background-color: color(var(--color-neutral-darkest) a(18%));
   }
+
+  &.is-selected {
+    background-color: color(var(--color-neutral-darkest) a(24%)) !important;
+  }
 }

--- a/src/components/link/theme.css
+++ b/src/components/link/theme.css
@@ -95,8 +95,11 @@
 
   &:hover,
   &:focus {
-    background: color(var(--color-neutral-darkest) a(12%));
     text-decoration: none !important;
+  }
+
+  &:hover {
+    background: color(var(--color-neutral-darkest) a(18%));
   }
 
   &:focus {

--- a/src/components/link/theme.css
+++ b/src/components/link/theme.css
@@ -103,7 +103,6 @@
   }
 
   &:focus {
-    background-color: color(var(--color-teal-darkest) a(6%));
     box-shadow: 0 0 0 2px color(var(--color-neutral-darkest) a(24%));
     outline: 0;
   }


### PR DESCRIPTION
### Description

Besides **adjusting** the `visual states` of our `badged Link` component,  this PR is also **adding** a `selected` prop, which renders the `Link in a selected state` when `true`.

#### Screenshot after this PR
![Screenshot 2020-04-20 10 03 27](https://user-images.githubusercontent.com/5336831/79728562-68c83500-82ee-11ea-8d85-ce0ad8e1f19e.png)

### Breaking changes

None.
