### PR TITLE
WysiwygEditor: Link fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,16 @@
 
 ### Changed
 
+- `WysiywygEditor`: Link popover is now displayed at center of toolbar icon instead of at end, to avoid issues on smaller sizes. ([@mikeverf](https://github.com/mikeverf) in [#1038])
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- `WysiywygEditor`: Link popover can now handle buttons with long labels. ([@mikeverf](https://github.com/mikeverf) in [#1038])
+- `WysiywygEditor`: Certain links were handled as relative links, so didn't open correctly. ([@mikeverf](https://github.com/mikeverf) in [#1038])
 
 ### Dependency updates
 

--- a/src/components/wysiwygEditor/LinkOptions.js
+++ b/src/components/wysiwygEditor/LinkOptions.js
@@ -75,7 +75,6 @@ const LinkOptions = ({
         onOverlayClick={handleClosePopoverClick}
         minWidth={276}
         maxWidth="100%"
-        position="end"
       >
         <Box display="flex" flexDirection="column" padding={4}>
           <Label htmlFor="linkText" helpText="">

--- a/src/components/wysiwygEditor/decorators/linkDecorator.js
+++ b/src/components/wysiwygEditor/decorators/linkDecorator.js
@@ -18,7 +18,11 @@ const LinkEntity = ({ entityKey, contentState, children }) => {
   const { url } = contentState.getEntity(entityKey).getData();
 
   const openLink = () => {
-    window.open(url, 'blank');
+    let prefixedUrl = url;
+    if (!url.includes('//')) {
+      prefixedUrl = '//' + url;
+    }
+    window.open(prefixedUrl, '_blank');
   };
 
   const toggleShowOpenLinkIcon = () => {


### PR DESCRIPTION
~**‼️ Don't merge before #1037**~

### Description

- The link popover can now handle longer button titles (scales along)
- Link popover now displays in center of toolbar button instead of at end, to avoid issues on smaller sizes
- Fixed certain links not being able to open correctly from the editor itself

#### Screenshot before this PR

![Screenshot 2020-04-21 at 13 41 41](https://user-images.githubusercontent.com/19315705/79862626-aacca600-83d6-11ea-85b5-6f7ce8d8bc35.png)

#### Screenshot after this PR

![Screenshot 2020-04-21 at 13 41 16](https://user-images.githubusercontent.com/19315705/79862628-ab653c80-83d6-11ea-97e8-e8c4fc02dea4.png)

### Breaking changes

- None