### PR TITLE
Radio: fix inconsistent left margin in Firefox vs Chrome on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- `Radio`: fixed the inconsistent left margin in Firefox vs Chrome on Linux. ([@driesd](https://github.com/driesd) in [#1175])
+
 ### Dependency updates
 
 ## [0.46.2] - 2020-06-18

--- a/src/components/radio/theme.css
+++ b/src/components/radio/theme.css
@@ -24,6 +24,7 @@
     height: 0;
     overflow: hidden;
     opacity: 0;
+    position: absolute;
     margin: 0;
   }
 


### PR DESCRIPTION
### Description

This PR fixes the inconsistent left margin of our `Radio` component in `Firefox vs Chrome on Linux`.

#### Screenshot before this PR

![Screenshot 2020-06-22 10 26 59](https://user-images.githubusercontent.com/5336831/85265699-ef2a0000-b472-11ea-8ad0-14b76431d5d0.png)

#### Screenshot after this PR

![Screenshot 2020-06-22 10 25 23](https://user-images.githubusercontent.com/5336831/85265708-f3561d80-b472-11ea-8f27-a4e41dd10098.png)

### Breaking changes

None.
