### PR TITLE
Text & Heading: multiline overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- [Breaking] `Text`: added `maxLines` prop (number), which replaces `ellipsis`. ([@driesd](https://github.com/driesd) in [#1092])
+
 ### Changed
 
 - `Button`: changed to handle spacing between icon an label with margin `Box` props, instead of dirty CSS. ([@driesd](https://github.com/driesd) in [#1072])
@@ -12,6 +14,7 @@
 ### Removed
 
 - `Button`: removed an obsolete SVG alignment fix for Safari. ([@driesd](https://github.com/driesd) in [#1072])
+- [Breaking] `Text`: removed `ellipsis` prop in order to use `maxLines` instead. ([@driesd](https://github.com/driesd) in [#1092])
 
 ### Fixed
 

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -118,7 +118,7 @@ class Button extends PureComponent {
         {(label || children) && (
           <Text
             element="span"
-            ellipsis
+            maxLines={1}
             marginLeft={icon && iconPlacement === 'left' && 2}
             marginRight={icon && iconPlacement === 'right' && 2}
           >

--- a/src/components/datagrid/HeaderCell.js
+++ b/src/components/datagrid/HeaderCell.js
@@ -37,7 +37,7 @@ class HeaderCell extends PureComponent {
     return (
       <Cell align={align} className={classNames} onClick={onClick} {...others} preventOverflow={false}>
         {sortable && align === 'right' && <Icon marginRight={1}>{this.renderSortedIndicators()}</Icon>}
-        <UITextBody element="span" ellipsis>
+        <UITextBody element="span" maxLines={1}>
           {children}
         </UITextBody>
         {sortable && align === 'left' && <Icon marginLeft={1}>{this.renderSortedIndicators()}</Icon>}

--- a/src/components/detailPage/DetailPageHeader.js
+++ b/src/components/detailPage/DetailPageHeader.js
@@ -22,7 +22,12 @@ class DetailPageHeader extends PureComponent {
           )}
           <Box flex="1 0 200px" paddingTop={5} overflow="hidden">
             <Box alignItems="center" display="flex">
-              <Heading1 color={titleColor} ellipsis tint={titleColor === 'neutral' ? 'dark' : 'darkest'} title={title}>
+              <Heading1
+                color={titleColor}
+                maxLines={1}
+                tint={titleColor === 'neutral' ? 'dark' : 'darkest'}
+                title={title}
+              >
                 {title}
               </Heading1>
               {titleSuffix && <Box marginLeft={3}>{titleSuffix}</Box>}

--- a/src/components/typography/Text.js
+++ b/src/components/typography/Text.js
@@ -8,7 +8,7 @@ import theme from './theme.css';
 const factory = (baseType, type, defaultElement) => {
   class Text extends PureComponent {
     render() {
-      const { children, className, color, element, ellipsis, tint, ...others } = this.props;
+      const { children, className, color, element, maxLines, style, tint, ...others } = this.props;
 
       const classNames = cx(
         theme[baseType],
@@ -16,15 +16,21 @@ const factory = (baseType, type, defaultElement) => {
         theme[color],
         theme[tint],
         {
-          [theme['overflow-ellipsis']]: ellipsis,
+          [theme['overflow-multiline']]: maxLines > 1,
+          [theme['overflow-singleline']]: maxLines === 1,
         },
         className,
       );
 
+      const styles = {
+        ...(maxLines > 1 && { MozLineClamp: maxLines, WebkitLineClamp: maxLines }),
+        ...style,
+      };
+
       const Element = element || defaultElement;
 
       return (
-        <Box className={classNames} data-teamleader-ui={baseType} element={Element} {...others}>
+        <Box className={classNames} data-teamleader-ui={baseType} element={Element} {...others} style={styles}>
           {children}
         </Box>
       );
@@ -36,13 +42,13 @@ const factory = (baseType, type, defaultElement) => {
     className: PropTypes.string,
     color: PropTypes.oneOf(COLORS),
     element: PropTypes.node,
-    ellipsis: PropTypes.bool,
+    maxLines: PropTypes.number,
+    style: PropTypes.object,
     tint: PropTypes.oneOf(TINTS),
   };
 
   Text.defaultProps = {
     element: null,
-    ellipsis: false,
     tint: 'darkest',
   };
 

--- a/src/components/typography/theme.css
+++ b/src/components/typography/theme.css
@@ -159,3 +159,18 @@
   background-color: color(var(--color-mint-light) a(0.3));
   color: inherit;
 }
+
+.overflow-multiline {
+  display: -webkit-box;
+  box-orient: vertical;
+  -webkit-box-orient: vertical;
+  -moz-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.overflow-singleline {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/components/typography/typography.stories.js
+++ b/src/components/typography/typography.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { addStoryInGroup, PRIMITIVES } from '../../../.storybook/utils';
-import { boolean, select } from '@storybook/addon-knobs/react';
+import { number, select } from '@storybook/addon-knobs/react';
 import {
   COLORS,
   TINTS,
@@ -35,14 +35,14 @@ export const headings = () => (
   <div>
     <Heading1
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
     >
       Heading 1 / font-size: 24px / line-height: 30px / weight: bold (700) / tracking: 0
     </Heading1>
     <Heading2
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
       marginTop={4}
     >
@@ -50,7 +50,7 @@ export const headings = () => (
     </Heading2>
     <Heading3
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
       marginTop={4}
     >
@@ -58,7 +58,7 @@ export const headings = () => (
     </Heading3>
     <Heading4
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
       marginTop={4}
     >
@@ -66,7 +66,7 @@ export const headings = () => (
     </Heading4>
     <Heading5
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
       marginTop={4}
     >
@@ -79,14 +79,14 @@ export const text = () => (
   <Box overflow="hidden">
     <TextDisplay
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
     >
       <strong>Text display</strong> / font-size: 16px / line-height: 24px / weight: regular (400) / tracking: 0
     </TextDisplay>
     <TextBody
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
       marginTop={4}
     >
@@ -94,7 +94,7 @@ export const text = () => (
     </TextBody>
     <TextBodyCompact
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
       marginTop={4}
     >
@@ -102,7 +102,7 @@ export const text = () => (
     </TextBodyCompact>
     <TextSmall
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
       marginTop={4}
     >
@@ -115,14 +115,14 @@ export const UIText = () => (
   <Box overflow="hidden">
     <UITextDisplay
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
     >
       <strong>UI Text display</strong> / font-size: 16px / line-height: 24px / weight: medium (500) / tracking: 0
     </UITextDisplay>
     <UITextBody
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
       marginTop={4}
     >
@@ -130,7 +130,7 @@ export const UIText = () => (
     </UITextBody>
     <UITextSmall
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
       marginTop={4}
     >
@@ -143,14 +143,14 @@ export const monospaced = () => (
   <Box padding={5}>
     <Heading1
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
     >
       <Monospaced>1234567890</Monospaced>
     </Heading1>
     <Heading2
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
       marginTop={2}
     >
@@ -158,7 +158,7 @@ export const monospaced = () => (
     </Heading2>
     <Heading3
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
       marginTop={2}
     >
@@ -166,7 +166,7 @@ export const monospaced = () => (
     </Heading3>
     <Heading4
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
       marginTop={2}
     >
@@ -174,7 +174,7 @@ export const monospaced = () => (
     </Heading4>
     <Heading5
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
       marginTop={2}
     >
@@ -182,7 +182,7 @@ export const monospaced = () => (
     </Heading5>
     <TextDisplay
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
       marginTop={6}
     >
@@ -190,7 +190,7 @@ export const monospaced = () => (
     </TextDisplay>
     <TextBody
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
       marginTop={2}
     >
@@ -198,7 +198,7 @@ export const monospaced = () => (
     </TextBody>
     <TextSmall
       color={select('Color', COLORS, 'teal')}
-      ellipsis={boolean('Overflow ellipsis', false)}
+      maxLines={number('Max lines', undefined)}
       tint={select('Tint', TINTS, 'darkest')}
       marginTop={2}
     >


### PR DESCRIPTION
### Description

This PR introduces `multi-line text-overflow` on all `Text` components (Text, UIText & Heading), by replacing the `ellipsis` prop with `maxLines`.

### Screenshots
#### maxLines={0} or undefined (full text)
![Screenshot 2020-05-07 12 26 39](https://user-images.githubusercontent.com/5336831/81284417-5d9b3600-905e-11ea-9dfa-fd6b97589c15.png)

#### maxLines={1} (truncated text)
![Screenshot 2020-05-07 12 26 52](https://user-images.githubusercontent.com/5336831/81284257-2b89d400-905e-11ea-95df-e368b44fd588.png)

#### maxLines={2} (truncated text)
![Screenshot 2020-05-07 12 27 10](https://user-images.githubusercontent.com/5336831/81284277-32184b80-905e-11ea-984e-000c6e9c2edb.png)

#### maxLines={3} (truncated text)
![Screenshot 2020-05-07 12 27 16](https://user-images.githubusercontent.com/5336831/81284385-5542fb00-905e-11ea-8a41-f30cddadba87.png)

### Breaking changes

🔥  `ellipsis` prop has been removed. Please use `maxLines={1}` instead to update your projects.
