### PR TITLE
Menu: let the component grow inside of its container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- The `Menu` component now takes up the full width of its container ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1173](https://github.com/teamleadercrm/ui/pull/1173))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/menu/theme.css
+++ b/src/components/menu/theme.css
@@ -23,6 +23,7 @@
 }
 
 .menu {
+  width: 100%;
   display: inline-block;
   position: relative;
 


### PR DESCRIPTION
### Description

- The menu component now grows to the width of its container

#### Screenshot before this PR

![Screenshot 2020-06-18 at 15 34 24](https://user-images.githubusercontent.com/10011712/85026654-3796a480-b179-11ea-9e6e-fea0f78c0263.png)


#### Screenshot after this PR

![Screenshot 2020-06-18 at 15 35 41](https://user-images.githubusercontent.com/10011712/85026787-66ad1600-b179-11ea-9826-e397f0d17178.png)


### Breaking changes

- None

### Manual check

On base branch:

- On the popover with menu story, open up the menu, and remove the last item in the inspector
- You'll notice the menu shrinks to a certain min width but its items are allowed to shrink even more, causing the selected states and highlights to be too small for its container
