### PR TITLE
Release 0.43.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Changed
 
-- `Container`: changed breakpoint to a large screen (1440px) to avoid horizontal scrollbars. ([@driesd](https://github.com/driesd) in [#1116])
-
 ### Deprecated
 
 ### Removed
@@ -13,6 +11,17 @@
 ### Fixed
 
 ### Dependency updates
+
+## [0.43.7] - 2020-05-25
+
+### Changed
+
+- `Container`: changed breakpoint to a large screen (1440px) to avoid horizontal scrollbars. ([@driesd](https://github.com/driesd) in [#1116])
+
+### Dependency updates
+
+- `react-select` from `3.1.0` to `3.0.4` ([@driesd](https://github.com/driesd) in [#1120])
+- `moment` from `2.25.3` to `2.26.0`
 
 ## [0.43.6] - 2020-05-19
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.43.6",
+  "version": "0.43.7",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Changed

- `Container`: changed breakpoint to a large screen (1440px) to avoid horizontal scrollbars. ([@driesd](https://github.com/driesd) in [#1116])

### Dependency updates

- `react-select` from `3.1.0` to `3.0.4` ([@driesd](https://github.com/driesd) in [#1120])
- `moment` from `2.25.3` to `2.26.0`
