### PR TITLE
WysiwygEditor: onFocus/onBlur fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `WysiwygEditor`: fixed onFocus and onBlur being called twice or not at all in some cases ([@mikeverf](https://github.com/mikeverf) in [#1205])
+
 ### Dependency updates
 
 ## [0.48.1] - 2020-06-30

--- a/src/components/wysiwygEditor/LinkOptions.js
+++ b/src/components/wysiwygEditor/LinkOptions.js
@@ -31,12 +31,17 @@ const LinkOptions = ({
     setLinkValue(link?.target);
   }, [link?.target, selectionText]);
 
+  const focusEditor = () => {
+    document.querySelector("[aria-label='rdw-editor']").focus();
+  };
+
   const handleOpenPopoverClick = () => {
     setIsPopoverShown(true);
   };
 
   const handleClosePopoverClick = () => {
     setIsPopoverShown(false);
+    focusEditor();
   };
 
   const onTextChange = ({ currentTarget: { value: newText } }) => {
@@ -50,6 +55,7 @@ const LinkOptions = ({
   const handleAddLinkClick = () => {
     onChange('link', textValue, linkValue, defaultTargetOption);
     setIsPopoverShown(false);
+    focusEditor();
   };
 
   return (

--- a/src/components/wysiwygEditor/WysiwygEditor.js
+++ b/src/components/wysiwygEditor/WysiwygEditor.js
@@ -80,26 +80,6 @@ const WysiwygEditor = ({
   }, [autoFocus]);
 
   useEffect(() => {
-    // We have to check on docmument focusin events, because the Editor component's onFocus/onBlur are unreliable
-    const editorInput = document.querySelector("[aria-label='rdw-editor']");
-
-    const handleFocus = (event) => {
-      if (event.target.dataset.wysiwyg || event.target === editorInput) {
-        setIsFocused(true);
-        onFocus && onFocus(event);
-      } else {
-        setIsFocused(false);
-        onBlur && onBlur(event);
-      }
-    };
-    document.addEventListener('focusin', handleFocus);
-
-    return () => {
-      document.removeEventListener('focusin', handleFocus);
-    };
-  }, []);
-
-  useEffect(() => {
     if (!onKeyDown || !editorRef?.current?.wrapper) {
       return;
     }
@@ -117,12 +97,27 @@ const WysiwygEditor = ({
   }, []);
 
   const handleBlur = (event) => {
+    const editorInput = document.querySelector("[aria-label='rdw-editor']");
+    // Only blur when editorInput is blurred and the newly focussed target is not part of the wysiwyg
+    if (event.target === editorInput && !event.relatedTarget?.dataset?.wysiwyg) {
+      setIsFocused(false);
+      onBlur && onBlur(event);
+    }
+
     if (onInputBlur) {
       onInputBlur(event);
     }
   };
 
   const handleFocus = (event) => {
+    const editorInput = document.querySelector("[aria-label='rdw-editor']");
+
+    // Only focus when focussed target is part of the wysiwyg and the editor isn't focussed yet
+    if (event.target.dataset.wysiwyg || (event.target === editorInput && !isFocused)) {
+      setIsFocused(true);
+      onFocus && onFocus(event);
+    }
+
     if (onInputFocus) {
       onInputFocus(event);
     }


### PR DESCRIPTION
### Description

- `WysiwygEditor`: fixed `onFocus` and `onBlur` being called twice or not at all in some cases

### Breaking changes

None
