### PR TITLE
Release/0.48.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@
 
 ### Dependency updates
 
-- `react-day-picker`: enforce upgrade to `7.4.8`.
+## [0.48.4] - 2020-07-02
+
+### Dependency updates
+
+- `react-day-picker`: enforce upgrade to `7.4.8`. ([@lowiebneoot](https://github.com/lowiebneoot) in [#1210])
 
 ## [0.48.3] - 2020-07-01
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.48.3",
+  "version": "0.48.4",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Dependency updates

- `react-day-picker`: enforce upgrade to `7.4.8`. ([@lowiebneoot](https://github.com/lowiebneoot) in [#1210])

