### PR TITLE
WysiwygEditor: Focus fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 
+- `WysiwygEditor`: Fix typo which resulted in onFocus being called multiple times anyway ([@mikeverf](https://github.com/mikeverf) in [#1207])
+- `WysiwygEditor`: Fix race condition for refocussing editor after adding a link ([@mikeverf](https://github.com/mikeverf) in [#1207])
+
 ### Dependency updates
 
 ## [0.48.2] - 2020-07-01

--- a/src/components/wysiwygEditor/LinkOptions.js
+++ b/src/components/wysiwygEditor/LinkOptions.js
@@ -52,10 +52,10 @@ const LinkOptions = ({
     setLinkValue(newLink);
   };
 
-  const handleAddLinkClick = () => {
-    onChange('link', textValue, linkValue, defaultTargetOption);
-    setIsPopoverShown(false);
-    focusEditor();
+  const handleAddLinkClick = async () => {
+    await onChange('link', textValue, linkValue, defaultTargetOption);
+    await setIsPopoverShown(false);
+    await focusEditor();
   };
 
   return (

--- a/src/components/wysiwygEditor/WysiwygEditor.js
+++ b/src/components/wysiwygEditor/WysiwygEditor.js
@@ -113,7 +113,7 @@ const WysiwygEditor = ({
     const editorInput = document.querySelector("[aria-label='rdw-editor']");
 
     // Only focus when focussed target is part of the wysiwyg and the editor isn't focussed yet
-    if (event.target.dataset.wysiwyg || (event.target === editorInput && !isFocused)) {
+    if ((event.target.dataset.wysiwyg || event.target === editorInput) && !isFocused) {
       setIsFocused(true);
       onFocus && onFocus(event);
     }


### PR DESCRIPTION
### Description

- Fix check order which resulted in onFocus being called multiple times anyway
- Fix race condition for refocussing editor after adding a link

### Breaking changes

None
