### PR TITLE
Fix incorrect month being displayed on initial render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fix incorrect month being displayed on initial render ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1067](https://github.com/teamleadercrm/ui/pull/1067))
+
 ### Dependency updates
 
 ## [0.42.8] - 2020-04-27

--- a/src/components/datepicker/DatePicker.js
+++ b/src/components/datepicker/DatePicker.js
@@ -72,6 +72,7 @@ class DatePicker extends PureComponent {
       <Box {...boxProps}>
         <DayPicker
           {...restProps}
+          initialMonth={selectedDate}
           month={selectedMonth}
           className={classNames}
           classNames={theme}


### PR DESCRIPTION
### Description

* Fix incorrect month being displayed on initial render

### Manual check

* run storybook
* go to the datepicker input
* on upstream: for today's date, you'll see the month of april is still selected, even though the first of may was passed, this is fixed on this brach
