### PR TITLE
IslandGroup: Filter out non-valid elements before changing props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - Fix incorrect month being displayed on initial render ([ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1067](https://github.com/teamleadercrm/ui/pull/1067))
+- Fix IslandGroup attempting to change props of invalid react elements (undefined, null, etc.).
 
 ### Dependency updates
 

--- a/src/components/island/IslandGroup.js
+++ b/src/components/island/IslandGroup.js
@@ -1,12 +1,20 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import Box, { pickBoxProps } from '../box';
 
 class IslandGroup extends PureComponent {
   render() {
-    const { children, className, color, dark, direction, size, ...otherProps } = this.props;
+    const { children: originalChildren, className, color, dark, direction, size, ...otherProps } = this.props;
 
     const boxProps = pickBoxProps(otherProps);
+    const children = [];
+
+    React.Children.forEach(originalChildren, (child) => {
+      if (isValidElement(child)) {
+        children.push(child);
+      }
+    });
+
     const hasMoreThanOneChild = children.length > 1;
 
     return (


### PR DESCRIPTION
### Description

Sometimes children could be null or undefined if they were
conditionally rendered. This broke the IslandGroup logic as it would map
through each child and overwrite some of its props for the border
styling. This patch filters the children array first, making sure all
children are valid react elements, before trying to change their props.

### Breaking changes

None