### PR TITLE
Update teal dark & darkest color values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Teal color`: changed the hex values of our `Teal dark & darkest` color variants. ([@driesd](https://github.com/driesd) in [#1111])
+
 ### Deprecated
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/cli": "^7.8.3",
     "@babel/runtime": "^7.9.6",
     "@teamleader/ui-animations": "^0.0.3",
-    "@teamleader/ui-colors": "^0.1.0",
+    "@teamleader/ui-colors": "^0.3.0",
     "@teamleader/ui-icons": "^0.2.29",
     "@teamleader/ui-illustrations": "^0.0.32",
     "@teamleader/ui-typography": "^0.2.3",

--- a/src/constants/colors.js
+++ b/src/constants/colors.js
@@ -40,8 +40,8 @@ export const COLOR = {
     LIGHTEST: '#f0f5fc',
     LIGHT: '#c1cede',
     NORMAL: '#64788f',
-    DARK: '#344b63',
-    DARKEST: '#2a3b4d',
+    DARK: '#2a3b4d',
+    DARKEST: '#1a1c20',
   },
   VIOLET: {
     LIGHTEST: '#f7f7ff',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1888,10 +1888,10 @@
   resolved "https://registry.yarnpkg.com/@teamleader/ui-animations/-/ui-animations-0.0.3.tgz#e80d91bff37cdf96e928c008cfca0add5c86d375"
   integrity sha512-gM+8TvZekcNcKWV3iZNXOXbLqpJytg33nYXcx7WgVQINbheeiPIv8Cj8XQZhHjwKP/TQJcNgiCTBjjo/dUu/EA==
 
-"@teamleader/ui-colors@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@teamleader/ui-colors/-/ui-colors-0.1.0.tgz#78b55444659f9f735a6bc2aa5070bce51f41e9bd"
-  integrity sha512-sAofd7VtphJXfYHw0QY94tPKtlb78/qBOySkcq9g0CUWn3AUJtetNs+H+hFwqiLdod/h0Pz1m1EqKpiZdX9/vg==
+"@teamleader/ui-colors@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@teamleader/ui-colors/-/ui-colors-0.3.0.tgz#beafe49d9389230b01310c3e4bd90ed7985ae6c6"
+  integrity sha512-TECQkD2Gjp8AvHKL3T+v6VFM95K8rKGE976TtLU8MuhCgUZWbllh9/8LY7+hoIqKVmxIRLbLsj5VFt154LHI1w==
 
 "@teamleader/ui-icons@^0.2.29":
   version "0.2.29"


### PR DESCRIPTION
### Description

This PR updates the `Teal` `dark & darkest` color to its new values.

#### Teal color palette
![Screenshot 2020-05-19 11 54 23](https://user-images.githubusercontent.com/5336831/82326116-a519ae80-99dc-11ea-92e5-fca46aa92919.png)

### Breaking changes

None.
