### PR TITLE
Release 0.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,25 @@
 
 ### Added
 
-- `Text`: added `maxLines` prop (number), which replaces `ellipsis`. ([@driesd](https://github.com/driesd) in [#1092])
-
 ### Changed
 
 ### Deprecated
 
 ### Removed
 
-- [Breaking] `Text`: removed `ellipsis` prop in order to use `maxLines` instead. ([@driesd](https://github.com/driesd) in [#1092])
-
 ### Fixed
 
 ### Dependency updates
+
+## [0.43.0] - 2020-05-11
+
+### Added
+
+- `Text`: added `maxLines` prop (number), which replaces `ellipsis`. ([@driesd](https://github.com/driesd) in [#1092])
+
+### Removed
+
+- [Breaking] `Text`: removed `ellipsis` prop in order to use `maxLines` instead. ([@driesd](https://github.com/driesd) in [#1092])
 
 ## [0.42.9] - 2020-05-07
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.42.9",
+  "version": "0.43.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Added

- `Text`: added `maxLines` prop (number), which replaces `ellipsis`. ([@driesd](https://github.com/driesd) in [#1092])

### Removed

- [Breaking] `Text`: removed `ellipsis` prop in order to use `maxLines` instead. ([@driesd](https://github.com/driesd) in [#1092])
