### PR TITLE
WysiwygEditor: Fix placeholder positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `WysiwygEditor`: Make sure placeholder is positioned correctly on scroll. ([@mikeverf](https://github.com/mikeverf) in [#1055])
+
 ## [0.42.5] - 2020-04-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `WysiwygEditor`: Make spacing between list items less high. ([@mikeverf](https://github.com/mikeverf) in [#1055])
+
 ### Deprecated
 
 ### Removed

--- a/src/components/wysiwygEditor/theme.css
+++ b/src/components/wysiwygEditor/theme.css
@@ -75,6 +75,10 @@
   & ol > li,
   & ul > li {
     margin-left: 12px;
+
+    & > :global(.public-DraftStyleDefault-block) {
+      margin: 0.5em 0;
+    }
   }
 }
 

--- a/src/components/wysiwygEditor/theme.css
+++ b/src/components/wysiwygEditor/theme.css
@@ -40,6 +40,10 @@
   font-smoothing: antialiased;
   text-size-adjust: 100%;
 
+  :global(.DraftEditor-root) {
+    position: relative;
+  }
+
   &:not(.has-placeholder) :global(.public-DraftEditorPlaceholder-root) {
     display: none;
   }


### PR DESCRIPTION
### Description

- Make sure placeholder is positioned relative to Wysiwyg root instead of parent.
- Make spacing between list items less high.

### Breaking changes

- None