### PR TITLE
Release 0.44.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,7 @@
 
 ### Added
 
-- `Tooltip`: added `zIndex` number prop (default 700). ([@driesd](https://github.com/driesd) in [#1148])
-
 ### Changed
-
-- `LabelValuePair`: only add vertical padding when label and value are displayed inline. ([@driesd](https://github.com/driesd) in [#1146])
 
 ### Deprecated
 
@@ -15,6 +11,20 @@
 ### Fixed
 
 ### Dependency updates
+
+## [0.44.2] - 2020-06-03
+
+### Added
+
+- `Tooltip`: added `zIndex` number prop (default 700). ([@driesd](https://github.com/driesd) in [#1148])
+
+### Changed
+
+- `LabelValuePair`: only add vertical padding when label and value are displayed inline. ([@driesd](https://github.com/driesd) in [#1146])
+
+### Dependency updates
+
+- `postcss` from `7.0.31` to `7.0.32`
 
 ## [0.44.1] - 2020-06-02
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.44.1",
+  "version": "0.44.2",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Added

- `Tooltip`: added `zIndex` number prop (default 700). ([@driesd](https://github.com/driesd) in [#1148])

### Changed

- `LabelValuePair`: only add vertical padding when label and value are displayed inline. ([@driesd](https://github.com/driesd) in [#1146])

### Dependency updates

- `postcss` from `7.0.31` to `7.0.32`

