### PR TITLE
Fix linkDecorator href of WysiwygEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `WysiwygEditor`: Remove href attribute from `linkDecorator` of `WysiwygEditor`. ([@mikeverf](https://github.com/mikeverf) in [#1057])
+
 ## [0.42.6] - 2020-04-23
 
 ### Changed

--- a/src/components/wysiwygEditor/decorators/linkDecorator.js
+++ b/src/components/wysiwygEditor/decorators/linkDecorator.js
@@ -31,7 +31,7 @@ const LinkEntity = ({ entityKey, contentState, children }) => {
 
   return (
     <Box display="inline-block" onMouseEnter={toggleShowOpenLinkIcon} onMouseLeave={toggleShowOpenLinkIcon}>
-      <Link className={theme['link']} href="" inherit={false} onClick={(event) => event.preventDefault()}>
+      <Link className={theme['link']} inherit={false} onClick={(event) => event.preventDefault()}>
         {children}
       </Link>
       {showOpenLinkIcon && <IconExternalLinkSmallOutline onClick={openLink} className={theme['icon']} />}


### PR DESCRIPTION
### Description

- Removed href attribute from link decorator of WysiwygEditor, which opened the link in some cases when clicking on it.

### Breaking changes

- None
