### PR TITLE
DatePickerInput: footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - `DatePicker`: added one extra character to the `short month labels` for the `French` language. ([@driesd](https://github.com/driesd) in [#1187])
+- `DatePickerInput`: added `footer` prop, which can take a custom component to render underneath the date picker. ([@driesd](https://github.com/driesd) in [#1193])
 
 ### Deprecated
 

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -81,6 +81,7 @@ class DatePickerInput extends PureComponent {
       bordered,
       className,
       dayPickerProps,
+      footer,
       inverse,
       inputProps,
       locale,
@@ -131,6 +132,21 @@ class DatePickerInput extends PureComponent {
               {...dayPickerProps}
             />
           </Box>
+          {footer && (
+            <Box
+              backgroundColor="neutral"
+              backgroundTint="light"
+              borderColor="neutral"
+              borderTint="normal"
+              borderTopWidth={1}
+              flex="1 0 auto"
+              overflowX="hidden"
+              paddingHorizontal={3}
+              paddingVertical={3}
+            >
+              {footer}
+            </Box>
+          )}
         </Popover>
       </Box>
     );
@@ -144,6 +160,8 @@ DatePickerInput.propTypes = {
   className: PropTypes.string,
   /** Object with props for the DatePicker component. */
   dayPickerProps: PropTypes.object,
+  /** A footer component, rendered at the bottom of the date picker */
+  footer: PropTypes.any,
   /** A custom function to format a date. */
   formatDate: PropTypes.func,
   /** Object with props for the Input component. */

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -111,7 +111,7 @@ class DatePickerInput extends PureComponent {
           active={isPopoverActive}
           anchorEl={popoverAnchorEl}
           backdrop="transparent"
-          fullWidth
+          maxWidth="min-content"
           onEscKeyDown={this.handlePopoverClose}
           onOverlayClick={this.handlePopoverClose}
           position="end"

--- a/src/components/datepicker/datePicker.stories.js
+++ b/src/components/datepicker/datePicker.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
 import { boolean, number, select, text } from '@storybook/addon-knobs/react';
-import { DatePicker, DatePickerRange, DatePickerInput, DatePickerInputRange } from '../../index';
+import { DatePicker, DatePickerRange, DatePickerInput, DatePickerInputRange, Toggle } from '../../index';
 import { DateTime } from 'luxon';
 import CustomLocaleUtils, { formatDate, parseDate } from './localeUtils';
 
@@ -107,6 +107,7 @@ export const inputSingleDate = () => {
         showWeekNumbers: boolean('Show week numbers', true),
         withMonthPicker: boolean('Use month picker', false),
       }}
+      footer={<Toggle label="Lorem ipsum dolor sit amet, suspendisse faucibus nunc et pellentesque" size="small" />}
       formatDate={customFormatDate}
       inputProps={{
         bold: boolean('Bold', false),


### PR DESCRIPTION
### Description

This PR adds a sticky `footer` to our `DatePickerInput` component.

#### Screenshots
![Screenshot 2020-06-30 14 16 06](https://user-images.githubusercontent.com/5336831/86125742-70ba0780-badd-11ea-87d8-99b5a698d058.png)

![Screenshot 2020-06-30 14 15 53](https://user-images.githubusercontent.com/5336831/86125754-76afe880-badd-11ea-9514-5ca88dbb87ce.png)


### Breaking changes

None.
