### PR TITLE
Release 0.48.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@
 
 ### Fixed
 
+### Dependency updates
+
+## [0.48.3] - 2020-07-01
+
+### Fixed
+
 - `WysiwygEditor`: Fix typo which resulted in onFocus being called multiple times anyway ([@mikeverf](https://github.com/mikeverf) in [#1207])
 - `WysiwygEditor`: Fix race condition for refocussing editor after adding a link ([@mikeverf](https://github.com/mikeverf) in [#1207])
-
-### Dependency updates
 
 ## [0.48.2] - 2020-07-01
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.48.2",
+  "version": "0.48.3",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Fixed

- `WysiwygEditor`: Fix typo which resulted in onFocus being called multiple times anyway ([@mikeverf](https://github.com/mikeverf) in #1207)
- `WysiwygEditor`: Fix race condition for refocussing editor after adding a link ([@mikeverf](https://github.com/mikeverf) in #1207)