### PR TITLE
Scrollable tabs: fine tune

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `TabGroup`: added fading gradients to soften the edges of our scroll buttons. ([@driesd](https://github.com/driesd) in [#1169])
+
 ### Changed
 
 ### Deprecated

--- a/src/components/tab/TabGroup.js
+++ b/src/components/tab/TabGroup.js
@@ -32,7 +32,7 @@ class TabGroup extends PureComponent {
 
     this.setState({
       canScrollLeft: scrollLeft > 0,
-      canScrollRight: scrollLeft !== scrollWidth - clientWidth,
+      canScrollRight: scrollLeft < scrollWidth - clientWidth,
     });
   };
 

--- a/src/components/tab/theme.css
+++ b/src/components/tab/theme.css
@@ -103,13 +103,29 @@
 .scroll-left-button-wrapper {
   left: 0;
 
-  &::before {
-    background: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
+  &::after {
+    background: linear-gradient(to left, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
+    content: '';
+    height: 100%;
+    left: 100%;
+    position: absolute;
+    top: 0;
+    width: var(--spacer-small);
   }
 }
 
 .scroll-right-button-wrapper {
   right: 0;
+
+  &::before {
+    background: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
+    content: '';
+    height: 100%;
+    right: 100%;
+    position: absolute;
+    top: 0;
+    width: var(--spacer-small);
+  }
 }
 
 .scroll-button {


### PR DESCRIPTION
### Description

This PR adds a subtle fade effect to soften the button edges. It also improves the `canScrollRight` logic as @lorgan3 stated in [this PR](https://github.com/teamleadercrm/ui/pull/1160).

#### Screenshot before this PR
![Screenshot 2020-06-18 12 17 09](https://user-images.githubusercontent.com/5336831/85008968-00ff6080-b15e-11ea-943e-58dc78cffebd.png)

#### Screenshot after this PR
![Screenshot 2020-06-18 12 16 25](https://user-images.githubusercontent.com/5336831/85008991-078dd800-b15e-11ea-973d-28edff86fb8c.png)

### Breaking changes

None.
