### PR TITLE
Release 0.42.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+## [0.42.7] - 2020-04-23
+
+### Fixed
+
 - `WysiwygEditor`: Remove href attribute from `linkDecorator` of `WysiwygEditor`. ([@mikeverf](https://github.com/mikeverf) in [#1057])
 
 ## [0.42.6] - 2020-04-23

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.42.6",
+  "version": "0.42.7",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Fixed

- `WysiwygEditor`: Remove href attribute from `linkDecorator` of `WysiwygEditor`. ([@mikeverf](https://github.com/mikeverf) in [#1057])
