### PR TITLE
WysiwygEditor: Add `locale` prop and translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `WysiywygEditor`: added functionality to add a link with the editor. ([@mikeverf](https://github.com/mikeverf) in [#1029])
 - `WysiywygEditor`: added tooltips to the toolbar options. ([@mikeverf](https://github.com/mikeverf) in [#1030])
 - `Tooltip`: added `showTooltipDelay` prop that defaults to `100` (current default). ([@mikeverf](https://github.com/mikeverf) in [#1030])
+- `WysiywygEditor`: added `locale` prop and translations for the component. ([@mikeverf](https://github.com/mikeverf) in [#1037])
 
 ### Changed
 

--- a/src/components/wysiwygEditor/InlineStylingOptions.js
+++ b/src/components/wysiwygEditor/InlineStylingOptions.js
@@ -10,22 +10,20 @@ const TooltippedIconButton = Tooltip(IconButton);
 
 const OPERATING_SYSTEM = getOS();
 
-const TooltipMessage = ({ optionType }) => {
+const TooltipMessage = ({ optionType, name }) => {
   const isMacOS = OPERATING_SYSTEM === OS_TYPES.MAC_OS;
   const shortcutsByOptionType = {
     bold: {
-      name: 'Bold',
       shortcut: isMacOS ? '⌘ Cmd + B' : 'Ctrl + B',
     },
     italic: {
-      name: 'Italic',
       shortcut: isMacOS ? '⌘ Cmd + I' : 'Ctrl + I',
     },
   };
 
   return (
     <>
-      <TextSmall>{shortcutsByOptionType[optionType].name}</TextSmall>
+      <TextSmall>{name}</TextSmall>
       <TextSmall color="neutral">{shortcutsByOptionType[optionType].shortcut}</TextSmall>
     </>
   );
@@ -39,6 +37,7 @@ const InlineStylingOptions = ({
   },
   currentState,
   onChange,
+  translations,
 }) => {
   const iconsByOptionType = {
     bold: boldIcon,
@@ -49,7 +48,9 @@ const InlineStylingOptions = ({
     <Box display="flex" borderRightWidth={1} marginRight={2}>
       {options.map((optionType) => (
         <TooltippedIconButton
-          tooltip={<TooltipMessage optionType={optionType} />}
+          tooltip={
+            <TooltipMessage optionType={optionType} name={translations[`components.controls.inline.${optionType}`]} />
+          }
           tooltipSize="small"
           tooltipShowDelay={1000}
           icon={iconsByOptionType[optionType]}

--- a/src/components/wysiwygEditor/LinkOptions.js
+++ b/src/components/wysiwygEditor/LinkOptions.js
@@ -74,6 +74,7 @@ const LinkOptions = ({
         onEscKeyDown={handleClosePopoverClick}
         onOverlayClick={handleClosePopoverClick}
         minWidth={276}
+        maxWidth="100%"
         position="end"
       >
         <Box display="flex" flexDirection="column" padding={4}>

--- a/src/components/wysiwygEditor/LinkOptions.js
+++ b/src/components/wysiwygEditor/LinkOptions.js
@@ -17,9 +17,9 @@ const LinkOptions = ({
     link: { icon: linkIcon },
     defaultTargetOption,
   },
-  currentState,
   currentState: { link, selectionText },
   onChange,
+  translations,
 }) => {
   const [isPopoverShown, setIsPopoverShown] = useState(false);
   const iconButtonRef = useRef();
@@ -56,7 +56,7 @@ const LinkOptions = ({
     <>
       <Box ref={iconButtonRef}>
         <TooltippedIconButton
-          tooltip={<TextSmall>Link</TextSmall>}
+          tooltip={<TextSmall>{translations['components.controls.link.link']}</TextSmall>}
           tooltipSize="small"
           tooltipShowDelay={1000}
           icon={linkIcon}
@@ -78,18 +78,29 @@ const LinkOptions = ({
       >
         <Box display="flex" flexDirection="column" padding={4}>
           <Label htmlFor="linkText" helpText="">
-            Text
+            {translations['components.controls.link.popover.text']}
             <Input id="linkText" autoFocus value={textValue || ''} onChange={onTextChange} />
           </Label>
           <Label htmlFor="link" helpText="" marginBottom={4}>
-            Link
-            <Input id="link" value={linkValue || ''} onChange={onLinkChange} placeholder="e.g. www.teamleader.eu" />
+            {translations['components.controls.link.popover.link']}
+            <Input
+              id="link"
+              value={linkValue || ''}
+              onChange={onLinkChange}
+              placeholder={translations['components.controls.link.popover.placeholder']}
+            />
           </Label>
           <Box display="flex" justifyContent="flex-end" alignItems="center" marginTop={4}>
-            <Button level="secondary" label="Cancel" size="small" marginRight={3} onClick={handleClosePopoverClick} />
+            <Button
+              level="secondary"
+              label={translations['components.controls.link.popover.cancel']}
+              size="small"
+              marginRight={3}
+              onClick={handleClosePopoverClick}
+            />
             <Button
               level="primary"
-              label="Add link"
+              label={translations['components.controls.link.popover.addLink']}
               size="small"
               disabled={!linkValue || !textValue}
               onClick={handleAddLinkClick}

--- a/src/components/wysiwygEditor/ListStylingOptions.js
+++ b/src/components/wysiwygEditor/ListStylingOptions.js
@@ -15,22 +15,18 @@ const ListStylingOptions = ({
   },
   currentState,
   onChange,
+  translations,
 }) => {
   const iconsByOptionType = {
     unordered: unorderedIcon,
     ordered: orderedIcon,
   };
 
-  const titlesByOptionType = {
-    unordered: 'Bulleted list',
-    ordered: 'Numbered list',
-  };
-
   return (
     <Box display="flex" borderRightWidth={1} marginRight={2}>
       {options.map((optionType) => (
         <TooltippedIconButton
-          tooltip={<TextSmall>{titlesByOptionType[optionType]}</TextSmall>}
+          tooltip={<TextSmall>{translations[`components.controls.list.${optionType}`]}</TextSmall>}
           tooltipSize="small"
           tooltipShowDelay={1000}
           icon={iconsByOptionType[optionType]}

--- a/src/components/wysiwygEditor/WysiwygEditor.js
+++ b/src/components/wysiwygEditor/WysiwygEditor.js
@@ -18,6 +18,7 @@ import ListStylingOptions from './ListStylingOptions';
 import LinkOptions from './LinkOptions';
 import { linkDecorator } from './decorators';
 import theme from './theme.css';
+import translations from './translations';
 
 const toolbar = {
   options: ['inline', 'list', 'link'],
@@ -48,7 +49,18 @@ const customStyleMap = {
   },
 };
 
-const WysiwygEditor = ({ className, error, onFocus, onBlur, success, warning, helpText, width, ...others }) => {
+const WysiwygEditor = ({
+  className,
+  error,
+  onFocus,
+  onBlur,
+  success,
+  warning,
+  helpText,
+  width,
+  locale = 'en',
+  ...others
+}) => {
   const [isFocused, setIsFocused] = useState(false);
   const [isPlaceholderShown, setIsPlaceholderShown] = useState(true);
 
@@ -98,6 +110,10 @@ const WysiwygEditor = ({ className, error, onFocus, onBlur, success, warning, he
         onContentStateChange={handleContentStateChange}
         customStyleMap={customStyleMap}
         customDecorators={[linkDecorator]}
+        localization={{
+          locale,
+          translations: translations[locale],
+        }}
         {...others}
       />
       <ValidationText error={error} help={helpText} success={success} warning={warning} />
@@ -116,6 +132,8 @@ WysiwygEditor.propTypes = {
   warning: PropTypes.oneOfType([PropTypes.bool, PropTypes.node]),
   /** A custom width for the editor field */
   width: PropTypes.string,
+  /** Locale key for the language you want the editor to be displayed in. */
+  locale: PropTypes.string,
 };
 
 export default WysiwygEditor;

--- a/src/components/wysiwygEditor/translations.js
+++ b/src/components/wysiwygEditor/translations.js
@@ -1,0 +1,74 @@
+export default {
+  en: {
+    // List
+    'components.controls.list.unordered': 'Bulleted list',
+    'components.controls.list.ordered': 'Numbered list',
+
+    // Link
+    'components.controls.link.popover.text': 'Text',
+    'components.controls.link.popover.link': 'Link',
+    'components.controls.link.popover.placeholder': 'e.g. www.teamleader.eu',
+    'components.controls.link.popover.cancel': 'Cancel',
+    'components.controls.link.popover.addLink': 'Add link',
+  },
+  nl: {
+    // List
+    'components.controls.list.unordered': 'Ongeordende lijst',
+    'components.controls.list.ordered': 'Genummerde lijst',
+
+    // Link
+    'components.controls.link.popover.text': 'Tekst',
+    'components.controls.link.popover.link': 'Link',
+    'components.controls.link.popover.placeholder': 'bv. www.teamleader.eu',
+    'components.controls.link.popover.cancel': 'Annuleren',
+    'components.controls.link.popover.addLink': 'Link toevoegen',
+  },
+  es: {
+    // List
+    'components.controls.list.unordered': 'Lista desorganizada',
+    'components.controls.list.ordered': 'Lista organizada',
+
+    // Link
+    'components.controls.link.popover.text': 'Texto',
+    'components.controls.link.popover.link': 'Enlace',
+    'components.controls.link.popover.placeholder': 'p.ej. www.teamleader.eu',
+    'components.controls.link.popover.cancel': 'Cancela',
+    'components.controls.link.popover.addLink': 'Añadir enlace',
+  },
+  it: {
+    // List
+    'components.controls.list.unordered': 'Elenco puntato',
+    'components.controls.list.ordered': 'Elenco numerato',
+
+    // Link
+    'components.controls.link.popover.text': 'Testo',
+    'components.controls.link.popover.link': 'Link',
+    'components.controls.link.popover.placeholder': 'e.g. www.teamleadercrm.it',
+    'components.controls.link.popover.cancel': 'Annulla',
+    'components.controls.link.popover.addLink': 'Aggiungi link',
+  },
+  de: {
+    // List
+    'components.controls.list.unordered': 'Aufzählungsliste',
+    'components.controls.list.ordered': 'Nummerierte Liste',
+
+    // Link
+    'components.controls.link.popover.text': 'Text',
+    'components.controls.link.popover.link': 'Link',
+    'components.controls.link.popover.placeholder': 'z.B. www.teamleadercrm.de',
+    'components.controls.link.popover.cancel': 'Abbrechen',
+    'components.controls.link.popover.addLink': 'Link hinzufügen',
+  },
+  fr: {
+    // List
+    'components.controls.list.unordered': 'Liste à puces',
+    'components.controls.list.ordered': 'Liste numérotée',
+
+    // Link
+    'components.controls.link.popover.text': 'Texte',
+    'components.controls.link.popover.link': 'Lien',
+    'components.controls.link.popover.placeholder': 'p.ex www.teamleader.fr',
+    'components.controls.link.popover.cancel': 'Annuler',
+    'components.controls.link.popover.addLink': 'Ajouter un lien',
+  },
+};


### PR DESCRIPTION
~**‼️ Don't merge before #1030**~

### Description

- Added `locale` prop to `WysiwygEditor`, and a translations file for locales: `en`, `nl`, `fr`, `de`, `es` and `it`

### Breaking changes

- None
