### PR TITLE
DatePickerInput and DatePicker improvements and alignment fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `DatePicker`, `DatePickerInput`: Allow sizing the input and picker independently, fix alignment when using the `MonthPicker`. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1156](https://github.com/teamleadercrm/ui/pull/1156))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -86,11 +86,13 @@ class DatePickerInput extends PureComponent {
       locale,
       popoverProps,
       size,
+      inputSize,
+      datePickerSize,
       ...others
     } = this.props;
     const { isPopoverActive, popoverAnchorEl, selectedDate } = this.state;
     const boxProps = pickBoxProps(others);
-    const datePickerClassNames = cx(theme['date-picker-input'], theme[`is-${size}`]);
+    const datePickerClassNames = cx(theme['date-picker-input'], theme[`is-${datePickerSize || size}`]);
 
     return (
       <Box className={className} {...boxProps}>
@@ -98,7 +100,7 @@ class DatePickerInput extends PureComponent {
           inverse={inverse}
           onFocus={this.handleInputFocus}
           prefix={this.renderIcon()}
-          size={size}
+          size={inputSize || size}
           value={this.getFormattedDate()}
           width="120px"
           noInputStyling={dayPickerProps && dayPickerProps.withMonthPicker}
@@ -125,6 +127,7 @@ class DatePickerInput extends PureComponent {
               month={selectedDate}
               onChange={this.handleDatePickerDateChange}
               selectedDate={selectedDate}
+              size={datePickerSize || size}
               {...dayPickerProps}
             />
           </Box>
@@ -157,6 +160,10 @@ DatePickerInput.propTypes = {
   selectedDate: PropTypes.instanceOf(Date),
   /** Size of the Input & DatePicker components. */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
+  /** Overridable size of the Input component. */
+  inputSize: PropTypes.oneOf(['small', 'medium', 'large']),
+  /** Overridable size of the DatePicker component. */
+  datePickerSize: PropTypes.oneOf(['small', 'medium', 'large']),
 };
 
 DatePickerInput.defaultProps = {

--- a/src/components/datepicker/MonthPicker.js
+++ b/src/components/datepicker/MonthPicker.js
@@ -123,7 +123,7 @@ const MonthPicker = ({ size, ...props }) => {
     return <MonthPickerUnary {...props} />;
   }
 
-  return <MonthPickerSplit {...props} />;
+  return <MonthPickerSplit size={size} {...props} />;
 };
 
 MonthPicker.propTypes = {

--- a/src/components/datepicker/MonthPicker.js
+++ b/src/components/datepicker/MonthPicker.js
@@ -128,13 +128,13 @@ const MonthPicker = ({ size, ...props }) => {
 
 MonthPicker.propTypes = {
   /** Current date */
-  date: PropTypes.bool,
+  date: PropTypes.instanceOf(Date),
   /** Callback function that is fired when the month has changed. */
   onChange: PropTypes.func,
   /** The set locale */
   locale: PropTypes.string,
   /** The localeUtils from the DatePicker */
-  localeUtils: PropTypes.instanceOf(Date),
+  localeUtils: PropTypes.object,
   /** Size of the MonthPicker component. */
   size: PropTypes.oneOf(['smallest', 'small', 'medium', 'large']),
 };

--- a/src/components/datepicker/MonthPicker.js
+++ b/src/components/datepicker/MonthPicker.js
@@ -56,7 +56,6 @@ const MonthPickerUnary = ({ date, locale, localeUtils, onChange }) => {
           onChange={handleChangeMonth}
           width={112}
           size="small"
-          isSearchable={false}
         />
       </Box>
     </Box>
@@ -103,7 +102,6 @@ const MonthPickerSplit = ({ date, locale, localeUtils, onChange, size }) => {
           onChange={handleChangeMonth}
           width={size === 'small' ? 88 : 112}
           size="small"
-          isSearchable={false}
         />
         <NumericInput
           value={`${yearInput}`}

--- a/src/components/datepicker/NavigationBar.js
+++ b/src/components/datepicker/NavigationBar.js
@@ -34,11 +34,13 @@ class NavigationBar extends PureComponent {
         justifyContent="space-between"
       >
         <IconButton
+          size={size === 'large' ? 'medium' : 'small'}
           icon={size === 'large' ? <IconArrowLeftMediumOutline /> : <IconArrowLeftSmallOutline />}
           onClick={this.handlePreviousClick}
           title={previousMonthButtonLabel}
         />
         <IconButton
+          size={size === 'large' ? 'medium' : 'small'}
           icon={size === 'large' ? <IconArrowRightMediumOutline /> : <IconArrowRightSmallOutline />}
           onClick={this.handleNextClick}
           title={nextMonthButtonLabel}

--- a/src/components/datepicker/NavigationBar.js
+++ b/src/components/datepicker/NavigationBar.js
@@ -29,7 +29,7 @@ class NavigationBar extends PureComponent {
 
     return (
       <Box
-        className={withMonthPicker ? cx(theme['navBar-with-month-picker'], className) : className}
+        className={cx(className, { [theme['navBar-with-month-picker']]: withMonthPicker })}
         display="flex"
         justifyContent="space-between"
       >

--- a/src/components/datepicker/datePicker.stories.js
+++ b/src/components/datepicker/datePicker.stories.js
@@ -20,6 +20,12 @@ const languages = [
   'sv-SE',
 ];
 const sizes = ['small', 'medium', 'large'];
+const optionalSizes = {
+  small: 'small',
+  medium: 'medium',
+  large: 'large',
+  none: null,
+};
 
 const customFormatDate = (date, locale) => {
   return DateTime.fromJSDate(date).setLocale(locale).toLocaleString(DateTime.DATETIME_HUGE);
@@ -113,6 +119,8 @@ export const inputSingleDate = () => {
       onChange={handleOnChange}
       selectedDate={preSelectedDate}
       size={select('Size', sizes, 'medium')}
+      inputSize={select('Input size', optionalSizes, null)}
+      datePickerSize={select('Date picker size', optionalSizes, null)}
     />
   );
 };

--- a/src/components/datepicker/theme.css
+++ b/src/components/datepicker/theme.css
@@ -63,15 +63,12 @@
 .navBar {
   position: absolute;
   left: 0;
-  top: 0;
-  right: 0;
-}
-
-.navBar-with-month-picker {
-  position: absolute;
-  left: 0;
   top: 6px;
   right: 0;
+
+  &-with-month-picker {
+    top: 12px;
+  }
 }
 
 .caption {
@@ -542,6 +539,11 @@
 
   .navBar {
     padding: 15px;
+    top: 0;
+
+    &-with-month-picker {
+      top: 6px;
+    }
   }
 
   .weekday {


### PR DESCRIPTION
### Description

* `DatePickerInput`: Added 2 new props: `inputSize` and `datePickerSize`
* `DatePicker`: Allow typing in the month selector when `withMonthPicker = true`
* `DatePicker`: Fixed alignment for the `medium` when `withMonthPicker = true` and `showWeekDays = false`

#### Screenshot before this PR

![Screenshot 2020-06-11 at 17 55 29](https://user-images.githubusercontent.com/10011712/84408757-d157d200-ac0c-11ea-9a11-d1e1f779e2d1.png)

#### Screenshot after this PR

![Screenshot 2020-06-11 at 17 55 48](https://user-images.githubusercontent.com/10011712/84408773-d74db300-ac0c-11ea-8d79-bcb1ca487ebc.png)


### Breaking changes

- None