### PR TITLE
DatePicker - month selector: use 4 characters for french

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `DatePicker`: added one extra character to the `short month labels` for the `French` language. ([@driesd](https://github.com/driesd) in [#1187])
+
 ### Deprecated
 
 ### Removed

--- a/src/components/datepicker/MonthPicker.js
+++ b/src/components/datepicker/MonthPicker.js
@@ -61,7 +61,7 @@ const MonthPickerUnary = ({ date, locale, localeUtils, onChange }) => {
           className={theme['month-picker-field']}
           options={getMonthOptions(localeUtils, locale)}
           onChange={handleChangeMonth}
-          width={112}
+          width="112px"
           size="small"
         />
       </Box>
@@ -107,7 +107,7 @@ const MonthPickerSplit = ({ date, locale, localeUtils, onChange, size }) => {
           className={theme['month-picker-field']}
           options={months}
           onChange={handleChangeMonth}
-          width={size === 'small' ? 88 : 112}
+          width={size === 'small' ? '88px' : '112px'}
           size="small"
         />
         <NumericInput
@@ -115,7 +115,7 @@ const MonthPickerSplit = ({ date, locale, localeUtils, onChange, size }) => {
           className={theme['month-picker-field']}
           onChange={handleChangeYear}
           onBlur={handleYearBlur}
-          width={size === 'small' ? 72 : 80}
+          width={size === 'small' ? '72px' : '80px'}
           size="small"
         />
       </Box>

--- a/src/components/datepicker/MonthPicker.js
+++ b/src/components/datepicker/MonthPicker.js
@@ -29,12 +29,19 @@ const getMonthOptions = (localeUtils, locale) => {
 };
 
 // e.g. "February 2020" => "Feb"
-const formatSelectedMonth = ({ label, value }) => ({ value, label: label.substring(0, 3) });
+// Exception for French language: we use 4 characters
+const formatSelectedMonth = ({ label, value }, locale) => ({
+  value,
+  label: label.substring(0, locale.startsWith('fr-') ? 4 : 3),
+});
 
 // e.g. "February 2020" => "Feb 2020"
-const formatSelectMonthAndYear = ({ label, value }) => ({
+// Exception for French language: we use 4 characters
+const formatSelectMonthAndYear = ({ label, value }, locale) => ({
   value,
-  label: label.replace(/(\w{3})\w+\s(\d{4})/, '$1 $2'),
+  label: locale.startsWith('fr-')
+    ? label.replace(/(\w{4})\w+\s(\d{4})/, '$1 $2')
+    : label.replace(/(\w{3})\w+\s(\d{4})/, '$1 $2'),
 });
 
 const MonthPickerUnary = ({ date, locale, localeUtils, onChange }) => {
@@ -50,7 +57,7 @@ const MonthPickerUnary = ({ date, locale, localeUtils, onChange }) => {
     <Box className={theme['caption']}>
       <Box display="flex" justifyContent="center">
         <Select
-          value={formatSelectMonthAndYear(selectedMonth)}
+          value={formatSelectMonthAndYear(selectedMonth, locale)}
           className={theme['month-picker-field']}
           options={getMonthOptions(localeUtils, locale)}
           onChange={handleChangeMonth}
@@ -96,7 +103,7 @@ const MonthPickerSplit = ({ date, locale, localeUtils, onChange, size }) => {
     <Box className={theme['caption']}>
       <Box display="flex" justifyContent="center">
         <Select
-          value={formatSelectedMonth(selectedMonth)}
+          value={formatSelectedMonth(selectedMonth, locale)}
           className={theme['month-picker-field']}
           options={months}
           onChange={handleChangeMonth}

--- a/src/components/datepicker/datePicker.stories.js
+++ b/src/components/datepicker/datePicker.stories.js
@@ -8,16 +8,20 @@ import CustomLocaleUtils, { formatDate, parseDate } from './localeUtils';
 const languages = [
   'da-DK',
   'de-DE',
-  'fr-FR',
   'en-GB',
   'en-US',
   'es-ES',
   'fi-FI',
+  'fr-BE',
+  'fr-FR',
   'it-IT',
+  'nb-NO',
   'nl-BE',
-  'pt-PT',
+  'nl-NL',
   'pl-PL',
+  'pt-PT',
   'sv-SE',
+  'tr-TR',
 ];
 const sizes = ['small', 'medium', 'large'];
 const optionalSizes = {


### PR DESCRIPTION
### Description

This PR adds one extra character to the short month labels for the French language. This prevents confusion between the month of `Jun` (`Jui` in French) and `Jul` (`Jui` in French).

#### Screenshot before this PR
![Screenshot 2020-06-24 16 09 42](https://user-images.githubusercontent.com/5336831/85572317-2ba55980-b635-11ea-8e40-00f289df146d.png)

#### Screenshot after this PR
![Screenshot 2020-06-24 16 07 31](https://user-images.githubusercontent.com/5336831/85572348-319b3a80-b635-11ea-8c63-c95d248d186c.png)

### Breaking changes

None.
