### PR TITLE
Release 0.42.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### Added
 
-- `WysiywygEditor`: Allow boxProps that are now set on the wrapper box. ([@mikeverf](https://github.com/mikeverf) in [#1044])
-
 ### Changed
 
 ### Deprecated
@@ -12,9 +10,17 @@
 
 ### Fixed
 
-- `WysiywygEditor`: added list styling instead of relying on browser styling. ([@mikeverf](https://github.com/mikeverf) in [#1044])
-
 ### Dependency updates
+
+## [0.42.2] - 2020-04-22
+
+### Added
+
+- `WysiywygEditor`: Allow boxProps that are now set on the wrapper box. ([@mikeverf](https://github.com/mikeverf) in [#1044])
+
+### Fixed
+
+- `WysiywygEditor`: added list styling instead of relying on browser styling. ([@mikeverf](https://github.com/mikeverf) in [#1044])
 
 ## [0.42.1] - 2020-04-22
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.42.1",
+  "version": "0.42.2",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Added

- `WysiywygEditor`: Allow boxProps that are now set on the wrapper box. ([@mikeverf](https://github.com/mikeverf) in [#1044])

### Fixed

- `WysiywygEditor`: added list styling instead of relying on browser styling. ([@mikeverf](https://github.com/mikeverf) in [#1044])
