### PR TITLE
`DatePickerInput`: Add `openPickerOnFocus` prop

### DIFF
--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -64,7 +64,7 @@ class DatePickerInput extends PureComponent {
   };
 
   handleInputClick = (event) => {
-    const { onFocus } = this.props.inputProps;
+    const { onFocus, onClick } = this.props.inputProps;
     const { openPickerOnFocus } = this.props;
 
     if (!openPickerOnFocus) {
@@ -76,6 +76,8 @@ class DatePickerInput extends PureComponent {
         () => onFocus && onFocus(),
       );
     }
+
+    onClick(event);
   };
 
   handlePopoverClose = () => {
@@ -123,8 +125,8 @@ class DatePickerInput extends PureComponent {
           value={this.getFormattedDate()}
           width="120px"
           noInputStyling={dayPickerProps && dayPickerProps.withMonthPicker}
-          onClick={this.handleInputClick}
           {...inputProps}
+          onClick={this.handleInputClick}
           onFocus={this.handleInputFocus}
         />
         <Popover

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -98,13 +98,13 @@ class DatePickerInput extends PureComponent {
       <Box className={className} {...boxProps}>
         <Input
           inverse={inverse}
-          onFocus={this.handleInputFocus}
           prefix={this.renderIcon()}
           size={inputSize || size}
           value={this.getFormattedDate()}
           width="120px"
           noInputStyling={dayPickerProps && dayPickerProps.withMonthPicker}
           {...inputProps}
+          onFocus={this.handleInputFocus}
         />
         <Popover
           active={isPopoverActive}

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -44,18 +44,38 @@ class DatePickerInput extends PureComponent {
 
   handleInputFocus = (event) => {
     const { onFocus, readOnly } = this.props.inputProps;
+    const { openPickerOnFocus } = this.props;
 
     if (readOnly) {
       return;
     }
 
-    this.setState(
-      {
-        popoverAnchorEl: event.currentTarget,
-        isPopoverActive: true,
-      },
-      () => onFocus && onFocus(),
-    );
+    if (openPickerOnFocus) {
+      this.setState(
+        {
+          popoverAnchorEl: event.currentTarget,
+          isPopoverActive: true,
+        },
+        () => onFocus && onFocus(event),
+      );
+    } else {
+      onFocus && onFocus(event);
+    }
+  };
+
+  handleInputClick = (event) => {
+    const { onFocus } = this.props.inputProps;
+    const { openPickerOnFocus } = this.props;
+
+    if (!openPickerOnFocus) {
+      this.setState(
+        {
+          popoverAnchorEl: event.currentTarget,
+          isPopoverActive: true,
+        },
+        () => onFocus && onFocus(),
+      );
+    }
   };
 
   handlePopoverClose = () => {
@@ -103,6 +123,7 @@ class DatePickerInput extends PureComponent {
           value={this.getFormattedDate()}
           width="120px"
           noInputStyling={dayPickerProps && dayPickerProps.withMonthPicker}
+          onClick={this.handleInputClick}
           {...inputProps}
           onFocus={this.handleInputFocus}
         />
@@ -178,6 +199,8 @@ DatePickerInput.propTypes = {
   inputSize: PropTypes.oneOf(['small', 'medium', 'large']),
   /** Overridable size of the DatePicker component. */
   datePickerSize: PropTypes.oneOf(['small', 'medium', 'large']),
+  /** Whether the picker should automatically open on input focus. True by default. */
+  openPickerOnFocus: PropTypes.bool,
 };
 
 DatePickerInput.defaultProps = {
@@ -187,6 +210,7 @@ DatePickerInput.defaultProps = {
   locale: 'en-GB',
   popoverProps: {},
   size: 'medium',
+  openPickerOnFocus: true,
 };
 
 export default DatePickerInput;


### PR DESCRIPTION
### Description

- Fixed: passing `onFocus` prop in `inputProps` on `DatePickerInput` would override the internal handleFocus
- Added: `openPickerOnFocus` prop to `DatePickerInput`, which is set to `true` by default

### Breaking changes

None
