### PR TITLE
Toast: use teal dark as background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Toast`: changed to have a `teal dark background` instead of teal darkest. ([@driesd](https://github.com/driesd) in [#1131])
+
 ### Deprecated
 
 ### Removed

--- a/src/components/toast/theme.css
+++ b/src/components/toast/theme.css
@@ -4,7 +4,7 @@
 @import '@teamleader/ui-utilities';
 
 :root {
-  --toast-background-color: var(--color-teal-darkest);
+  --toast-background-color: var(--color-teal-dark);
   --toast-border-radius: calc(0.4 * var(--unit));
   --toast-min-width: calc(18 * var(--unit));
   --toast-max-width: calc(37.2 * var(--unit));


### PR DESCRIPTION
### Description

This PR changes our `Toast` component to have a teal `dark` background instead of teal `darkest`.

#### Screenshot before this PR
![Screenshot 2020-05-27 08 12 11](https://user-images.githubusercontent.com/5336831/82984153-d3594880-9ff1-11ea-9da7-a08a31caf2ef.png)

#### Screenshot after this PR
![Screenshot 2020-05-27 08 06 18](https://user-images.githubusercontent.com/5336831/82983943-6776e000-9ff1-11ea-9519-e0380cdc4116.png)

### Breaking changes

None.
