### PR TITLE
release/0.46.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### Added
 
-- `IconButton`: add tint prop to customize the tint of the icon inside of the button. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1156](https://github.com/teamleadercrm/ui/pull/1166))
-
 ### Changed
 
 ### Deprecated
@@ -13,6 +11,16 @@
 ### Fixed
 
 ### Dependency updates
+
+## [0.46.1] - 2020-06-18
+
+### Added
+
+- `IconButton`: add tint prop to customize the tint of the icon inside of the button. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1156](https://github.com/teamleadercrm/ui/pull/1166))
+
+### Dependency updates
+
+- Bump react-resize-detector from `5.0.3` to `5.0.4`
 
 ## [0.46.0] - 2020-06-16
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [0.46.1] - 2020-06-18

### Added

- `IconButton`: add tint prop to customize the tint of the icon inside of the button. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1156](https://github.com/teamleadercrm/ui/pull/1166))

### Dependency updates

- Bump react-resize-detector from `5.0.3` to `5.0.4`