### PR TITLE
Silent banner/enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `SilentBanner`: added a `white background` and `decreased left padding` when it has a color status. ([@driesd](https://github.com/driesd) in [#1112])
+
 ### Deprecated
 
 ### Removed

--- a/src/components/silentBanner/SilentBanner.js
+++ b/src/components/silentBanner/SilentBanner.js
@@ -74,6 +74,8 @@ class SilentBanner extends PureComponent {
           </Box>
         )}
         <Box
+          backgroundColor="neutral"
+          backgroundTint="lightest"
           borderColor="neutral"
           borderTint="normal"
           borderLeftWidth={status ? 0 : 1}

--- a/src/components/silentBanner/SilentBanner.js
+++ b/src/components/silentBanner/SilentBanner.js
@@ -88,7 +88,7 @@ class SilentBanner extends PureComponent {
           borderTopLeftRadius={status ? 'square' : 'rounded'}
           display="flex"
         >
-          <Box padding={4}>
+          <Box paddingLeft={status ? 3 : 4} paddingRight={4} paddingVertical={4}>
             {title && (
               <Heading3 color="teal" marginBottom={2}>
                 {title}


### PR DESCRIPTION
### Description

This PR:

- adds a white background to the content box
- use left padding of 12px instead of 18 when the banner has a status bar (for better alignment with other components)

#### Screenshot before this PR
![Screenshot 2020-05-19 15 43 33](https://user-images.githubusercontent.com/5336831/82333834-840a8b00-99e7-11ea-95b1-a58558c68b8c.png)

#### Screenshot after this PR
![Screenshot 2020-05-19 15 42 00](https://user-images.githubusercontent.com/5336831/82333667-50c7fc00-99e7-11ea-80e0-677f20d5031f.png)

### Breaking changes

None.
