### PR TITLE
Toggle: use consistent margins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Toggle`: changed to have consistent spacing between track and label for all sizes. ([@driesd](https://github.com/driesd) in [#1200])
+
 ### Deprecated
 
 ### Removed
@@ -25,7 +27,7 @@
 - `WysiwygEditor`: added `autoFocus` prop ([@mikeverf](https://github.com/mikeverf) in [#1196])
 - `WysiwygEditor`: added `onInputFocus` and `onInputBlur` props ([@mikeverf](https://github.com/mikeverf) in [#1196])
 - `WysiwygEditor`: added `onKeyDown` prop ([@mikeverf](https://github.com/mikeverf) in [#1196])
-- `Toggle`: added `maxLines` prop and pass it to the label `Text` component. ([@driesd](https://github.com/driesd) in [#1194]) next-release -- Current Change
+- `Toggle`: added `maxLines` prop and pass it to the label `Text` component. ([@driesd](https://github.com/driesd) in [#1194])
 
 ### Changed
 

--- a/src/components/toggle/theme.css
+++ b/src/components/toggle/theme.css
@@ -33,6 +33,10 @@
     margin: 0;
   }
 
+  .label {
+    margin-left: var(--spacer-small);
+  }
+
   .track {
     box-sizing: border-box;
     background: var(--color-neutral-light);
@@ -119,10 +123,6 @@
   }
 
   &.is-small {
-    .label {
-      margin-left: var(--spacer-smaller);
-    }
-
     .track {
       flex: 0 0 var(--toggle-track-width-small);
       height: var(--toggle-track-height-small);
@@ -149,7 +149,6 @@
 
   &.is-medium {
     .label {
-      margin-left: var(--spacer-small);
       padding-top: 2px;
     }
 
@@ -179,7 +178,6 @@
 
   &.is-large {
     .label {
-      margin-left: var(--spacer-small);
       padding-top: 4px;
     }
 


### PR DESCRIPTION
### Description

This PR increases the margin between track and label of our `small-sized Toggle` component. All sizes will now have consistent spacing between track and label.

#### Screenshot before this PR
![Screenshot 2020-07-01 11 26 23](https://user-images.githubusercontent.com/5336831/86228916-49237780-bb8f-11ea-8b99-fc9285034846.png)

#### Screenshot after this PR
![Screenshot 2020-07-01 11 18 16](https://user-images.githubusercontent.com/5336831/86228940-504a8580-bb8f-11ea-8f5c-86cf78ef200c.png)

### Breaking changes

None.
