### PR TITLE
Box: forwardRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- :boom: `Box`: added `forwardRef`. ([@driesd](https://github.com/driesd) in [#1183])
+
 ### Changed
 
 ### Deprecated

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ declare module '@teamleader/ui' {
   type BoxProps = HTMLAttributes<HTMLDivElement> &
     Partial<SpacingProps> &
     Partial<LayoutProps> & {
-      ref?: RefObject<{ boxNode: RefObject<HTMLDivElement> }>;
+      ref?: RefObject<HTMLDivElement>;
       backgroundColor?: string;
       backgroundTint?: string;
       children?: ReactNode;

--- a/src/components/badge/Badge.js
+++ b/src/components/badge/Badge.js
@@ -10,7 +10,7 @@ class Badge extends PureComponent {
   badgeNode = createRef();
 
   handleMouseUp = (event) => {
-    this.badgeNode.current.boxNode.current.blur();
+    this.badgeNode.current.blur();
 
     if (this.props.onMouseUp) {
       this.props.onMouseUp(event);
@@ -18,7 +18,7 @@ class Badge extends PureComponent {
   };
 
   handleMouseLeave = (event) => {
-    this.badgeNode.current.boxNode.current.blur();
+    this.badgeNode.current.blur();
 
     if (this.props.onMouseLeave) {
       this.props.onMouseLeave(event);

--- a/src/components/box/Box.js
+++ b/src/components/box/Box.js
@@ -1,4 +1,4 @@
-import React, { createRef, PureComponent } from 'react';
+import React, { forwardRef, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { COLOR, COLORS, TINTS } from '../../constants';
@@ -15,8 +15,6 @@ const borderRadiuses = {
 };
 
 class Box extends PureComponent {
-  boxNode = createRef();
-
   getBorder = (value) => {
     const { borderColor, borderTint } = this.props;
     return `${value}px solid ${COLOR[borderColor.toUpperCase()][borderTint.toUpperCase()]}`;
@@ -52,6 +50,7 @@ class Box extends PureComponent {
       flexGrow,
       flexShrink,
       flexWrap,
+      forwardedRef,
       justifyContent,
       margin,
       marginHorizontal = margin,
@@ -132,7 +131,7 @@ class Box extends PureComponent {
     const Element = element;
 
     return (
-      <Element ref={this.boxNode} className={classNames} style={elementStyles} {...others}>
+      <Element className={classNames} ref={forwardedRef} style={elementStyles} {...others}>
         {children}
       </Element>
     );
@@ -207,4 +206,4 @@ Box.defaultProps = {
   padding: 0,
 };
 
-export default Box;
+export default forwardRef((props, ref) => <Box {...props} forwardedRef={ref} />);

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -52,8 +52,8 @@ class Button extends PureComponent {
   };
 
   blur() {
-    if (this.buttonNode.boxNode.current.blur) {
-      this.buttonNode.boxNode.current.blur();
+    if (this.buttonNode.blur) {
+      this.buttonNode.blur();
     }
   }
 

--- a/src/components/iconButton/IconButton.js
+++ b/src/components/iconButton/IconButton.js
@@ -22,8 +22,8 @@ class IconButton extends Component {
   };
 
   blur() {
-    if (this.buttonNode.boxNode.current.blur) {
-      this.buttonNode.boxNode.current.blur();
+    if (this.buttonNode.blur) {
+      this.buttonNode.blur();
     }
   }
 

--- a/src/components/tab/TabGroup.js
+++ b/src/components/tab/TabGroup.js
@@ -20,15 +20,15 @@ class TabGroup extends PureComponent {
 
   componentDidMount() {
     smoothScroll.polyfill();
-    this.scrollContainerRef.current.boxNode.current.addEventListener('scroll', this.handleScroll);
+    this.scrollContainerRef.current.addEventListener('scroll', this.handleScroll);
   }
 
   componentWillUnmount() {
-    this.scrollContainerRef.current.boxNode.current.removeEventListener('scroll', this.handleScroll);
+    this.scrollContainerRef.current.removeEventListener('scroll', this.handleScroll);
   }
 
   checkForScrollPosition = () => {
-    const { scrollLeft, scrollWidth, clientWidth } = this.scrollContainerRef.current.boxNode.current;
+    const { scrollLeft, scrollWidth, clientWidth } = this.scrollContainerRef.current;
 
     this.setState({
       canScrollLeft: scrollLeft > 0,
@@ -45,7 +45,7 @@ class TabGroup extends PureComponent {
   };
 
   scrollContainerBy = (distance) => {
-    this.scrollContainerRef.current.boxNode.current.scrollBy({ left: distance, behavior: 'smooth' });
+    this.scrollContainerRef.current.scrollBy({ left: distance, behavior: 'smooth' });
   };
 
   render() {

--- a/src/components/tab/TitleTab.js
+++ b/src/components/tab/TitleTab.js
@@ -20,8 +20,8 @@ class TitleTab extends PureComponent {
   };
 
   blur = () => {
-    if (this.tabNode.current.boxNode.current) {
-      this.tabNode.current.boxNode.current.blur();
+    if (this.tabNode.current) {
+      this.tabNode.current.blur();
     }
   };
 

--- a/src/components/wysiwygEditor/LinkOptions.js
+++ b/src/components/wysiwygEditor/LinkOptions.js
@@ -68,7 +68,7 @@ const LinkOptions = ({
         />
       </Box>
       <Popover
-        anchorEl={iconButtonRef?.current?.boxNode?.current}
+        anchorEl={iconButtonRef?.current}
         active={isPopoverShown}
         backdrop="transparent"
         onEscKeyDown={handleClosePopoverClick}


### PR DESCRIPTION
### Description

This PR implements `React.forwardRef()` in our `Box` component.

### :boom:   Breaking changes

For every usage of `Box` or `Box-based components` working with a `ref`, you'll need to remove the `.boxNode.current` part in order to make it work again.
