### PR TITLE
Release 0.42.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,16 @@
 
 ### Fixed
 
+## [0.42.5] - 2020-04-23
+
+### Fixed
+
 - `WysiwygEditor`: Fall back to `en` when `locale` prop isn't one of `en`, `it`, `nl`, `de`, `fr` or `es`. ([@mikeverf](https://github.com/mikeverf) in [#1052])
+
+### Dependency updates
+
+- `react-day-picker` from `7.4.7` to `7.4.8`
+- `eslint-config-prettier` from `6.10.1` to `6.11.0`
 
 ## [0.42.4] - 2020-04-23
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.42.4",
+  "version": "0.42.5",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Fixed

- `WysiwygEditor`: Fall back to `en` when `locale` prop isn't one of `en`, `it`, `nl`, `de`, `fr` or `es`. ([@mikeverf](https://github.com/mikeverf) in [#1052])

### Dependency updates

- `react-day-picker` from `7.4.7` to `7.4.8`
- `eslint-config-prettier` from `6.10.1` to `6.11.0`
