### PR TITLE
Fix: WysiwygEditor auto height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - `DatePickerInput` Fix months not being formatted according to the passed locale. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1098])
+- `WysiwygEditor` Fix input overflowing wrapper when wrapper has set height. ([@mikeverf](https://github.com/mikeverf) in [#1101])
 
 ### Dependency updates
 

--- a/src/components/wysiwygEditor/theme.css
+++ b/src/components/wysiwygEditor/theme.css
@@ -13,13 +13,14 @@
   --input-warning-border: var(--color-gold-dark);
   --input-min-height: calc(9.3 * var(--unit));
   --input-spacing: calc(0.5 * var(--unit));
+  --toolbar-height: 43px;
 }
 
 /**
  * Components
  */
 .input {
-  height: 100%;
+  height: calc(100% - var(--toolbar-height) - 2 * var(--input-spacing));
   overflow: auto;
   min-height: var(--input-min-height);
   margin: var(--input-spacing);


### PR DESCRIPTION
### Description

When setting a height on the wrapper, the input field wouldn't fill space correctly; we had to take into account the toolbar height and applied margins.
So here, I made sure Wysiwyg input takes rest height instead of overflowing the parent.

#### Screenshot before this PR

![Screenshot 2020-05-13 at 13 37 59](https://user-images.githubusercontent.com/19315705/81807865-25449d80-951f-11ea-98cd-54277185909a.png)


#### Screenshot after this PR

![Screenshot 2020-05-13 at 13 35 42](https://user-images.githubusercontent.com/19315705/81807871-270e6100-951f-11ea-95e2-2d4f06e88444.png)


### Breaking changes

- None
