### PR TITLE
WysiwygEditor: styling fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `WysiywygEditor`: Allow boxProps that are now set on the wrapper box. ([@mikeverf](https://github.com/mikeverf) in [#1044])
+
 ### Changed
 
 ### Deprecated
@@ -9,6 +11,8 @@
 ### Removed
 
 ### Fixed
+
+- `WysiywygEditor`: added list styling instead of relying on browser styling. ([@mikeverf](https://github.com/mikeverf) in [#1044])
 
 ### Dependency updates
 

--- a/src/components/wysiwygEditor/WysiwygEditor.js
+++ b/src/components/wysiwygEditor/WysiwygEditor.js
@@ -10,7 +10,7 @@ import {
   IconLinkMediumOutline,
 } from '@teamleader/ui-icons';
 
-import Box from '../box';
+import Box, { pickBoxProps } from '../box';
 import ValidationText from '../validationText';
 
 import InlineStylingOptions from './InlineStylingOptions';
@@ -98,8 +98,10 @@ const WysiwygEditor = ({
     className,
   );
 
+  const boxProps = pickBoxProps(others);
+
   return (
-    <Box style={{ width, flex: width && '0 0 auto' }}>
+    <Box style={{ width, flex: width && '0 0 auto' }} {...boxProps}>
       <Editor
         toolbar={toolbar}
         wrapperClassName={wrapperClassNames}

--- a/src/components/wysiwygEditor/theme.css
+++ b/src/components/wysiwygEditor/theme.css
@@ -61,6 +61,17 @@
       margin-top: 0;
     }
   }
+
+  & ul,
+  ol {
+    margin: 0;
+    padding-left: 12px;
+  }
+
+  & ol > li,
+  & ul > li {
+    margin-left: 12px;
+  }
 }
 
 .toolbar {


### PR DESCRIPTION
### Description

- Allow boxProps that are now set on the wrapper box. 
- Added list styling instead of relying on browser styling.

### Breaking changes

- None
