### PR TITLE
Fix: WysiwygEditor `LinkOptions` dialog z-index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `WysiwygEditor` Set `zIndex` of `LinkOptions` dialog to `401`, so that it's higher than the zIndex of a `Dialog`. ([@mikeverf](https://github.com/mikeverf) in [#1106])
+
 ### Dependency updates
 
 ## [0.43.3] - 2020-05-14

--- a/src/components/wysiwygEditor/LinkOptions.js
+++ b/src/components/wysiwygEditor/LinkOptions.js
@@ -75,6 +75,7 @@ const LinkOptions = ({
         onOverlayClick={handleClosePopoverClick}
         minWidth={276}
         maxWidth="100%"
+        zIndex={401}
       >
         <Box display="flex" flexDirection="column" padding={4}>
           <Label htmlFor="linkText" helpText="">


### PR DESCRIPTION
### Description

Set zIndex of LinkOptions popover to be higher than the Index of a Dialog
So WysiwygEditor can be used in a Dialog without issues

#### Screenshot before this PR

![Screenshot 2020-05-14 at 13 22 09](https://user-images.githubusercontent.com/19315705/81928831-32788f80-95e6-11ea-978a-e9f86b42015c.png)


#### Screenshot after this PR

![Screenshot 2020-05-14 at 13 22 59](https://user-images.githubusercontent.com/19315705/81928836-35738000-95e6-11ea-8056-0cd83f52ff9c.png)


### Breaking changes

None
