### PR TITLE
Tooltip: add `zIndex` prop and replace CSS rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Tooltip`: added `zIndex` number prop (default 700). ([@driesd](https://github.com/driesd) in [#1148])
+
 ### Changed
 
 - `LabelValuePair`: only add vertical padding when label and value are displayed inline. ([@driesd](https://github.com/driesd) in [#1146])

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -152,6 +152,7 @@ const Tooltip = (ComposedComponent) => {
         tooltipIcon,
         tooltipSize,
         tooltipShowDelay,
+        zIndex,
         ...other
       } = this.props;
 
@@ -201,7 +202,7 @@ const Tooltip = (ComposedComponent) => {
               );
 
               return (
-                <div className={classNames} data-teamleader-ui="tooltip" style={{ top, left }}>
+                <div className={classNames} data-teamleader-ui="tooltip" style={{ top, left, zIndex }}>
                   <Box className={theme['inner']} {...SIZES[tooltipSize]}>
                     {tooltipIcon && <div className={theme['icon']}>{tooltipIcon}</div>}
                     <div className={theme['text']}>{tooltip}</div>
@@ -232,6 +233,8 @@ const Tooltip = (ComposedComponent) => {
     tooltipSize: PropTypes.oneOf(Object.keys(SIZES)),
     documentObject: PropTypes.object.isRequired,
     tooltipShowDelay: PropTypes.number,
+    /** The z-index of the Tooltip */
+    zIndex: PropTypes.number,
   };
 
   TooltippedComponent.defaultProps = {
@@ -243,6 +246,7 @@ const Tooltip = (ComposedComponent) => {
     tooltipShowOnClick: false,
     tooltipSize: 'medium',
     tooltipShowDelay: 100,
+    zIndex: 700,
   };
 
   return DocumentObjectProvider((props) => {

--- a/src/components/tooltip/theme.css
+++ b/src/components/tooltip/theme.css
@@ -11,7 +11,6 @@
   --tooltip-medium-max-width: calc(24 * var(--unit));
   --tooltip-large-max-width: calc(36 * var(--unit));
   --tooltip-animation-duration: 200ms;
-  --tooltip-z-index: 700;
 }
 
 .tooltip {
@@ -27,7 +26,6 @@
   text-align: left;
   transform-origin: top left;
   transition: cubic-bezier(0.4, 0, 0.2, 1) var(--tooltip-animation-duration) transform;
-  z-index: var(--tooltip-z-index);
 
   &::after {
     content: '';


### PR DESCRIPTION
### Description

This PR adds a `zIndex` prop (default 700) to our `Tooltip`.

### Breaking changes

None.
