### PR TITLE
Release 0.48.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [0.48.6] - 2020-07-06
+
+### Added
+
+- `DatePickerInput` added `openPickerOnFocus` prop that's `true` by default ([@mikeverf](https://github.com/mikeverf) in [#1216](https://github.com/teamleadercrm/ui/pull/1216))
+
 ## [0.48.5] - 2020-07-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "0.48.5",
+  "version": "0.48.6",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Added

- `DatePickerInput` added `openPickerOnFocus` prop that's `true` by default ([@mikeverf](https://github.com/mikeverf) in [#1216](https://github.com/teamleadercrm/ui/pull/1216))

### Breaking changes

None