### PR TITLE
SilentBanner: component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `SilentBanner`: added as a new component. ([@driesd](https://github.com/driesd) in [#1109])
+
 ### Changed
 
 ### Deprecated

--- a/src/components/silentBanner/SilentBanner.js
+++ b/src/components/silentBanner/SilentBanner.js
@@ -1,0 +1,135 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import {
+  IconBellMediumOutline,
+  IconCheckmarkBadgedMediumFilled,
+  IconCloseMediumOutline,
+  IconWarningBadgedMediumFilled,
+} from '@teamleader/ui-icons';
+import Box from '../box';
+import Button from '../button';
+import ButtonGroup from '../buttonGroup';
+import Icon from '../icon';
+import { IconButton } from '../iconButton';
+import { Heading3, TextBody } from '../typography';
+
+const backgroundColorMap = {
+  error: 'ruby',
+  info: 'neutral',
+  success: 'mint',
+  warning: 'gold',
+};
+
+const backgroundTintMap = {
+  error: 'normal',
+  info: 'normal',
+  success: 'light',
+  warning: 'light',
+};
+
+const iconMap = {
+  error: IconWarningBadgedMediumFilled,
+  info: IconBellMediumOutline,
+  success: IconCheckmarkBadgedMediumFilled,
+  warning: IconWarningBadgedMediumFilled,
+};
+
+const iconColorMap = {
+  error: 'neutral',
+  info: 'neutral',
+  success: 'neutral',
+  warning: 'gold',
+};
+
+const iconTintMap = {
+  error: 'lightest',
+  info: 'darkest',
+  success: 'lightest',
+  warning: 'dark',
+};
+
+class SilentBanner extends PureComponent {
+  render() {
+    const { children, onClose, primaryAction, secondaryAction, showIcon, status, title, ...others } = this.props;
+
+    const hasActions = Boolean(primaryAction || secondaryAction);
+    const IconToRender = iconMap[status];
+
+    return (
+      <Box {...others} display="flex">
+        {status && (
+          <Box
+            backgroundColor={backgroundColorMap[status]}
+            backgroundTint={backgroundTintMap[status]}
+            borderBottomLeftRadius="rounded"
+            borderTopLeftRadius="rounded"
+            paddingHorizontal={showIcon ? 2 : 1}
+            paddingVertical={4}
+          >
+            {showIcon && (
+              <Icon color={iconColorMap[status]} tint={iconTintMap[status]}>
+                <IconToRender />
+              </Icon>
+            )}
+          </Box>
+        )}
+        <Box
+          borderColor="neutral"
+          borderTint="normal"
+          borderLeftWidth={status ? 0 : 1}
+          borderTopWidth={1}
+          borderRightWidth={1}
+          borderBottomWidth={1}
+          borderBottomRightRadius="rounded"
+          borderTopRightRadius="rounded"
+          borderBottomLeftRadius={status ? 'square' : 'rounded'}
+          borderTopLeftRadius={status ? 'square' : 'rounded'}
+          display="flex"
+        >
+          <Box padding={4}>
+            {title && (
+              <Heading3 color="teal" marginBottom={2}>
+                {title}
+              </Heading3>
+            )}
+            {children && <TextBody color="teal">{children}</TextBody>}
+            {hasActions && (
+              <ButtonGroup display="flex" justifyContent="flex-end" marginTop={4}>
+                {secondaryAction && (
+                  <Button level="link" size="small">
+                    Secondary action
+                  </Button>
+                )}
+                {primaryAction && <Button size="small">Primary action</Button>}
+              </ButtonGroup>
+            )}
+          </Box>
+          {onClose && (
+            <Box paddingVertical={4} paddingRight={3}>
+              <IconButton icon={<IconCloseMediumOutline />} marginLeft={-2} marginTop={-1} onClick={onClose} />
+            </Box>
+          )}
+        </Box>
+      </Box>
+    );
+  }
+}
+
+SilentBanner.propTypes = {
+  /** The content to display inside the banner. */
+  children: PropTypes.node,
+  /** Callback function that is fired when the close button of the banner is clicked. */
+  onClose: PropTypes.func,
+  /** Callback function that is fired when the primary action button is clicked. */
+  primaryAction: PropTypes.func,
+  /** Callback function that is fired when the secondary action button is clicked. */
+  secondaryAction: PropTypes.func,
+  /** If true, an icon will show up depending on the status type */
+  showIcon: PropTypes.bool,
+  /** A status type to determine color and icon */
+  status: PropTypes.oneOf(['info', 'error', 'success', 'warning']),
+  /** The banner title */
+  title: PropTypes.node,
+};
+
+export default SilentBanner;

--- a/src/components/silentBanner/SilentBanner.js
+++ b/src/components/silentBanner/SilentBanner.js
@@ -50,7 +50,18 @@ const iconTintMap = {
 
 class SilentBanner extends PureComponent {
   render() {
-    const { children, onClose, primaryAction, secondaryAction, showIcon, status, title, ...others } = this.props;
+    const {
+      children,
+      onClose,
+      primaryAction,
+      primaryActionLabel,
+      secondaryAction,
+      secondaryActionLabel,
+      showIcon,
+      status,
+      title,
+      ...others
+    } = this.props;
 
     const hasActions = Boolean(primaryAction || secondaryAction);
     const IconToRender = iconMap[status];
@@ -97,10 +108,10 @@ class SilentBanner extends PureComponent {
               <ButtonGroup display="flex" justifyContent="flex-end" marginTop={4}>
                 {secondaryAction && (
                   <Button level="link" size="small">
-                    Secondary action
+                    {secondaryActionLabel}
                   </Button>
                 )}
-                {primaryAction && <Button size="small">Primary action</Button>}
+                {primaryAction && <Button size="small">{primaryActionLabel}</Button>}
               </ButtonGroup>
             )}
           </Box>
@@ -122,8 +133,12 @@ SilentBanner.propTypes = {
   onClose: PropTypes.func,
   /** Callback function that is fired when the primary action button is clicked. */
   primaryAction: PropTypes.func,
+  /** The primary action button label */
+  primaryActionLabel: PropTypes.node,
   /** Callback function that is fired when the secondary action button is clicked. */
   secondaryAction: PropTypes.func,
+  /** The secondary action button label */
+  secondaryActionLabel: PropTypes.node,
   /** If true, an icon will show up depending on the status type */
   showIcon: PropTypes.bool,
   /** A status type to determine color and icon */

--- a/src/components/silentBanner/SilentBanner.js
+++ b/src/components/silentBanner/SilentBanner.js
@@ -50,18 +50,7 @@ const iconTintMap = {
 
 class SilentBanner extends PureComponent {
   render() {
-    const {
-      children,
-      onClose,
-      primaryAction,
-      primaryActionLabel,
-      secondaryAction,
-      secondaryActionLabel,
-      showIcon,
-      status,
-      title,
-      ...others
-    } = this.props;
+    const { children, onClose, primaryAction, secondaryAction, showIcon, status, title, ...others } = this.props;
 
     const hasActions = Boolean(primaryAction || secondaryAction);
     const IconToRender = iconMap[status];
@@ -108,10 +97,10 @@ class SilentBanner extends PureComponent {
               <ButtonGroup display="flex" justifyContent="flex-end" marginTop={4}>
                 {secondaryAction && (
                   <Button level="link" size="small">
-                    {secondaryActionLabel}
+                    Secondary action
                   </Button>
                 )}
-                {primaryAction && <Button size="small">{primaryActionLabel}</Button>}
+                {primaryAction && <Button size="small">Primary action</Button>}
               </ButtonGroup>
             )}
           </Box>
@@ -133,12 +122,8 @@ SilentBanner.propTypes = {
   onClose: PropTypes.func,
   /** Callback function that is fired when the primary action button is clicked. */
   primaryAction: PropTypes.func,
-  /** The primary action button label */
-  primaryActionLabel: PropTypes.node,
   /** Callback function that is fired when the secondary action button is clicked. */
   secondaryAction: PropTypes.func,
-  /** The secondary action button label */
-  secondaryActionLabel: PropTypes.node,
   /** If true, an icon will show up depending on the status type */
   showIcon: PropTypes.bool,
   /** A status type to determine color and icon */

--- a/src/components/silentBanner/SilentBanner.js
+++ b/src/components/silentBanner/SilentBanner.js
@@ -95,12 +95,8 @@ class SilentBanner extends PureComponent {
             {children && <TextBody color="teal">{children}</TextBody>}
             {hasActions && (
               <ButtonGroup display="flex" justifyContent="flex-end" marginTop={4}>
-                {secondaryAction && (
-                  <Button level="link" size="small">
-                    Secondary action
-                  </Button>
-                )}
-                {primaryAction && <Button size="small">Primary action</Button>}
+                {secondaryAction && <Button level="link" size="small" {...secondaryAction} />}
+                {primaryAction && <Button size="small" {...primaryAction} />}
               </ButtonGroup>
             )}
           </Box>
@@ -120,10 +116,10 @@ SilentBanner.propTypes = {
   children: PropTypes.node,
   /** Callback function that is fired when the close button of the banner is clicked. */
   onClose: PropTypes.func,
-  /** Callback function that is fired when the primary action button is clicked. */
-  primaryAction: PropTypes.func,
-  /** Callback function that is fired when the secondary action button is clicked. */
-  secondaryAction: PropTypes.func,
+  /** Object containing the props of the primary action (a Button). */
+  primaryAction: PropTypes.object,
+  /** Object containing the props of the secondary action (a Button, with level prop set to 'link'). */
+  secondaryAction: PropTypes.object,
   /** If true, an icon will show up depending on the status type */
   showIcon: PropTypes.bool,
   /** A status type to determine color and icon */

--- a/src/components/silentBanner/index.js
+++ b/src/components/silentBanner/index.js
@@ -1,0 +1,4 @@
+import SilentBanner from './SilentBanner';
+
+export default SilentBanner;
+export { SilentBanner };

--- a/src/components/silentBanner/silentBanner.stories.js
+++ b/src/components/silentBanner/silentBanner.stories.js
@@ -40,9 +40,7 @@ export const dismissable = () => (
 export const withActions = () => (
   <SilentBanner
     primaryAction={() => console.log('primaryAction click handler')}
-    primaryActionLabel={text('Primary action label', 'Primary action')}
     secondaryAction={() => console.log('secondaryAction click handler')}
-    secondaryActionLabel={text('Secondary action label', 'Secondary action')}
     title={text('Title', 'I am the title of this message')}
   >
     Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link> tempor
@@ -65,9 +63,7 @@ export const fullOption = () => (
   <SilentBanner
     onClose={() => console.log('onClose click handler')}
     primaryAction={() => console.log('primaryAction click handler')}
-    primaryActionLabel={text('Primary action label', 'Primary action')}
     secondaryAction={() => console.log('secondaryAction click handler')}
-    secondaryActionLabel={text('Secondary action label', 'Secondary action')}
     showIcon={boolean('Show icon', true)}
     status={select('Status', statusValues, 'success')}
     title={text('Title', 'I am the title of this message')}

--- a/src/components/silentBanner/silentBanner.stories.js
+++ b/src/components/silentBanner/silentBanner.stories.js
@@ -40,9 +40,9 @@ export const dismissable = () => (
 export const withActions = () => (
   <SilentBanner
     primaryAction={() => console.log('primaryAction click handler')}
-    primaryActionLabel={text('Primary action label')}
+    primaryActionLabel={text('Primary action label', 'Primary action')}
     secondaryAction={() => console.log('secondaryAction click handler')}
-    secondaryActionLabel={text('Secondary action label')}
+    secondaryActionLabel={text('Secondary action label', 'Secondary action')}
     title={text('Title', 'I am the title of this message')}
   >
     Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link> tempor
@@ -65,9 +65,9 @@ export const fullOption = () => (
   <SilentBanner
     onClose={() => console.log('onClose click handler')}
     primaryAction={() => console.log('primaryAction click handler')}
-    primaryActionLabel={text('Primary action label')}
+    primaryActionLabel={text('Primary action label', 'Primary action')}
     secondaryAction={() => console.log('secondaryAction click handler')}
-    secondaryActionLabel={text('Secondary action label')}
+    secondaryActionLabel={text('Secondary action label', 'Secondary action')}
     showIcon={boolean('Show icon', true)}
     status={select('Status', statusValues, 'success')}
     title={text('Title', 'I am the title of this message')}

--- a/src/components/silentBanner/silentBanner.stories.js
+++ b/src/components/silentBanner/silentBanner.stories.js
@@ -36,7 +36,9 @@ export const dismissable = () => (
 export const withActions = () => (
   <SilentBanner
     primaryAction={() => console.log('primaryAction click handler')}
+    primaryActionLabel={text('Primary action label')}
     secondaryAction={() => console.log('secondaryAction click handler')}
+    secondaryActionLabel={text('Secondary action label')}
     title={text('Title', 'I am the title of this message')}
   >
     Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link> tempor
@@ -59,7 +61,9 @@ export const fullOption = () => (
   <SilentBanner
     onClose={() => console.log('onClose click handler')}
     primaryAction={() => console.log('primaryAction click handler')}
+    primaryActionLabel={text('Primary action label')}
     secondaryAction={() => console.log('secondaryAction click handler')}
+    secondaryActionLabel={text('Secondary action label')}
     showIcon={boolean('Show icon', true)}
     status={select('Status', statusValues, 'success')}
     title={text('Title', 'I am the title of this message')}

--- a/src/components/silentBanner/silentBanner.stories.js
+++ b/src/components/silentBanner/silentBanner.stories.js
@@ -10,6 +10,10 @@ export default {
   title: addStoryInGroup(MID_LEVEL_BLOCKS, 'Silent banners'),
 
   parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/LHH25GN90ljQaBEUNMsdJn/Desktop-components?node-id=1225%3A0',
+    },
     info: {
       propTables: [SilentBanner],
     },

--- a/src/components/silentBanner/silentBanner.stories.js
+++ b/src/components/silentBanner/silentBanner.stories.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import { addStoryInGroup, MID_LEVEL_BLOCKS } from '../../../.storybook/utils';
+import { boolean, select, text } from '@storybook/addon-knobs/react';
+import SilentBanner from './SilentBanner';
+import Link from '../link';
+
+const statusValues = ['info', 'error', 'success', 'warning'];
+
+export default {
+  title: addStoryInGroup(MID_LEVEL_BLOCKS, 'Silent banners'),
+
+  parameters: {
+    info: {
+      propTables: [SilentBanner],
+    },
+  },
+};
+
+export const basic = () => (
+  <SilentBanner title={text('Title', 'I am the title of this message')}>
+    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link> tempor
+    invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+  </SilentBanner>
+);
+
+export const dismissable = () => (
+  <SilentBanner
+    onClose={() => console.log('onClose click handler')}
+    title={text('Title', 'I am the title of this message')}
+  >
+    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link> tempor
+    invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+  </SilentBanner>
+);
+
+export const withActions = () => (
+  <SilentBanner
+    primaryAction={() => console.log('primaryAction click handler')}
+    secondaryAction={() => console.log('secondaryAction click handler')}
+    title={text('Title', 'I am the title of this message')}
+  >
+    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link> tempor
+    invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+  </SilentBanner>
+);
+
+export const withStatus = () => (
+  <SilentBanner
+    showIcon={boolean('Show icon', false)}
+    status={select('Status', statusValues, 'success')}
+    title={text('Title', 'I am the title of this message')}
+  >
+    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link> tempor
+    invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+  </SilentBanner>
+);
+
+export const fullOption = () => (
+  <SilentBanner
+    onClose={() => console.log('onClose click handler')}
+    primaryAction={() => console.log('primaryAction click handler')}
+    secondaryAction={() => console.log('secondaryAction click handler')}
+    showIcon={boolean('Show icon', true)}
+    status={select('Status', statusValues, 'success')}
+    title={text('Title', 'I am the title of this message')}
+  >
+    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link> tempor
+    invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+  </SilentBanner>
+);

--- a/src/components/silentBanner/silentBanner.stories.js
+++ b/src/components/silentBanner/silentBanner.stories.js
@@ -39,8 +39,14 @@ export const dismissable = () => (
 
 export const withActions = () => (
   <SilentBanner
-    primaryAction={() => console.log('primaryAction click handler')}
-    secondaryAction={() => console.log('secondaryAction click handler')}
+    primaryAction={{
+      label: text('Primary action label', 'Primary action'),
+      onClick: () => console.log('primaryAction.onClick'),
+    }}
+    secondaryAction={{
+      label: text('Secondary action label', 'Secondary action'),
+      onClick: () => console.log('secondaryAction.onClick'),
+    }}
     title={text('Title', 'I am the title of this message')}
   >
     Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link> tempor
@@ -62,8 +68,14 @@ export const withStatus = () => (
 export const fullOption = () => (
   <SilentBanner
     onClose={() => console.log('onClose click handler')}
-    primaryAction={() => console.log('primaryAction click handler')}
-    secondaryAction={() => console.log('secondaryAction click handler')}
+    primaryAction={{
+      label: text('Primary action label', 'Primary action'),
+      onClick: () => console.log('primaryAction.onClick'),
+    }}
+    secondaryAction={{
+      label: text('Secondary action label', 'Secondary action'),
+      onClick: () => console.log('secondaryAction.onClick'),
+    }}
     showIcon={boolean('Show icon', true)}
     status={select('Status', statusValues, 'success')}
     title={text('Title', 'I am the title of this message')}

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,7 @@ import { RadioButton, RadioGroup } from './components/radio';
 import ScrollContainer from './components/scrollContainer';
 import Section from './components/section';
 import Select, { AsyncSelect } from './components/select';
+import SilentBanner from './components/silentBanner';
 import { Island, IslandGroup } from './components/island';
 import SplitButton from './components/splitButton';
 import StatusBullet from './components/statusBullet';
@@ -153,6 +154,7 @@ export {
   ScrollContainer,
   Section,
   Select,
+  SilentBanner,
   SplitButton,
   StatusBullet,
   StatusLabel,


### PR DESCRIPTION
### Description

This PR adds the new `SilentBanner` component.
**Small disclaimer:** the name of this new component is temporary and will be changed.

#### Basic
<img width="576" alt="Screenshot 2020-05-18 16 38 55" src="https://user-images.githubusercontent.com/5336831/82226016-3d089100-9926-11ea-8b56-cf88d2a35c65.png">

#### Dismissable
<img width="577" alt="Screenshot 2020-05-18 16 39 20" src="https://user-images.githubusercontent.com/5336831/82226062-4c87da00-9926-11ea-9a3d-0a5f4373f986.png">

#### With actions
<img width="575" alt="Screenshot 2020-05-18 16 39 31" src="https://user-images.githubusercontent.com/5336831/82226088-56a9d880-9926-11ea-97f2-b770764af261.png">

#### With status
<img width="578" alt="Screenshot 2020-05-18 16 39 43" src="https://user-images.githubusercontent.com/5336831/82226174-73461080-9926-11ea-978e-ae2140a72aa9.png">

#### With status and icon
<img width="575" alt="Screenshot 2020-05-18 16 42 28" src="https://user-images.githubusercontent.com/5336831/82226307-a25c8200-9926-11ea-9db7-8a36d9fef867.png">

#### Full option
<img width="577" alt="Screenshot 2020-05-18 16 39 53" src="https://user-images.githubusercontent.com/5336831/82226189-78a35b00-9926-11ea-948e-e720e75a915c.png">

### Breaking changes

None.
