### PR TITLE
Add figma urls

### DIFF
--- a/src/components/checkbox/checkbox.stories.js
+++ b/src/components/checkbox/checkbox.stories.js
@@ -9,6 +9,10 @@ export default {
   title: addStoryInGroup(LOW_LEVEL_BLOCKS, 'Form elements/Checkbox'),
 
   parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/LHH25GN90ljQaBEUNMsdJn/Desktop-components?node-id=6454%3A21716',
+    },
     info: {
       propTablesExclude: [Link, TextBody],
     },

--- a/src/components/radio/radio.stories.js
+++ b/src/components/radio/radio.stories.js
@@ -18,6 +18,10 @@ export default {
   title: addStoryInGroup(LOW_LEVEL_BLOCKS, 'Form elements/Radio'),
 
   parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/LHH25GN90ljQaBEUNMsdJn/Desktop-components?node-id=6454%3A22776',
+    },
     info: {
       propTablesExclude: [State],
     },

--- a/src/components/toggle/toggle.stories.js
+++ b/src/components/toggle/toggle.stories.js
@@ -7,6 +7,13 @@ const sizes = ['small', 'medium', 'large'];
 
 export default {
   title: addStoryInGroup(LOW_LEVEL_BLOCKS, 'Form elements/Toggle'),
+
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/LHH25GN90ljQaBEUNMsdJn/Desktop-components?node-id=6454%3A23548',
+    },
+  },
 };
 
 const ControlledToggle = (props) => {


### PR DESCRIPTION
This PR adds the missing Figma urls for `Checkbox`, `Radio` & `Toggle` components.