### PR TITLE
Button: handle overflowing text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### Added
 
+- `Button`: handle overflowing text. ([@driesd](https://github.com/driesd) in [#1059])
+
 ### Changed
+
+- `Button`: replaced `span` wrapper, containing `label` & `children`, with our `UIText` components. ([@driesd](https://github.com/driesd) in [#1059])
 
 ### Deprecated
 

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -116,7 +116,7 @@ class Button extends PureComponent {
       <Box {...props}>
         {icon && iconPlacement === 'left' && icon}
         {(label || children) && (
-          <Text element="span">
+          <Text element="span" ellipsis>
             {label}
             {children}
           </Text>

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Box from '../box';
 import LoadingSpinner from '../loadingSpinner';
+import { UITextBody, UITextDisplay } from '../typography';
 import cx from 'classnames';
 import theme from './theme.css';
 
@@ -109,14 +110,16 @@ class Button extends PureComponent {
       'data-teamleader-ui': 'button',
     };
 
+    const Text = size === 'large' ? UITextDisplay : UITextBody;
+
     return (
       <Box {...props}>
         {icon && iconPlacement === 'left' && icon}
         {(label || children) && (
-          <span>
+          <Text element="span">
             {label}
             {children}
-          </span>
+          </Text>
         )}
         {icon && iconPlacement === 'right' && icon}
         {processing && (

--- a/src/components/button/button.stories.js
+++ b/src/components/button/button.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { boolean, select } from '@storybook/addon-knobs/react';
+import { boolean, select, text } from '@storybook/addon-knobs/react';
 import { IconAddMediumOutline, IconAddSmallOutline } from '@teamleader/ui-icons';
 import { Button } from '../../index';
 
@@ -25,7 +25,7 @@ export const withText = () => (
   <Button
     active={boolean('Active', false)}
     color={select('Color', colors, 'teal')}
-    label="Button"
+    label={text('Label', 'Button with label')}
     level={select('Level', levels, 'secondary')}
     disabled={boolean('Disabled', false)}
     fullWidth={boolean('Full width', false)}
@@ -63,7 +63,7 @@ export const withTextAndIcon = () => (
     color={select('Color', colors, 'teal')}
     icon={select('Size', sizes, 'medium') === 'small' ? <IconAddSmallOutline /> : <IconAddMediumOutline />}
     iconPlacement={select('Icon placement', iconPositions, 'left')}
-    label="Button"
+    label={text('Label', 'Button with icon and label')}
     level={select('Level', levels, 'secondary')}
     disabled={boolean('Disabled', false)}
     fullWidth={boolean('Full width', false)}
@@ -82,7 +82,7 @@ export const withCustomElement = () => (
     active={boolean('Active', false)}
     color={select('Color', colors, 'teal')}
     element={select('Element', elements, 'a')}
-    label="Button"
+    label={text('Label', 'Button with custom element')}
     level={select('Level', levels, 'secondary')}
     disabled={boolean('Disabled', false)}
     fullWidth={boolean('Full width', false)}

--- a/src/components/button/theme.css
+++ b/src/components/button/theme.css
@@ -60,6 +60,8 @@
 }
 
 .button {
+  max-width: 100%;
+
   &:not(.is-disabled) {
     &:hover {
       z-index: 1;

--- a/src/components/button/theme.css
+++ b/src/components/button/theme.css
@@ -60,8 +60,6 @@
 }
 
 .button {
-  font-family: var(--font-family-medium);
-
   &:not(.is-disabled) {
     &:hover {
       z-index: 1;
@@ -338,9 +336,7 @@
 
 /* Button sizes */
 .small {
-  font-size: calc(1.4 * var(--unit));
   height: calc(3 * var(--unit));
-  line-height: calc(2.8 * var(--unit));
   min-width: calc(3 * var(--unit));
   padding: 0 calc(1.2 * var(--unit));
 
@@ -350,9 +346,7 @@
 }
 
 .medium {
-  font-size: calc(1.4 * var(--unit));
   height: calc(3.6 * var(--unit));
-  line-height: calc(3.4 * var(--unit));
   min-width: calc(3.6 * var(--unit));
   padding: 0 calc(1.2 * var(--unit));
 
@@ -362,9 +356,7 @@
 }
 
 .large {
-  font-size: calc(1.6 * var(--unit));
   height: calc(4.8 * var(--unit));
-  line-height: calc(4.6 * var(--unit));
   min-width: calc(4.8 * var(--unit));
   padding: 0 calc(1.8 * var(--unit));
 


### PR DESCRIPTION
### Description

This PR handles overflowing text in our `Button` component by replacing the label & children wrapper with our `UIText` components.

#### Screenshot before this PR
![Screenshot 2020-04-23 17 19 41](https://user-images.githubusercontent.com/5336831/80116791-b1018480-8586-11ea-9d2b-87223fbec79d.png)

#### Screenshot after this PR
![Screenshot 2020-04-23 17 19 12](https://user-images.githubusercontent.com/5336831/80116805-b4950b80-8586-11ea-9883-97bab209d739.png)

### Breaking changes

None.