### PR TITLE
Container: use a larger breakpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Container`: changed breakpoint to a large screen (1440px) to avoid horizontal scrollbars. ([@driesd](https://github.com/driesd) in [#1116])
+
 ### Deprecated
 
 ### Removed

--- a/src/components/container/theme.css
+++ b/src/components/container/theme.css
@@ -11,7 +11,7 @@
   max-width: 1056px;
 }
 
-@media (--larger-than-lg-viewport) {
+@media (--larger-than-xl-viewport) {
   .container:not(.is-fixed) {
     padding-left: var(--spacer-biggest);
     padding-right: var(--spacer-biggest);


### PR DESCRIPTION
### Description

This changes our `Container` breakpoint to a large screen (1440px) to avoid horizontal scrollbars.

### Breaking changes

None.
