### PR TITLE
DatePickerInput: remove bordered prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Removed
 
+- :boom: `DatePickerInput`: removed `bordered` prop as the `Popover` already provides one. ([@driesd](https://github.com/driesd) in [#1195])
+
 ### Fixed
 
 ### Dependency updates

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -78,7 +78,6 @@ class DatePickerInput extends PureComponent {
 
   render() {
     const {
-      bordered,
       className,
       dayPickerProps,
       footer,
@@ -121,7 +120,6 @@ class DatePickerInput extends PureComponent {
         >
           <Box overflowY="auto">
             <DatePicker
-              bordered={bordered}
               className={datePickerClassNames}
               locale={locale}
               localeUtils={LocaleUtils}
@@ -154,8 +152,6 @@ class DatePickerInput extends PureComponent {
 }
 
 DatePickerInput.propTypes = {
-  /** If true we give a border to our wrapper. */
-  bordered: PropTypes.bool,
   /** A class name for the wrapper to give custom styles. */
   className: PropTypes.string,
   /** Object with props for the DatePicker component. */
@@ -185,7 +181,6 @@ DatePickerInput.propTypes = {
 };
 
 DatePickerInput.defaultProps = {
-  bordered: false,
   dayPickerProps: {},
   inputProps: {},
   inverse: false,

--- a/src/components/datepicker/datePicker.stories.js
+++ b/src/components/datepicker/datePicker.stories.js
@@ -100,7 +100,6 @@ export const inputSingleDate = () => {
 
   return (
     <DatePickerInput
-      bordered={boolean('bordered', false)}
       dayPickerProps={{
         numberOfMonths: number('Number of months', 1),
         showOutsideDays: boolean('Show outside days', true),


### PR DESCRIPTION
### Description

This PR removes the `bordered` prop from our `DatePickerInput` component because its `Popover` already provides one.

### :boom: Breaking changes

Removed the `bordered` prop from the `DatePickerInput` component.
