### PR TITLE
Change minWidth setting to 180px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `Button`: changed to handle spacing between icon an label with margin `Box` props, instead of dirty CSS. ([@driesd](https://github.com/driesd) in [#1072])
 - `SplitButton`: prevent scroll lock when showing `Popover` menu. ([@driesd](https://github.com/driesd) in [#1071])
+- `Popover`: set min width to 180px. ([@lorgan3](https://github.com/lorgan3) in [#1090])
 
 ### Deprecated
 

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -185,7 +185,7 @@ Popover.defaultProps = {
   color: 'neutral',
   lockScroll: true,
   maxWidth: '50vw',
-  minWidth: 'auto',
+  minWidth: '180px',
   offsetCorrection: 0,
   position: 'center',
   tint: 'lightest',


### PR DESCRIPTION
### Description
Change the minWidth property to 180px so by default the component looks better with short children.

Slightly more info in jira: https://teamleader.atlassian.net/browse/IN-2731

#### Screenshot before this PR

![image](https://user-images.githubusercontent.com/1833617/81194786-58d27580-8fbd-11ea-8fcc-76b0b4f37d9e.png)

#### Screenshot after this PR

![image](https://user-images.githubusercontent.com/1833617/81194857-6daf0900-8fbd-11ea-9d81-022374d7573d.png)
