### PR TITLE
Scrollable tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `TabGroup`: added scrollable functionality when tabs start to overflow their container. ([@driesd](https://github.com/driesd) in [#1160])
+
 ### Changed
 
 ### Deprecated

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "react-input-mask": "^2.0.4",
     "react-resize-detector": "^4.2.0",
     "react-select": "3.0.4",
-    "react-transition-group": "^4.2.1"
+    "react-transition-group": "^4.2.1",
+    "smoothscroll-polyfill": "^0.4.4"
   },
   "devDependencies": {
     "@babel/core": "^7.10.0",

--- a/src/components/tab/TabGroup.js
+++ b/src/components/tab/TabGroup.js
@@ -1,5 +1,6 @@
 import React, { createRef, PureComponent } from 'react';
 import ReactResizeDetector from 'react-resize-detector';
+import smoothScroll from 'smoothscroll-polyfill';
 import PropTypes from 'prop-types';
 import Box from '../box';
 import IconButton from '../iconButton';
@@ -18,6 +19,7 @@ class TabGroup extends PureComponent {
   };
 
   componentDidMount() {
+    smoothScroll.polyfill();
     this.scrollContainerRef.current.boxNode.current.addEventListener('scroll', this.handleScroll);
   }
 

--- a/src/components/tab/TabGroup.js
+++ b/src/components/tab/TabGroup.js
@@ -5,14 +5,26 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 class TabGroup extends PureComponent {
+  scrollContainerRef = createRef();
+
   render() {
     const { children, className, inverted, size, ...others } = this.props;
 
     const classNames = cx(theme['tab-group'], className);
 
     return (
-      <Box data-teamleader-ui="tab-group" className={classNames} {...others}>
-        {React.Children.map(children, (child) => React.cloneElement(child, { size }))}
+      <Box
+        backgroundColor="neutral"
+        backgroundTint="lightest"
+        data-teamleader-ui="tab-group"
+        className={classNames}
+        {...others}
+        display="flex"
+        paddingHorizontal={1}
+      >
+        <Box className={theme['scroll-container']} display="flex" overflowX="scroll" ref={this.scrollContainerRef}>
+          {React.Children.map(children, (child) => React.cloneElement(child, { size, marginHorizontal: 1 }))}
+        </Box>
       </Box>
     );
   }

--- a/src/components/tab/TabGroup.js
+++ b/src/components/tab/TabGroup.js
@@ -1,4 +1,5 @@
-import React, { PureComponent } from 'react';
+import React, { createRef, PureComponent } from 'react';
+import ReactResizeDetector from 'react-resize-detector';
 import PropTypes from 'prop-types';
 import Box from '../box';
 import cx from 'classnames';
@@ -6,6 +7,24 @@ import theme from './theme.css';
 
 class TabGroup extends PureComponent {
   scrollContainerRef = createRef();
+
+  state = {
+    canScrollLeft: false,
+    canScrollRight: false,
+  };
+
+  checkForScrollPosition = () => {
+    const { scrollLeft, scrollWidth, clientWidth } = this.scrollContainerRef.current.boxNode.current;
+
+    this.setState({
+      canScrollLeft: scrollLeft > 0,
+      canScrollRight: scrollLeft !== scrollWidth - clientWidth,
+    });
+  };
+
+  handleResize = () => {
+    this.checkForScrollPosition();
+  };
 
   render() {
     const { children, className, inverted, size, ...others } = this.props;
@@ -25,6 +44,7 @@ class TabGroup extends PureComponent {
         <Box className={theme['scroll-container']} display="flex" overflowX="scroll" ref={this.scrollContainerRef}>
           {React.Children.map(children, (child) => React.cloneElement(child, { size, marginHorizontal: 1 }))}
         </Box>
+        <ReactResizeDetector handleWidth onResize={this.handleResize} />
       </Box>
     );
   }

--- a/src/components/tab/TabGroup.js
+++ b/src/components/tab/TabGroup.js
@@ -2,6 +2,8 @@ import React, { createRef, PureComponent } from 'react';
 import ReactResizeDetector from 'react-resize-detector';
 import PropTypes from 'prop-types';
 import Box from '../box';
+import IconButton from '../iconButton';
+import { IconChevronLeftSmallOutline, IconChevronRightSmallOutline } from '@teamleader/ui-icons';
 import cx from 'classnames';
 import theme from './theme.css';
 
@@ -40,6 +42,7 @@ class TabGroup extends PureComponent {
 
   render() {
     const { children, className, inverted, size, ...others } = this.props;
+    const { canScrollLeft, canScrollRight } = this.state;
 
     const classNames = cx(theme['tab-group'], className);
 
@@ -56,6 +59,16 @@ class TabGroup extends PureComponent {
         <Box className={theme['scroll-container']} display="flex" overflowX="scroll" ref={this.scrollContainerRef}>
           {React.Children.map(children, (child) => React.cloneElement(child, { size, marginHorizontal: 1 }))}
         </Box>
+        {canScrollLeft && (
+          <Box className={theme['scroll-left-button-wrapper']}>
+            <IconButton className={theme['scroll-button']} icon={<IconChevronLeftSmallOutline />} />
+          </Box>
+        )}
+        {canScrollRight && (
+          <Box className={theme['scroll-right-button-wrapper']}>
+            <IconButton className={theme['scroll-button']} icon={<IconChevronRightSmallOutline />} />
+          </Box>
+        )}
         <ReactResizeDetector handleWidth onResize={this.handleResize} />
       </Box>
     );

--- a/src/components/tab/TabGroup.js
+++ b/src/components/tab/TabGroup.js
@@ -13,6 +13,14 @@ class TabGroup extends PureComponent {
     canScrollRight: false,
   };
 
+  componentDidMount() {
+    this.scrollContainerRef.current.boxNode.current.addEventListener('scroll', this.handleScroll);
+  }
+
+  componentWillUnmount() {
+    this.scrollContainerRef.current.boxNode.current.removeEventListener('scroll', this.handleScroll);
+  }
+
   checkForScrollPosition = () => {
     const { scrollLeft, scrollWidth, clientWidth } = this.scrollContainerRef.current.boxNode.current;
 
@@ -23,6 +31,10 @@ class TabGroup extends PureComponent {
   };
 
   handleResize = () => {
+    this.checkForScrollPosition();
+  };
+
+  handleScroll = () => {
     this.checkForScrollPosition();
   };
 

--- a/src/components/tab/TabGroup.js
+++ b/src/components/tab/TabGroup.js
@@ -7,6 +7,8 @@ import { IconChevronLeftSmallOutline, IconChevronRightSmallOutline } from '@team
 import cx from 'classnames';
 import theme from './theme.css';
 
+const SCROLL_DISTANCE = 200;
+
 class TabGroup extends PureComponent {
   scrollContainerRef = createRef();
 
@@ -40,6 +42,10 @@ class TabGroup extends PureComponent {
     this.checkForScrollPosition();
   };
 
+  scrollContainerBy = (distance) => {
+    this.scrollContainerRef.current.boxNode.current.scrollBy({ left: distance, behavior: 'smooth' });
+  };
+
   render() {
     const { children, className, inverted, size, ...others } = this.props;
     const { canScrollLeft, canScrollRight } = this.state;
@@ -61,12 +67,24 @@ class TabGroup extends PureComponent {
         </Box>
         {canScrollLeft && (
           <Box className={theme['scroll-left-button-wrapper']}>
-            <IconButton className={theme['scroll-button']} icon={<IconChevronLeftSmallOutline />} />
+            <IconButton
+              className={theme['scroll-button']}
+              icon={<IconChevronLeftSmallOutline />}
+              onClick={() => {
+                this.scrollContainerBy(-1 * SCROLL_DISTANCE);
+              }}
+            />
           </Box>
         )}
         {canScrollRight && (
           <Box className={theme['scroll-right-button-wrapper']}>
-            <IconButton className={theme['scroll-button']} icon={<IconChevronRightSmallOutline />} />
+            <IconButton
+              className={theme['scroll-button']}
+              icon={<IconChevronRightSmallOutline />}
+              onClick={() => {
+                this.scrollContainerBy(SCROLL_DISTANCE);
+              }}
+            />
           </Box>
         )}
         <ReactResizeDetector handleWidth onResize={this.handleResize} />

--- a/src/components/tab/TabGroup.js
+++ b/src/components/tab/TabGroup.js
@@ -62,10 +62,10 @@ class TabGroup extends PureComponent {
         className={classNames}
         {...others}
         display="flex"
-        paddingHorizontal={1}
+        paddingHorizontal={size === 'small' ? 2 : 0}
       >
         <Box className={theme['scroll-container']} display="flex" overflowX="scroll" ref={this.scrollContainerRef}>
-          {React.Children.map(children, (child) => React.cloneElement(child, { size, marginHorizontal: 1 }))}
+          {React.Children.map(children, (child) => React.cloneElement(child, { size }))}
         </Box>
         {canScrollLeft && (
           <Box className={theme['scroll-left-button-wrapper']}>

--- a/src/components/tab/TitleTab.js
+++ b/src/components/tab/TitleTab.js
@@ -48,6 +48,7 @@ class TitleTab extends PureComponent {
       <Box
         data-teamleader-ui="title-tab"
         className={classNames}
+        marginHorizontal={size === 'small' ? 1 : 2}
         paddingHorizontal={this.getPaddingHorizontal()}
         ref={this.tabNode}
         onClick={this.handleClick}

--- a/src/components/tab/TitleTab.js
+++ b/src/components/tab/TitleTab.js
@@ -49,7 +49,6 @@ class TitleTab extends PureComponent {
         data-teamleader-ui="title-tab"
         className={classNames}
         paddingHorizontal={this.getPaddingHorizontal()}
-        paddingVertical={4}
         ref={this.tabNode}
         onClick={this.handleClick}
         {...rest}

--- a/src/components/tab/TitleTab.js
+++ b/src/components/tab/TitleTab.js
@@ -5,7 +5,7 @@ import cx from 'classnames';
 import theme from './theme.css';
 import omit from 'lodash.omit';
 
-import { Heading4 } from '../typography';
+import { Heading4, Heading5 } from '../typography';
 
 class TitleTab extends PureComponent {
   tabNode = createRef();
@@ -37,10 +37,12 @@ class TitleTab extends PureComponent {
   };
 
   render() {
-    const { active, children, className, counter = null, ...others } = this.props;
+    const { active, children, className, counter = null, size, ...others } = this.props;
     const classNames = cx(theme['title-tab'], { [theme['is-active']]: active }, className);
 
     const rest = omit(others, ['onClick']);
+
+    const TextElement = size === 'small' ? Heading5 : Heading4;
 
     return (
       <Box
@@ -52,7 +54,7 @@ class TitleTab extends PureComponent {
         onClick={this.handleClick}
         {...rest}
       >
-        <Heading4 element="span">{children}</Heading4>
+        <TextElement element="span">{children}</TextElement>
         {counter}
       </Box>
     );

--- a/src/components/tab/tab.stories.js
+++ b/src/components/tab/tab.stories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { select } from '@storybook/addon-knobs';
 import { addStoryInGroup, MID_LEVEL_BLOCKS } from '../../../.storybook/utils';
 import { IconTab, TabGroup, TitleTab, Box, Counter as UICounter } from '../../index';
 
@@ -35,6 +36,10 @@ export default {
   title: addStoryInGroup(MID_LEVEL_BLOCKS, 'Tab'),
 
   parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/LHH25GN90ljQaBEUNMsdJn/Desktop-components?node-id=3336%3A291',
+    },
     info: {
       propTablesExclude: [Box],
     },
@@ -42,10 +47,16 @@ export default {
 };
 
 export const titleTab = () => (
-  <TabGroup>
+  <TabGroup size={select('Size', ['small', 'medium'], 'medium')}>
     {tabItems.map((item, key) => {
       const optionalProps = item.count
-        ? { counter: React.createElement(TitleCounter, { count: item.count, color: item.active ? 'mint' : 'neutral' }) }
+        ? {
+            counter: React.createElement(TitleCounter, {
+              count: item.count,
+              color: item.active ? 'mint' : 'neutral',
+              size: select('Size', ['small', 'medium'], 'medium'),
+            }),
+          }
         : {};
       return (
         <TitleTab
@@ -69,10 +80,16 @@ titleTab.story = {
 };
 
 export const iconTab = () => (
-  <TabGroup>
+  <TabGroup size={select('Size', ['small', 'medium'], 'medium')}>
     {tabItems.map((item, key) => {
       const optionalProps = item.count
-        ? { counter: React.createElement(IconCounter, { count: item.count, color: item.active ? 'mint' : 'neutral' }) }
+        ? {
+            counter: React.createElement(IconCounter, {
+              count: item.count,
+              color: item.active ? 'mint' : 'neutral',
+              size: select('Size', ['small', 'medium'], 'medium'),
+            }),
+          }
         : {};
       const IconToRender = iconMap[item.icon.toLowerCase()];
       return (

--- a/src/components/tab/tab.stories.js
+++ b/src/components/tab/tab.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { addStoryInGroup, MID_LEVEL_BLOCKS } from '../../../.storybook/utils';
 import { IconTab, TabGroup, TitleTab, Box, Counter as UICounter } from '../../index';
 
-import { tabItems, invertedTabItems } from '../../static/data/tab';
+import { tabItems } from '../../static/data/tab';
 import {
   IconCalendarMediumOutline,
   IconCheckmarkMediumOutline,
@@ -42,10 +42,10 @@ export default {
 };
 
 export const titleTab = () => (
-  <TabGroup display="flex">
+  <TabGroup>
     {tabItems.map((item, key) => {
       const optionalProps = item.count
-        ? { counter: React.createElement(TitleCounter, { count: item.count, color: 'mint' }) }
+        ? { counter: React.createElement(TitleCounter, { count: item.count, color: item.active ? 'mint' : 'neutral' }) }
         : {};
       return (
         <TitleTab
@@ -69,10 +69,10 @@ titleTab.story = {
 };
 
 export const iconTab = () => (
-  <TabGroup display="flex">
-    {invertedTabItems.map((item, key) => {
+  <TabGroup>
+    {tabItems.map((item, key) => {
       const optionalProps = item.count
-        ? { counter: React.createElement(IconCounter, { count: item.count, color: 'mint' }) }
+        ? { counter: React.createElement(IconCounter, { count: item.count, color: item.active ? 'mint' : 'neutral' }) }
         : {};
       const IconToRender = iconMap[item.icon.toLowerCase()];
       return (

--- a/src/components/tab/theme.css
+++ b/src/components/tab/theme.css
@@ -24,6 +24,7 @@
   border: none;
   border-radius: 0;
   flex-shrink: 0;
+  height: 48px;
 
   &:focus {
     box-shadow: inset 0 0 0 2px var(--color-neutral);

--- a/src/components/tab/theme.css
+++ b/src/components/tab/theme.css
@@ -81,6 +81,17 @@
   }
 }
 
+.scroll-container {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* Internet Explorer 10+ */
+}
+
+.scroll-container::-webkit-scrollbar {
+  /* WebKit */
+  width: 0;
+  height: 0;
+}
+
 .scroll-left-button-wrapper,
 .scroll-right-button-wrapper {
   background-color: var(--color-neutral-lightest);

--- a/src/components/tab/theme.css
+++ b/src/components/tab/theme.css
@@ -2,14 +2,12 @@
 @import '@teamleader/ui-animations';
 @import '@teamleader/ui-utilities';
 
-.tab-group {
-  & > * {
-    margin-left: var(--spacer-small);
+:root {
+  --scroll-button-size: 48px;
+}
 
-    &:last-child {
-      margin-right: var(--spacer-small);
-    }
-  }
+.tab-group {
+  position: relative;
 }
 
 .title-tab,
@@ -81,4 +79,29 @@
   &::after {
     transform: scale(1, 1);
   }
+}
+
+.scroll-left-button-wrapper,
+.scroll-right-button-wrapper {
+  background-color: var(--color-neutral-lightest);
+  position: absolute;
+  top: 0;
+}
+
+.scroll-left-button-wrapper {
+  left: 0;
+
+  &::before {
+    background: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
+  }
+}
+
+.scroll-right-button-wrapper {
+  right: 0;
+}
+
+.scroll-button {
+  border-radius: 0;
+  height: var(--scroll-button-size);
+  width: var(--scroll-button-size);
 }

--- a/src/static/data/tab.js
+++ b/src/static/data/tab.js
@@ -6,30 +6,27 @@ const tabItems = [
     title: 'Invoices',
   },
   {
-    active: true,
+    active: false,
     href: '#',
     icon: 'CRM',
     title: 'CRM',
   },
   {
-    active: false,
+    active: true,
     count: 30,
     href: '#',
     icon: 'Planning',
     title: 'Planning',
   },
-];
-
-const invertedTabItems = [
   {
-    active: true,
-    count: 8,
+    active: false,
     href: '#',
     icon: 'Products',
     title: 'Products',
   },
   {
     active: false,
+    count: 8,
     href: '#',
     icon: 'Deals',
     title: 'Deals',
@@ -42,4 +39,4 @@ const invertedTabItems = [
   },
 ];
 
-export { tabItems, invertedTabItems };
+export { tabItems };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10745,6 +10745,11 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
+smoothscroll-polyfill@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz#3a259131dc6930e6ca80003e1cb03b603b69abf8"
+  integrity sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"


### PR DESCRIPTION
### Description

This PR makes our `TabGroup` component scrollable when tabs are horizontally overflowing their container. It is also possible to scroll with the mouse wheel because of the `overflowX="scroll"` prop. The scrollbar is hidden with CSS.

**Tested in:**
- Chrome
- Firefox
- Safari
- Opera
- IE11

#### Medium sized
![Screen Recording 2020-06-15 at 16 27 51](https://user-images.githubusercontent.com/5336831/84673327-d927b700-af29-11ea-91d5-70d80ac86854.gif)

#### Small sized
![Screen Recording 2020-06-15 at 16 28 08](https://user-images.githubusercontent.com/5336831/84673470-05433800-af2a-11ea-8c43-2da7b8d2ebbf.gif)

#### Resize behavior
![Screen Recording 2020-06-15 at 16 28 38](https://user-images.githubusercontent.com/5336831/84673599-358ad680-af2a-11ea-88db-50869a2321fd.gif)

### Breaking changes

None.

### Coming up, 2 PR's
- `TabGroup` will auto-scroll to the active `TitleTab`
- `IconTab` will be removed