### PR TITLE
WysiwygEditor: fallback to English when locale prop is non-supported locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `WysiwygEditor`: Fall back to `en` when `locale` prop isn't one of `en`, `it`, `nl`, `de`, `fr` or `es`. ([@mikeverf](https://github.com/mikeverf) in [#1052])
+
 ## [0.42.4] - 2020-04-23
 
 ### Added

--- a/src/components/wysiwygEditor/WysiwygEditor.js
+++ b/src/components/wysiwygEditor/WysiwygEditor.js
@@ -49,6 +49,8 @@ const customStyleMap = {
   },
 };
 
+const availableLocales = ['en', 'es', 'it', 'nl', 'fr', 'de'];
+
 const WysiwygEditor = ({
   className,
   error,
@@ -112,10 +114,17 @@ const WysiwygEditor = ({
         onContentStateChange={handleContentStateChange}
         customStyleMap={customStyleMap}
         customDecorators={[linkDecorator]}
-        localization={{
-          locale,
-          translations: translations[locale],
-        }}
+        localization={
+          availableLocales.includes(locale)
+            ? {
+                locale,
+                translations: translations[locale],
+              }
+            : {
+                locale: 'en',
+                translations: translations['en'],
+              }
+        }
         {...others}
       />
       <ValidationText error={error} help={helpText} success={success} warning={warning} />


### PR DESCRIPTION
### Description

Fallback to English when locale prop is non-supported locale 

### Breaking changes

- None
