### PR TITLE
LabelValuePair: fix right alignment for multiline values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixed
 
-- `LabelValuePair`: fixed right alignment for multiline text. ([@driesd](https://github.com/driesd) in [#1116])
+- `LabelValuePair`: fixed right alignment for multiline text. ([@driesd](https://github.com/driesd) in [#1122])
 
 ### Dependency updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `LabelValuePair`: fixed right alignment for multiline text. ([@driesd](https://github.com/driesd) in [#1116])
+
 ### Dependency updates
 
 ## [0.43.7] - 2020-05-25

--- a/src/components/labelValuePair/LabelValuePair.js
+++ b/src/components/labelValuePair/LabelValuePair.js
@@ -19,6 +19,7 @@ class LabelValuePair extends PureComponent {
           if (isComponentOfType(Value, child)) {
             return React.cloneElement(child, {
               justifyContent: alignValue === 'left' ? 'flex-start' : 'flex-end',
+              textAlign: alignValue,
               ...child.props,
             });
           }


### PR DESCRIPTION
### Description

This PR fixes `right alignment` for `multiline values` in our `LabelValuePair`.

#### Screenshot before this PR
![Screenshot 2020-05-25 14 48 52](https://user-images.githubusercontent.com/5336831/82814440-7cd7f700-9e97-11ea-88e2-febaf094def5.png)

![Screenshot 2020-05-25 14 48 30](https://user-images.githubusercontent.com/5336831/82814451-806b7e00-9e97-11ea-8b2e-f3bd4a1d5ab6.png)

#### Screenshot after this PR
![Screenshot 2020-05-25 14 47 49](https://user-images.githubusercontent.com/5336831/82814507-98db9880-9e97-11ea-85dd-43043bfc6f6d.png)

### Breaking changes

None.
