### PR TITLE
DataGrid: inverse sorting arrow direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- `Datagrid`: changed the sorting arrow direction in `HeaderCell`. ([@driesd](https://github.com/driesd) in [#1060])
+- `Datagrid`: changed to use `UITextBody` for `HeaderCell` text. ([@driesd](https://github.com/driesd) in [#1060])
+
 ### Deprecated
 
 ### Removed

--- a/src/components/datagrid/HeaderCell.js
+++ b/src/components/datagrid/HeaderCell.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import theme from './theme.css';
 import Cell from './Cell';
 import Icon from '../icon';
+import { UITextBody } from '../typography';
 import cx from 'classnames';
 import { IconArrowDownSmallOutline, IconArrowUpSmallOutline } from '@teamleader/ui-icons';
 
@@ -36,7 +37,9 @@ class HeaderCell extends PureComponent {
     return (
       <Cell align={align} className={classNames} onClick={onClick} {...others} preventOverflow={false}>
         {sortable && align === 'right' && <Icon marginRight={1}>{this.renderSortedIndicators()}</Icon>}
-        <span className={theme['has-overflow-prevention']}>{children}</span>
+        <UITextBody element="span" ellipsis>
+          {children}
+        </UITextBody>
         {sortable && align === 'left' && <Icon marginLeft={1}>{this.renderSortedIndicators()}</Icon>}
       </Cell>
     );

--- a/src/components/datagrid/HeaderCell.js
+++ b/src/components/datagrid/HeaderCell.js
@@ -11,11 +11,11 @@ class HeaderCell extends PureComponent {
     const { sortable, sorted } = this.props;
 
     if (sorted === 'asc' || (!sorted && sortable)) {
-      return <IconArrowDownSmallOutline />;
+      return <IconArrowUpSmallOutline />;
     }
 
     if (sorted === 'desc') {
-      return <IconArrowUpSmallOutline />;
+      return <IconArrowDownSmallOutline />;
     }
 
     return null;

--- a/src/components/datagrid/theme.css
+++ b/src/components/datagrid/theme.css
@@ -66,7 +66,6 @@
 
 .header-cell {
   color: var(--color-teal-dark);
-  font-family: var(--font-family-medium);
 }
 
 .has-overflow-prevention {


### PR DESCRIPTION
### Description

This PR inverts the `sorting arrow` direction of our `DataGrid.HeaderCell`, according to design specs. Also using `UITextBody` for `HeaderCell` text now, which enhances vertical alignment.

#### Screenshot before this PR (ASC sorted)
![Screenshot 2020-04-27 09 33 43](https://user-images.githubusercontent.com/5336831/80345992-54de7f00-886a-11ea-9312-30c90847c6bb.png)

#### Screenshot after this PR (ASC sorted)
![Screenshot 2020-04-27 09 33 20](https://user-images.githubusercontent.com/5336831/80345955-4bedad80-886a-11ea-8058-dbf945406d6d.png)

### Breaking changes

None.
