### PR TITLE
DatePicker: fix broken import

### DIFF
--- a/src/components/datepicker/DatePickerInputRange.js
+++ b/src/components/datepicker/DatePickerInputRange.js
@@ -6,7 +6,7 @@ import Icon from '../icon';
 import NavigationBar from './NavigationBar';
 import WeekDay from './WeekDay';
 import { convertModifiersToClassnames, isSelectingFirstDay } from './utils';
-import { DateUtils } from 'react-day-picker/lib/src/index';
+import { DateUtils } from 'react-day-picker';
 import { IconCalendarSmallOutline } from '@teamleader/ui-icons';
 import ValidationText from '../validationText';
 import cx from 'classnames';

--- a/src/components/datepicker/utils.js
+++ b/src/components/datepicker/utils.js
@@ -1,4 +1,4 @@
-import { DateUtils } from 'react-day-picker/lib/src/index';
+import { DateUtils } from 'react-day-picker';
 
 export const convertModifiersToClassnames = (modifiers, theme) => {
   if (!modifiers) {


### PR DESCRIPTION
### Description

This PR fixes a broken import: `Can't resolve 'react-day-picker/lib/src/index' in '/Users/dries/Projects/teamleadercrm/ui/src/components/datepicker'`

### Breaking changes

None.
