### PR TITLE
Release 0.48.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [0.48.1] - 2020-06-30
+
+### Fixed
+
+- `WysiwygEditor`: fixed build error due to unsupported typing ([@mikeverf](https://github.com/mikeverf) in [#1198])
+
 ## [0.48.0] - 2020-06-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Fixed

- `WysiwygEditor`: fixed build error due to unsupported typing ([@mikeverf](https://github.com/mikeverf) in [#1198])
