### PR TITLE
WysiwygEditor: Focus states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Added
 
+- `WysiwygEditor`: added `autoFocus` prop ([@mikeverf](https://github.com/mikeverf) in [#1196])
+- `WysiwygEditor`: added `onInputFocus` and `onInputBlur` props ([@mikeverf](https://github.com/mikeverf) in [#1196])
+- `WysiwygEditor`: added `onKeyDown` prop ([@mikeverf](https://github.com/mikeverf) in [#1196])
+
 ### Changed
 
 - `DatePicker`: added one extra character to the `short month labels` for the `French` language. ([@driesd](https://github.com/driesd) in [#1187])
@@ -11,6 +15,8 @@
 ### Removed
 
 ### Fixed
+
+- `WysiwygEditor`: added `onFocus` and `onBlur` props now focus and blur reliably on the entire editor ([@mikeverf](https://github.com/mikeverf) in [#1196])
 
 ### Dependency updates
 

--- a/src/components/wysiwygEditor/InlineStylingOptions.js
+++ b/src/components/wysiwygEditor/InlineStylingOptions.js
@@ -48,6 +48,7 @@ const InlineStylingOptions = ({
     <Box display="flex" borderRightWidth={1} marginRight={2}>
       {options.map((optionType) => (
         <TooltippedIconButton
+          data-wysiwyg
           tooltip={
             <TooltipMessage optionType={optionType} name={translations[`components.controls.inline.${optionType}`]} />
           }

--- a/src/components/wysiwygEditor/LinkOptions.js
+++ b/src/components/wysiwygEditor/LinkOptions.js
@@ -56,6 +56,7 @@ const LinkOptions = ({
     <>
       <Box ref={iconButtonRef}>
         <TooltippedIconButton
+          data-wysiwyg
           tooltip={<TextSmall>{translations['components.controls.link.link']}</TextSmall>}
           tooltipSize="small"
           tooltipShowDelay={1000}
@@ -80,7 +81,7 @@ const LinkOptions = ({
         <Box display="flex" flexDirection="column" padding={4}>
           <Label htmlFor="linkText" helpText="">
             {translations['components.controls.link.popover.text']}
-            <Input id="linkText" autoFocus value={textValue || ''} onChange={onTextChange} />
+            <Input id="linkText" autoFocus value={textValue || ''} onChange={onTextChange} data-wysiwyg />
           </Label>
           <Label htmlFor="link" helpText="" marginBottom={4}>
             {translations['components.controls.link.popover.link']}
@@ -89,6 +90,7 @@ const LinkOptions = ({
               value={linkValue || ''}
               onChange={onLinkChange}
               placeholder={translations['components.controls.link.popover.placeholder']}
+              data-wysiwyg
             />
           </Label>
           <Box display="flex" justifyContent="flex-end" alignItems="center" marginTop={4}>
@@ -98,6 +100,7 @@ const LinkOptions = ({
               size="small"
               marginRight={3}
               onClick={handleClosePopoverClick}
+              data-wysiwyg
             />
             <Button
               level="primary"
@@ -105,6 +108,7 @@ const LinkOptions = ({
               size="small"
               disabled={!linkValue || !textValue}
               onClick={handleAddLinkClick}
+              data-wysiwyg
             />
           </Box>
         </Box>

--- a/src/components/wysiwygEditor/ListStylingOptions.js
+++ b/src/components/wysiwygEditor/ListStylingOptions.js
@@ -26,6 +26,7 @@ const ListStylingOptions = ({
     <Box display="flex" borderRightWidth={1} marginRight={2}>
       {options.map((optionType) => (
         <TooltippedIconButton
+          data-wysiwyg
           tooltip={<TextSmall>{translations[`components.controls.list.${optionType}`]}</TextSmall>}
           tooltipSize="small"
           tooltipShowDelay={1000}

--- a/src/components/wysiwygEditor/WysiwygEditor.js
+++ b/src/components/wysiwygEditor/WysiwygEditor.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Editor } from 'react-draft-wysiwyg';
 import cx from 'classnames';
@@ -62,10 +62,19 @@ const WysiwygEditor = ({
   width,
   locale = 'en',
   inputClassName,
+  autoFocus,
   ...others
 }) => {
   const [isFocused, setIsFocused] = useState(false);
   const [isPlaceholderShown, setIsPlaceholderShown] = useState(true);
+  const editorRef = useRef();
+
+  useEffect(() => {
+    if (autoFocus) {
+      // eslint-disable-next-line no-unused-expressions
+      editorRef?.current?.focusEditor();
+    }
+  }, [autoFocus]);
 
   const handleBlur = (event) => {
     setIsFocused(false);
@@ -128,6 +137,7 @@ const WysiwygEditor = ({
                 translations: translations['en'],
               }
         }
+        ref={editorRef}
         {...others}
       />
       <ValidationText error={error} help={helpText} success={success} warning={warning} />
@@ -150,6 +160,8 @@ WysiwygEditor.propTypes = {
   locale: PropTypes.string,
   /** Classname for the WysiwygEditor's input element */
   inputClassName: PropTypes.string,
+  /** Determines if the editor should be autofocussed on render */
+  autoFocus: PropTypes.bool,
 };
 
 export default WysiwygEditor;

--- a/src/components/wysiwygEditor/WysiwygEditor.js
+++ b/src/components/wysiwygEditor/WysiwygEditor.js
@@ -54,7 +54,9 @@ const availableLocales = ['en', 'es', 'it', 'nl', 'fr', 'de'];
 const WysiwygEditor = ({
   className,
   error,
+  onInputFocus,
   onFocus,
+  onInputBlur,
   onBlur,
   success,
   warning,
@@ -76,17 +78,35 @@ const WysiwygEditor = ({
     }
   }, [autoFocus]);
 
+  useEffect(() => {
+    // We have to check on docmument focusin events, because the Editor component's onFocus/onBlur are unreliable
+    const editorInput = document.querySelector("[aria-label='rdw-editor']");
+
+    const handleFocus = (event: FocusEvent) => {
+      if (event.target.dataset.wysiwyg || event.target === editorInput) {
+        setIsFocused(true);
+        onFocus && onFocus(event);
+      } else {
+        setIsFocused(false);
+        onBlur && onBlur(event);
+      }
+    };
+    document.addEventListener('focusin', handleFocus);
+
+    return () => {
+      document.removeEventListener('focusin', handleFocus);
+    };
+  }, []);
+
   const handleBlur = (event) => {
-    setIsFocused(false);
-    if (onBlur) {
-      onBlur(event);
+    if (onInputBlur) {
+      onInputBlur(event);
     }
   };
 
   const handleFocus = (event) => {
-    setIsFocused(true);
-    if (onFocus) {
-      onFocus(event);
+    if (onInputFocus) {
+      onInputFocus(event);
     }
   };
 
@@ -162,6 +182,14 @@ WysiwygEditor.propTypes = {
   inputClassName: PropTypes.string,
   /** Determines if the editor should be autofocussed on render */
   autoFocus: PropTypes.bool,
+  /** Callback function for focussing on anything in the editor */
+  onFocus: PropTypes.func,
+  /** Callback function for blurring anything in the editor */
+  onBlur: PropTypes.func,
+  /** Callback function for focussing on the input field of the editor */
+  onEditorFocus: PropTypes.func,
+  /** Callback function for blurring the input field of the editor */
+  onEditorBlur: PropTypes.func,
 };
 
 export default WysiwygEditor;

--- a/src/components/wysiwygEditor/WysiwygEditor.js
+++ b/src/components/wysiwygEditor/WysiwygEditor.js
@@ -65,6 +65,7 @@ const WysiwygEditor = ({
   locale = 'en',
   inputClassName,
   autoFocus,
+  onKeyDown,
   ...others
 }) => {
   const [isFocused, setIsFocused] = useState(false);
@@ -95,6 +96,23 @@ const WysiwygEditor = ({
 
     return () => {
       document.removeEventListener('focusin', handleFocus);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!onKeyDown || !editorRef?.current?.wrapper) {
+      return;
+    }
+
+    const handleKeyDown = (event) => onKeyDown(event);
+
+    editorRef.current.wrapper.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      if (!onKeyDown && !editorRef?.current?.wrapper) {
+        return;
+      }
+      editorRef.current.wrapper.removeEventListener('keydown', handleKeyDown);
     };
   }, []);
 
@@ -190,6 +208,8 @@ WysiwygEditor.propTypes = {
   onEditorFocus: PropTypes.func,
   /** Callback function for blurring the input field of the editor */
   onEditorBlur: PropTypes.func,
+  /** Callback function for keydown in the input field of the editor */
+  onKeyDown: PropTypes.func,
 };
 
 export default WysiwygEditor;


### PR DESCRIPTION
### Description
Made focus states of `WysiwygEditor` more reliable, added an `autoFocus` and `onKeyDown` prop. Sadly, this WysiwygEditor library is _very_ limiting in passing down props, and its internal focus management is pure garbage. These are the kind of workarounds I had to do…

### Added

- `WysiwygEditor`: added `autoFocus` prop
- `WysiwygEditor`: added `onInputFocus` and `onInputBlur` props
- `WysiwygEditor`: added `onKeyDown` prop

### Fixed

- `WysiwygEditor`: added `onFocus` and `onBlur` props now focus and blur reliably on the entire editor

### Breaking changes

- None
