### PR TITLE
WysiwygEditor: Toolbar tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Added
 
 - `WysiywygEditor`: added functionality to add a link with the editor. ([@mikeverf](https://github.com/mikeverf) in [#1029])
+- `WysiywygEditor`: added tooltips to the toolbar options. ([@mikeverf](https://github.com/mikeverf) in [#1030])
+- `Tooltip`: added `showTooltipDelay` prop that defaults to `100` (current default). ([@mikeverf](https://github.com/mikeverf) in [#1030])
 
 ### Changed
 

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -144,7 +144,16 @@ const Tooltip = (ComposedComponent) => {
 
     render() {
       const { active, left, top, position } = this.state;
-      const { children, className, tooltip, tooltipColor, tooltipIcon, tooltipSize, ...other } = this.props;
+      const {
+        children,
+        className,
+        tooltip,
+        tooltipColor,
+        tooltipIcon,
+        tooltipSize,
+        tooltipShowDelay,
+        ...other
+      } = this.props;
 
       const rest = omit(other, [
         'onClick',
@@ -154,6 +163,7 @@ const Tooltip = (ComposedComponent) => {
         'tooltipHideOnClick',
         'tooltipPosition',
         'tooltipShowOnClick',
+        'tooltipShowDelay',
         'documentObject',
       ]);
 
@@ -174,7 +184,7 @@ const Tooltip = (ComposedComponent) => {
             in={active}
             onExited={this.handleTransitionExited}
             onEntered={this.handleTransitionEntered}
-            timeout={{ enter: 100, exit: 1000 }}
+            timeout={{ enter: tooltipShowDelay, exit: 1000 }}
           >
             {(state) => {
               const classNames = cx(
@@ -221,6 +231,7 @@ const Tooltip = (ComposedComponent) => {
     tooltipShowOnClick: PropTypes.bool,
     tooltipSize: PropTypes.oneOf(Object.keys(SIZES)),
     documentObject: PropTypes.object.isRequired,
+    tooltipShowDelay: PropTypes.number,
   };
 
   TooltippedComponent.defaultProps = {
@@ -231,6 +242,7 @@ const Tooltip = (ComposedComponent) => {
     tooltipPosition: POSITIONS.TOP,
     tooltipShowOnClick: false,
     tooltipSize: 'medium',
+    tooltipShowDelay: 100,
   };
 
   return DocumentObjectProvider((props) => {

--- a/src/components/wysiwygEditor/InlineStylingOptions.js
+++ b/src/components/wysiwygEditor/InlineStylingOptions.js
@@ -25,9 +25,7 @@ const TooltipMessage = ({ optionType }) => {
 
   return (
     <>
-      <TextSmall>
-        <strong>{shortcutsByOptionType[optionType].name}</strong>
-      </TextSmall>
+      <TextSmall>{shortcutsByOptionType[optionType].name}</TextSmall>
       <TextSmall color="neutral">{shortcutsByOptionType[optionType].shortcut}</TextSmall>
     </>
   );

--- a/src/components/wysiwygEditor/InlineStylingOptions.js
+++ b/src/components/wysiwygEditor/InlineStylingOptions.js
@@ -2,6 +2,36 @@ import React from 'react';
 
 import Box from '../box';
 import IconButton from '../iconButton';
+import Tooltip from '../tooltip';
+import { TextSmall } from '../typography';
+import getOS, { OS_TYPES } from '../../utils/getOS';
+
+const TooltippedIconButton = Tooltip(IconButton);
+
+const OPERATING_SYSTEM = getOS();
+
+const TooltipMessage = ({ optionType }) => {
+  const isMacOS = OPERATING_SYSTEM === OS_TYPES.MAC_OS;
+  const shortcutsByOptionType = {
+    bold: {
+      name: 'Bold',
+      shortcut: isMacOS ? '⌘ Cmd + B' : 'Ctrl + B',
+    },
+    italic: {
+      name: 'Italic',
+      shortcut: isMacOS ? '⌘ Cmd + I' : 'Ctrl + I',
+    },
+  };
+
+  return (
+    <>
+      <TextSmall>
+        <strong>{shortcutsByOptionType[optionType].name}</strong>
+      </TextSmall>
+      <TextSmall color="neutral">{shortcutsByOptionType[optionType].shortcut}</TextSmall>
+    </>
+  );
+};
 
 const InlineStylingOptions = ({
   config: {
@@ -20,7 +50,9 @@ const InlineStylingOptions = ({
   return (
     <Box display="flex" borderRightWidth={1} marginRight={2}>
       {options.map((optionType) => (
-        <IconButton
+        <TooltippedIconButton
+          tooltip={<TooltipMessage optionType={optionType} />}
+          tooltipSize="small"
           icon={iconsByOptionType[optionType]}
           color="black"
           key={optionType}

--- a/src/components/wysiwygEditor/InlineStylingOptions.js
+++ b/src/components/wysiwygEditor/InlineStylingOptions.js
@@ -53,6 +53,7 @@ const InlineStylingOptions = ({
         <TooltippedIconButton
           tooltip={<TooltipMessage optionType={optionType} />}
           tooltipSize="small"
+          tooltipShowDelay={1000}
           icon={iconsByOptionType[optionType]}
           color="black"
           key={optionType}

--- a/src/components/wysiwygEditor/InlineStylingOptions.js
+++ b/src/components/wysiwygEditor/InlineStylingOptions.js
@@ -57,7 +57,6 @@ const InlineStylingOptions = ({
           icon={iconsByOptionType[optionType]}
           color="black"
           key={optionType}
-          title={optionType}
           onClick={() => onChange(optionType)}
           selected={currentState[optionType]}
           marginRight={2}

--- a/src/components/wysiwygEditor/LinkOptions.js
+++ b/src/components/wysiwygEditor/LinkOptions.js
@@ -6,6 +6,10 @@ import Popover from '../popover';
 import Label from '../label';
 import Input from '../input';
 import Button from '../button';
+import Tooltip from '../tooltip';
+import { TextSmall } from '../typography';
+
+const TooltippedIconButton = Tooltip(IconButton);
 
 const LinkOptions = ({
   config: {
@@ -50,18 +54,21 @@ const LinkOptions = ({
 
   return (
     <>
-      <IconButton
-        icon={linkIcon}
-        color="black"
-        key="link"
-        title="link"
-        onClick={handleOpenPopoverClick}
-        selected={!!link || isPopoverShown}
-        marginRight={2}
-        ref={iconButtonRef}
-      />
+      <Box ref={iconButtonRef}>
+        <TooltippedIconButton
+          tooltip={<TextSmall>Link</TextSmall>}
+          tooltipSize="small"
+          tooltipShowDelay={1000}
+          icon={linkIcon}
+          color="black"
+          key="link"
+          onClick={handleOpenPopoverClick}
+          selected={!!link || isPopoverShown}
+          marginRight={2}
+        />
+      </Box>
       <Popover
-        anchorEl={iconButtonRef?.current?.buttonNode?.boxNode?.current}
+        anchorEl={iconButtonRef?.current?.boxNode?.current}
         active={isPopoverShown}
         backdrop="transparent"
         onEscKeyDown={handleClosePopoverClick}

--- a/src/components/wysiwygEditor/ListStylingOptions.js
+++ b/src/components/wysiwygEditor/ListStylingOptions.js
@@ -2,6 +2,10 @@ import React from 'react';
 
 import Box from '../box';
 import IconButton from '../iconButton';
+import Tooltip from '../tooltip';
+import { TextSmall } from '../typography';
+
+const TooltippedIconButton = Tooltip(IconButton);
 
 const ListStylingOptions = ({
   config: {
@@ -17,14 +21,21 @@ const ListStylingOptions = ({
     ordered: orderedIcon,
   };
 
+  const titlesByOptionType = {
+    unordered: 'Bulleted list',
+    ordered: 'Numbered list',
+  };
+
   return (
     <Box display="flex" borderRightWidth={1} marginRight={2}>
       {options.map((optionType) => (
-        <IconButton
+        <TooltippedIconButton
+          tooltip={<TextSmall>{titlesByOptionType[optionType]}</TextSmall>}
+          tooltipSize="small"
+          tooltipShowDelay={1000}
           icon={iconsByOptionType[optionType]}
           color="black"
           key={optionType}
-          title={optionType}
           onClick={() => onChange(optionType)}
           selected={currentState.listType === optionType}
           marginRight={2}

--- a/src/utils/getOS.js
+++ b/src/utils/getOS.js
@@ -1,0 +1,32 @@
+export const OS_TYPES = {
+  MAC_OS: 'Mac OS',
+  IOS: 'iOS',
+  WINDOWS: 'Windows',
+  ANDROID: 'Android',
+  LINUX: 'Linux',
+};
+
+const getOS = () => {
+  const userAgent = window.navigator.userAgent;
+  const platform = window.navigator.platform;
+  const macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
+  const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
+  const iosPlatforms = ['iPhone', 'iPad', 'iPod'];
+
+  let os = null;
+  if (macosPlatforms.indexOf(platform) !== -1) {
+    os = OS_TYPES.MAC_OS;
+  } else if (iosPlatforms.indexOf(platform) !== -1) {
+    os = OS_TYPES.IOS;
+  } else if (windowsPlatforms.indexOf(platform) !== -1) {
+    os = OS_TYPES.WINDOWS;
+  } else if (/Android/.test(userAgent)) {
+    os = OS_TYPES.ANDROID;
+  } else if (!os && /Linux/.test(platform)) {
+    os = OS_TYPES.LINUX;
+  }
+
+  return os;
+};
+
+export default getOS;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,3 @@
+import getOS from './getOS';
+
+export { getOS };


### PR DESCRIPTION
**‼️ Don't merge before #1029**

### Description

- Added Tooltips to the toolbar options on `WysiwygEditor`.
For inline styling, it also shows the available shortcuts based on the platform (MacOS or other). They only show after hovering for 1 second.
- Added a `showTooltipDelay` prop to `Tooltip` that defaults to `100` (current default)

#### Screenshot after this PR

![Screenshot 2020-04-20 at 16 01 12](https://user-images.githubusercontent.com/19315705/79762625-47357080-8323-11ea-834c-1c1e22670232.png)

### Breaking changes

- None
