### PR TITLE
Release 0.46.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### Added
 
-- `TabGroup`: added fading gradients to soften the edges of our scroll buttons. ([@driesd](https://github.com/driesd) in [#1169])
-
 ### Changed
 
 ### Deprecated
@@ -12,10 +10,22 @@
 
 ### Fixed
 
+### Dependency updates
+
+## [0.46.2] - 2020-06-18
+
+### Added
+
+- `TabGroup`: added fading gradients to soften the edges of our scroll buttons. ([@driesd](https://github.com/driesd) in [#1169])
+
+### Fixed
+
 - `Button`: fix blurring `onMouseUp` and `onMouseLeave`. ([@driesd](https://github.com/driesd) in [#1171])
 - `IconButton`: fix blurring `onMouseUp` and `onMouseLeave`. ([@driesd](https://github.com/driesd) in [#1170])
 
 ### Dependency updates
+
+- Bump `react-resize-detector` from `5.0.4` to `5.0.6`
 
 ## [0.46.1] - 2020-06-18
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.46.1",
+  "version": "0.46.2",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Added

- `TabGroup`: added fading gradients to soften the edges of our scroll buttons. ([@driesd](https://github.com/driesd) in [#1169])

### Fixed

- `Button`: fix blurring `onMouseUp` and `onMouseLeave`. ([@driesd](https://github.com/driesd) in [#1171])
- `IconButton`: fix blurring `onMouseUp` and `onMouseLeave`. ([@driesd](https://github.com/driesd) in [#1170])

### Dependency updates

- Bump `react-resize-detector` from `5.0.4` to `5.0.6`
