### PR TITLE
Button: fix blurring `onMouseUp` and `onMouseLeave`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Button`: fix blurring `onMouseUp` and `onMouseLeave`. ([@driesd](https://github.com/driesd) in [#1171])
+
 ### Dependency updates
 
 ## [0.46.1] - 2020-06-18

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -52,8 +52,8 @@ class Button extends PureComponent {
   };
 
   blur() {
-    if (this.buttonNode.blur) {
-      this.buttonNode.blur();
+    if (this.buttonNode.boxNode.current.blur) {
+      this.buttonNode.boxNode.current.blur();
     }
   }
 


### PR DESCRIPTION
### Description

This PR fixes the blurring of the `Button`, fired when `onMouseUp` and `onMouseLeave` events occur.

#### Screenshot before this PR
![Screenshot 2020-06-18 14 30 30](https://user-images.githubusercontent.com/5336831/85020228-4c226f00-b170-11ea-9dc0-246634709482.png)

#### Screenshot after this PR
![Screenshot 2020-06-18 14 26 01](https://user-images.githubusercontent.com/5336831/85019917-dae2bc00-b16f-11ea-9416-370b0480170f.png)

### Breaking changes

None.
