### PR TITLE
IconButton: fix blurring `onMouseUp` and `onMouseLeave`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `IconButton`: fix blurring `onMouseUp` and `onMouseLeave`. ([@driesd](https://github.com/driesd) in [#1170])
+
 ### Dependency updates
 
 ## [0.46.1] - 2020-06-18

--- a/src/components/iconButton/IconButton.js
+++ b/src/components/iconButton/IconButton.js
@@ -22,8 +22,8 @@ class IconButton extends Component {
   };
 
   blur() {
-    if (this.buttonNode.blur) {
-      this.buttonNode.blur();
+    if (this.buttonNode.boxNode.current.blur) {
+      this.buttonNode.boxNode.current.blur();
     }
   }
 


### PR DESCRIPTION
### Description

This PR fixes the blurring of the `IconButton`, fired when `onMouseUp` and `onMouseLeave` events occur.

#### Screenshot before this PR
![Screenshot 2020-06-18 12 31 02](https://user-images.githubusercontent.com/5336831/85009991-994a1500-b15f-11ea-9e86-b25507df98e3.png)

#### Screenshot after this PR
![Screenshot 2020-06-18 12 29 40](https://user-images.githubusercontent.com/5336831/85010008-9d763280-b15f-11ea-80eb-4259313e4f7a.png)

### Breaking changes

None.
