### PR TITLE
Toggle: label max lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Toggle`: added `maxLines` prop and pass it to the label `Text` component. ([@driesd](https://github.com/driesd) in [#1194])
+
 ### Changed
 
 - `DatePicker`: added one extra character to the `short month labels` for the `French` language. ([@driesd](https://github.com/driesd) in [#1187])

--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -34,7 +34,7 @@ class Toggle extends PureComponent {
   }
 
   render() {
-    const { checked, disabled, className, size, label, children, ...others } = this.props;
+    const { checked, disabled, className, maxLines, size, label, children, ...others } = this.props;
 
     const restProps = omit(others, ['onChange']);
     const boxProps = pickBoxProps(restProps);
@@ -69,7 +69,7 @@ class Toggle extends PureComponent {
         {(label || children) && (
           <span className={theme['label']}>
             {label && (
-              <TextElement element="span" color={disabled ? 'neutral' : 'teal'}>
+              <TextElement element="span" color={disabled ? 'neutral' : 'teal'} maxLines={maxLines}>
                 {label}
               </TextElement>
             )}
@@ -85,6 +85,8 @@ Toggle.propTypes = {
   checked: PropTypes.bool,
   children: PropTypes.node,
   disabled: PropTypes.bool,
+  /** The maximum number of lines the label can take */
+  maxLines: PropTypes.number,
   name: PropTypes.string,
   className: PropTypes.string,
   label: PropTypes.string,

--- a/src/components/toggle/theme.css
+++ b/src/components/toggle/theme.css
@@ -124,7 +124,7 @@
     }
 
     .track {
-      width: var(--toggle-track-width-small);
+      flex: 0 0 var(--toggle-track-width-small);
       height: var(--toggle-track-height-small);
       border-radius: var(--toggle-track-height-small);
     }
@@ -154,7 +154,7 @@
     }
 
     .track {
-      width: var(--toggle-track-width-medium);
+      flex: 0 0 var(--toggle-track-width-medium);
       height: var(--toggle-track-height-medium);
       border-radius: var(--toggle-track-height-medium);
     }
@@ -184,7 +184,7 @@
     }
 
     .track {
-      width: var(--toggle-track-width-large);
+      flex: 0 0 var(--toggle-track-width-large);
       height: var(--toggle-track-height-large);
       border-radius: var(--toggle-track-height-large);
     }

--- a/src/components/toggle/toggle.stories.js
+++ b/src/components/toggle/toggle.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { boolean, select } from '@storybook/addon-knobs/react';
-import { Toggle } from '../../index';
+import Toggle from './Toggle';
+import { boolean, number, select, text } from '@storybook/addon-knobs/react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
 
 const sizes = ['small', 'medium', 'large'];
@@ -38,7 +38,8 @@ export const withLabels = () => (
   <ControlledToggle
     checked={boolean('Checked', false)}
     disabled={boolean('Disabled', false)}
-    label={`I'm a toggle`}
+    label={text('Label', 'I am a label')}
+    maxLines={number('Max lines', undefined)}
     size={select('Size', sizes, 'medium')}
   />
 );


### PR DESCRIPTION
### Description

This PR adds a `maxLines` prop to our `Toggle` component and pass it to the `Text` element.

#### Screenshot before this PR
![Screenshot 2020-06-30 14 29 55](https://user-images.githubusercontent.com/5336831/86130464-79620c00-bae4-11ea-958c-4368bef216e1.png)

#### Screenshot after this PR
![Screenshot 2020-06-30 14 28 51](https://user-images.githubusercontent.com/5336831/86130481-8121b080-bae4-11ea-9772-0e5f00cbab95.png)

### Breaking changes

None.
