### PR TITLE
Release 0.42.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,23 @@
 
 ### Changed
 
-- `Tag`: changed internally to use `Badge` components. ([@driesd](https://github.com/driesd) in [#1046])
-
 ### Deprecated
 
 ### Removed
 
 ### Fixed
 
-- `Tag`: fixed accidentally removed `onClick` prop. ([@driesd](https://github.com/driesd) in [#1046])
-
 ### Dependency updates
+
+## [0.42.3] - 2020-04-22
+
+### Changed
+
+- `Tag`: changed internally to use `Badge` components. ([@driesd](https://github.com/driesd) in [#1046])
+
+### Fixed
+
+- `Tag`: fixed accidentally removed `onClick` prop. ([@driesd](https://github.com/driesd) in [#1046])
 
 ## [0.42.2] - 2020-04-22
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.42.2",
+  "version": "0.42.3",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Changed

- `Tag`: changed internally to use `Badge` components. ([@driesd](https://github.com/driesd) in [#1046])

### Fixed

- `Tag`: fixed accidentally removed `onClick` prop. ([@driesd](https://github.com/driesd) in [#1046])
