### PR TITLE
EmptyState: add hidePointer prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### Added
 
+- `EmptyState`: added `hidePointer` boolean prop (default false). ([@driesd](https://github.com/driesd) in [#1104])
+
 ### Changed
+
+- `EmptyState`: changed meta text component to increase line-height from 18px to 21px. ([@driesd](https://github.com/driesd) in [#1104])
 
 ### Deprecated
 

--- a/src/components/emptyState/EmptyState.js
+++ b/src/components/emptyState/EmptyState.js
@@ -18,7 +18,7 @@ const illustrationMap = {
 
 class EmptyState extends PureComponent {
   render() {
-    const { className, metaText, size, title, ...others } = this.props;
+    const { className, metaText, hidePointer, size, title, ...others } = this.props;
 
     const classNames = cx(
       theme['wrapper'],
@@ -39,7 +39,7 @@ class EmptyState extends PureComponent {
         justifyContent="center"
         textAlign="center"
       >
-        {title && <div className={theme['pointer']}>{illustrationMap[size]}</div>}
+        {title && !hidePointer && <div className={theme['pointer']}>{illustrationMap[size]}</div>}
         <div className={theme['content']}>
           {title && <Heading3 color="teal">{title}</Heading3>}
           {metaText && (
@@ -54,12 +54,14 @@ class EmptyState extends PureComponent {
 }
 
 EmptyState.propTypes = {
+  hidePointer: PropTypes.bool,
   metaText: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   title: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
 };
 
 EmptyState.defaultProps = {
+  hidePointer: false,
   size: 'medium',
 };
 

--- a/src/components/emptyState/EmptyState.js
+++ b/src/components/emptyState/EmptyState.js
@@ -7,7 +7,7 @@ import {
   IllustrationEmptyState48X48Pointer,
   IllustrationEmptyState130X130Pointer,
 } from '@teamleader/ui-illustrations';
-import { Heading3, TextBodyCompact } from '../typography';
+import { Heading3, TextBody } from '../typography';
 import theme from './theme.css';
 
 const illustrationMap = {
@@ -43,9 +43,9 @@ class EmptyState extends PureComponent {
         <div className={theme['content']}>
           {title && <Heading3 color="teal">{title}</Heading3>}
           {metaText && (
-            <TextBodyCompact marginTop={title && 2} color="neutral">
+            <TextBody marginTop={title && 2} color="neutral">
               {metaText}
-            </TextBodyCompact>
+            </TextBody>
           )}
         </div>
       </Box>

--- a/src/components/emptyState/emptyState.stories.js
+++ b/src/components/emptyState/emptyState.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { select } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import { addStoryInGroup, MID_LEVEL_BLOCKS } from '../../../.storybook/utils';
 import EmptyState from './EmptyState';
 import { Marker } from '../typography';
@@ -26,6 +26,7 @@ export const basic = () => <EmptyState metaText="I am the meta information of th
 
 export const withTitle = () => (
   <EmptyState
+    hidePointer={boolean('Hide pointer', false)}
     metaText="I am the meta information and I basically explain that you can start adding content via the add button above."
     size={select('Size', sizes, 'medium')}
     title={title}


### PR DESCRIPTION
### Description

This PR adds a `hidePointer` boolean prop (default false) to our `EmptyState` component. Also, the line-height of the `meta text` is now updated from 18px to 21px by using `TextBody` instead of `TextBodyCompact`.

![Screenshot 2020-05-13 18 24 56](https://user-images.githubusercontent.com/5336831/81838898-14a81d80-9547-11ea-8d72-cac2dcf4c5e0.png)

### Breaking changes

None.
