### PR TITLE
Tabs: scroll to active tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### Added
 
+- `TitleTab`: added forwardRef. ([@driesd](https://github.com/driesd) in [#1213])
+
 ### Changed
+
+- `TabGroup`: changed to always scroll to the active tab. ([@driesd](https://github.com/driesd) in [#1213])
 
 ### Deprecated
 

--- a/src/components/tab/TabGroup.js
+++ b/src/components/tab/TabGroup.js
@@ -12,6 +12,7 @@ const SCROLL_DISTANCE = 200;
 
 class TabGroup extends PureComponent {
   scrollContainerRef = createRef();
+  activeTabRef = createRef();
 
   state = {
     canScrollLeft: false,
@@ -65,7 +66,12 @@ class TabGroup extends PureComponent {
         paddingHorizontal={size === 'small' ? 2 : 0}
       >
         <Box className={theme['scroll-container']} display="flex" overflowX="scroll" ref={this.scrollContainerRef}>
-          {React.Children.map(children, (child) => React.cloneElement(child, { size }))}
+          {React.Children.map(children, (child) =>
+            React.cloneElement(child, {
+              size,
+              ...(child.props.active && { ref: this.activeTabRef }),
+            }),
+          )}
         </Box>
         {canScrollLeft && (
           <Box className={theme['scroll-left-button-wrapper']}>

--- a/src/components/tab/TabGroup.js
+++ b/src/components/tab/TabGroup.js
@@ -8,6 +8,7 @@ import { IconChevronLeftSmallOutline, IconChevronRightSmallOutline } from '@team
 import cx from 'classnames';
 import theme from './theme.css';
 
+const SCROLL_BUTTON_WIDTH = 48;
 const SCROLL_DISTANCE = 200;
 
 class TabGroup extends PureComponent {
@@ -28,6 +29,11 @@ class TabGroup extends PureComponent {
     this.scrollContainerRef.current.removeEventListener('scroll', this.handleScroll);
   }
 
+  scrollToActiveTab = () => {
+    const { offsetLeft } = this.activeTabRef.current;
+    this.scrollContainerRef.current.scrollTo({ left: offsetLeft - SCROLL_BUTTON_WIDTH });
+  };
+
   checkForScrollPosition = () => {
     const { scrollLeft, scrollWidth, clientWidth } = this.scrollContainerRef.current;
 
@@ -38,6 +44,7 @@ class TabGroup extends PureComponent {
   };
 
   handleResize = () => {
+    this.scrollToActiveTab();
     this.checkForScrollPosition();
   };
 

--- a/src/components/tab/TitleTab.js
+++ b/src/components/tab/TitleTab.js
@@ -1,4 +1,4 @@
-import React, { createRef, PureComponent } from 'react';
+import React, { createRef, forwardRef, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Box from '../box';
 import cx from 'classnames';
@@ -20,8 +20,12 @@ class TitleTab extends PureComponent {
   };
 
   blur = () => {
+    const { forwardedRef } = this.props;
     if (this.tabNode.current) {
       this.tabNode.current.blur();
+    }
+    if (forwardedRef && forwardedRef.current) {
+      forwardedRef.current.blur();
     }
   };
 
@@ -37,7 +41,7 @@ class TitleTab extends PureComponent {
   };
 
   render() {
-    const { active, children, className, counter = null, size, ...others } = this.props;
+    const { active, children, className, counter = null, forwardedRef, size, ...others } = this.props;
     const classNames = cx(theme['title-tab'], { [theme['is-active']]: active }, className);
 
     const rest = omit(others, ['onClick']);
@@ -50,7 +54,7 @@ class TitleTab extends PureComponent {
         className={classNames}
         marginHorizontal={size === 'small' ? 1 : 2}
         paddingHorizontal={this.getPaddingHorizontal()}
-        ref={this.tabNode}
+        ref={forwardedRef || this.tabNode}
         onClick={this.handleClick}
         {...rest}
       >
@@ -77,4 +81,4 @@ TitleTab.defaultProps = {
   size: 'medium',
 };
 
-export default TitleTab;
+export default forwardRef((props, ref) => <TitleTab {...props} forwardedRef={ref} />);

--- a/src/static/data/tab.js
+++ b/src/static/data/tab.js
@@ -12,14 +12,14 @@ const tabItems = [
     title: 'CRM',
   },
   {
-    active: true,
+    active: false,
     count: 30,
     href: '#',
     icon: 'Planning',
     title: 'Planning',
   },
   {
-    active: false,
+    active: true,
     href: '#',
     icon: 'Products',
     title: 'Products',


### PR DESCRIPTION
### Description

This PR makes sure that the `active tab` is always visible when `TabGroup` goes into scrollable overflow mode.

#### Before this PR
<img width="363" alt="Screenshot 2020-07-03 10 54 56" src="https://user-images.githubusercontent.com/5336831/86451863-c7ad2000-bd1b-11ea-8d43-429b2937e2b9.png">

#### After this PR
<img width="364" alt="Screenshot 2020-07-03 10 48 12" src="https://user-images.githubusercontent.com/5336831/86451879-cd0a6a80-bd1b-11ea-9f34-ae3608bd5c56.png">

### Breaking changes

None.