### PR TITLE
Force upgrade react-day-picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Dependency updates
 
+- `react-day-picker`: enforce upgrade to `7.4.8`.
+
 ## [0.48.3] - 2020-07-01
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "postcss-cli": "^7.0.0",
     "prop-types": "^15.5.9",
     "react": "^16.3.1",
-    "react-day-picker": "^7.1.8",
+    "react-day-picker": "^7.4.8",
     "react-dom": "^16.3.1",
     "react-draft-wysiwyg": "^1.14.4",
     "react-input-mask": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10581,7 +10581,7 @@ react-color@^2.17.0:
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
 
-react-day-picker@^7.1.8:
+react-day-picker@^7.4.8:
   version "7.4.8"
   resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-7.4.8.tgz#675625240d3fae1b41c0a9d5177c968c8517c1d4"
   integrity sha512-pp0hnxFVoRuBQcRdR1Hofw4CQtOCGVmzCNrscyvS0Q8NEc+UiYLEDqE5dk37bf0leSnBW4lheIt0CKKhuKzDVw==


### PR DESCRIPTION
Dependabot upgrades only update the lock file. This means `@teamleader/ui` users are not enforced to update the `react-day-picker` package if it's still within the range of what is specified in package.json.

In this case, there are some bugfixes in react-day-picker, that are necessary to make the DatePicker component to work well. 

Some info about dependabot upgrades:
> For libraries (whose description in the package.json matches the description on npm) we only update the requirement in the package.json if the update is out of range. The assumption there is that library maintainers would want to keep their supported version ranges wide, in case they have integrators using --flat.