### PR TITLE
Release 0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,6 @@
 - `DatePicker`: added one extra character to the `short month labels` for the `French` language. ([@driesd](https://github.com/driesd) in [#1187])
 - `DatePickerInput`: added `footer` prop, which can take a custom component to render underneath the date picker. ([@driesd](https://github.com/driesd) in [#1193])
 
-### Deprecated
-
 ### Removed
 
 - :boom: `DatePickerInput`: removed `bordered` prop as the `Popover` already provides one. ([@driesd](https://github.com/driesd) in [#1195])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Dependency updates
+
+## [0.48.0] - 2020-06-30
+
+### Added
+
 - `WysiwygEditor`: added `autoFocus` prop ([@mikeverf](https://github.com/mikeverf) in [#1196])
 - `WysiwygEditor`: added `onInputFocus` and `onInputBlur` props ([@mikeverf](https://github.com/mikeverf) in [#1196])
 - `WysiwygEditor`: added `onKeyDown` prop ([@mikeverf](https://github.com/mikeverf) in [#1196])
@@ -23,6 +37,11 @@
 - `WysiwygEditor`: added `onFocus` and `onBlur` props now focus and blur reliably on the entire editor ([@mikeverf](https://github.com/mikeverf) in [#1196])
 
 ### Dependency updates
+
+- `eslint-plugin-babel` from `5.3.0` to `5.3.1`
+- `eslint-plugin-import` from `2.21.2` to `2.22.0`
+- `eslint-plugin-react` from `7.20.0` to `7.20.2`
+- `storybook-addon-designs` from `5.3.0` to `5.4.0`
 
 ## [0.47.0] - 2020-06-24
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Added

- `WysiwygEditor`: added `autoFocus` prop ([@mikeverf](https://github.com/mikeverf) in [#1196])
- `WysiwygEditor`: added `onInputFocus` and `onInputBlur` props ([@mikeverf](https://github.com/mikeverf) in [#1196])
- `WysiwygEditor`: added `onKeyDown` prop ([@mikeverf](https://github.com/mikeverf) in [#1196])
- `Toggle`: added `maxLines` prop and pass it to the label `Text` component. ([@driesd](https://github.com/driesd) in [#1194]) next-release -- Current Change

### Changed

- `DatePicker`: added one extra character to the `short month labels` for the `French` language. ([@driesd](https://github.com/driesd) in [#1187])
- `DatePickerInput`: added `footer` prop, which can take a custom component to render underneath the date picker. ([@driesd](https://github.com/driesd) in [#1193])

### Removed

- :boom: `DatePickerInput`: removed `bordered` prop as the `Popover` already provides one. ([@driesd](https://github.com/driesd) in [#1195])

### Fixed

- `WysiwygEditor`: added `onFocus` and `onBlur` props now focus and blur reliably on the entire editor ([@mikeverf](https://github.com/mikeverf) in [#1196])

### Dependency updates

- `eslint-plugin-babel` from `5.3.0` to `5.3.1`
- `eslint-plugin-import` from `2.21.2` to `2.22.0`
- `eslint-plugin-react` from `7.20.0` to `7.20.2`
- `storybook-addon-designs` from `5.3.0` to `5.4.0`
