### PR TITLE
Fix: LabelValuePair and LabelValuePairGroup were not exported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `LabelValuePair` and `LabelValuePairGroup` were not exported. ([@lowiebenoot](https://github.com/lowiebenoot) in [#1107])
+
 ### Dependency updates
 
 ## [0.43.3] - 2020-05-14

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ import Link from './components/link';
 import Message from './components/message';
 import Overlay from './components/overlay';
 import OverviewPage, { OverviewPageBody, OverviewPageHeader } from './components/overviewPage';
+import { LabelValuePair, LabelValuePairGroup } from './components/labelValuePair';
 import LoadingBar from './components/loadingBar';
 import LoadingMolecule from './components/loadingMolecule';
 import LoadingSpinner from './components/loadingSpinner';
@@ -125,6 +126,8 @@ export {
   Island,
   IslandGroup,
   Label,
+  LabelValuePair,
+  LabelValuePairGroup,
   Link,
   LoadingBar,
   LoadingMolecule,


### PR DESCRIPTION
### Fixed

- `LabelValuePair` and `LabelValuePairGroup` were not exported