### PR TITLE
LabelValuePair: only add vertical padding when displaying label & value inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `LabelValuePair`: only add vertical padding when label and value are displayed inline. ([@driesd](https://github.com/driesd) in [#1146])
+
 ### Deprecated
 
 ### Removed

--- a/src/components/labelValuePair/Label.js
+++ b/src/components/labelValuePair/Label.js
@@ -13,7 +13,7 @@ class Label extends PureComponent {
         marginBottom={inline ? 0 : 1}
         marginRight={inline ? 2 : 0}
         maxLines={2}
-        paddingVertical={1}
+        paddingVertical={inline ? 1 : 0}
         {...others}
       >
         {children}

--- a/src/components/labelValuePair/LabelValuePair.js
+++ b/src/components/labelValuePair/LabelValuePair.js
@@ -19,6 +19,7 @@ class LabelValuePair extends PureComponent {
           if (isComponentOfType(Value, child)) {
             return React.cloneElement(child, {
               justifyContent: alignValue === 'left' ? 'flex-start' : 'flex-end',
+              paddingVertical: inline ? 1 : 0,
               textAlign: alignValue,
               ...child.props,
             });

--- a/src/components/labelValuePair/Value.js
+++ b/src/components/labelValuePair/Value.js
@@ -7,7 +7,7 @@ class Value extends PureComponent {
     const { children, ...others } = this.props;
 
     return (
-      <Box display="flex" flex={1} overflow="hidden" paddingVertical={1} {...others}>
+      <Box display="flex" flex={1} overflow="hidden" {...others}>
         {children}
       </Box>
     );


### PR DESCRIPTION
### Description

This PR reduces the spacing between stacked label/value pairs by only adding vertical padding when displayed inline.

#### Screenshot before this PR
![Screenshot 2020-06-02 16 03 16](https://user-images.githubusercontent.com/5336831/83530051-7ecf3500-a4eb-11ea-9072-6cb1203c9162.png)

#### Screenshot after this PR
![Screenshot 2020-06-02 16 01 29](https://user-images.githubusercontent.com/5336831/83530072-87277000-a4eb-11ea-88f9-c762761c2324.png)

### Breaking changes

None.
