### PR TITLE
Select: keep showing selected options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@
 
 ### Changed
 
+- `Select`: changed so the selected options still show up in the list by default. ([@driesd](https://github.com/driesd) in [#1099])
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
 
-- `DatePickerInput` Fix months not being formatted according to the passed locale. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1095])
+- `DatePickerInput` Fix months not being formatted according to the passed locale. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1098])
 
 ### Dependency updates
 

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -347,6 +347,7 @@ class Select extends PureComponent {
             IndicatorSeparator: null,
             ...components,
           }}
+          hideSelectedOptions={false}
           menuPortalTarget={portalTarget}
           styles={this.getStyles()}
           {...restProps}

--- a/src/components/select/select.stories.js
+++ b/src/components/select/select.stories.js
@@ -49,7 +49,7 @@ export const basic = () => (
     options={options}
     placeholder="Select your favourite(s)"
     size={select('Size', sizes, 'medium')}
-    hideSelectedOptions={boolean('Hide selected options', true)}
+    hideSelectedOptions={boolean('Hide selected options', false)}
     menuWidth={text('Menu width', undefined)}
     error={text('error', '')}
     helpText={text('helpText', '')}
@@ -71,7 +71,7 @@ export const grouped = () => (
     options={groupedOptions}
     placeholder="Select your favourite(s)"
     size={select('Size', sizes, 'medium')}
-    hideSelectedOptions={boolean('Hide selected options', true)}
+    hideSelectedOptions={boolean('Hide selected options', false)}
     error={text('error', '')}
     helpText={text('helpText', '')}
     success={text('success', '')}
@@ -95,7 +95,7 @@ export const customOption = () => (
     options={customOptions}
     placeholder="Select your favourite(s)"
     size={select('Size', sizes, 'medium')}
-    hideSelectedOptions={boolean('Hide selected options', true)}
+    hideSelectedOptions={boolean('Hide selected options', false)}
     error={text('error', '')}
     helpText={text('helpText', '')}
     success={text('success', '')}
@@ -136,7 +136,7 @@ export const async = () => {
       options={options}
       placeholder="Select your favourite(s)"
       size={select('size', sizes, 'medium')}
-      hideSelectedOptions={boolean('hideSelectedOptions', true)}
+      hideSelectedOptions={boolean('hideSelectedOptions', false)}
       error={text('error', '')}
       helpText={text('helpText', '')}
       success={text('success', '')}


### PR DESCRIPTION
### Description

This PR changes the `hideSelectedOptions` default value of our `Select` component from `true` to `false`.

**From a UX point of view:** showing the selected option would be consistent with us not hiding things that were available to the user before.

### Breaking changes

None.
