### PR TITLE
SilentBanner: full width by default & add inline prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 
-- `SilentBanner`: changed to take the full width by default. ([@driesd](https://github.com/driesd) in [#1220])
+- :boom: `SilentBanner`: changed to take the full width by default. ([@driesd](https://github.com/driesd) in [#1220])
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### Added
 
+- `SilentBanner`: added `inline` boolean prop (default false), which will render the banner inline instead of taking full width. ([@driesd](https://github.com/driesd) in [#1220])
+
 ### Changed
+
+- `SilentBanner`: changed to take the full width by default. ([@driesd](https://github.com/driesd) in [#1220])
 
 ### Deprecated
 

--- a/src/components/silentBanner/SilentBanner.js
+++ b/src/components/silentBanner/SilentBanner.js
@@ -50,13 +50,23 @@ const iconTintMap = {
 
 class SilentBanner extends PureComponent {
   render() {
-    const { children, onClose, primaryAction, secondaryAction, showIcon, status, title, ...others } = this.props;
+    const {
+      children,
+      inline,
+      onClose,
+      primaryAction,
+      secondaryAction,
+      showIcon,
+      status,
+      title,
+      ...others
+    } = this.props;
 
     const hasActions = Boolean(primaryAction || secondaryAction);
     const IconToRender = iconMap[status];
 
     return (
-      <Box {...others} display="flex">
+      <Box {...others} display={inline ? 'inline-flex' : 'flex'}>
         {status && (
           <Box
             backgroundColor={backgroundColorMap[status]}
@@ -117,6 +127,8 @@ class SilentBanner extends PureComponent {
 SilentBanner.propTypes = {
   /** The content to display inside the banner. */
   children: PropTypes.node,
+  /** If true, the banner will be rendered inline instead of taking full width. */
+  inline: PropTypes.bool,
   /** Callback function that is fired when the close button of the banner is clicked. */
   onClose: PropTypes.func,
   /** Object containing the props of the primary action (a Button). */

--- a/src/components/silentBanner/SilentBanner.js
+++ b/src/components/silentBanner/SilentBanner.js
@@ -86,9 +86,10 @@ class SilentBanner extends PureComponent {
           borderTopRightRadius="rounded"
           borderBottomLeftRadius={status ? 'square' : 'rounded'}
           borderTopLeftRadius={status ? 'square' : 'rounded'}
+          flex={1}
           display="flex"
         >
-          <Box paddingLeft={status ? 3 : 4} paddingRight={4} paddingVertical={4}>
+          <Box flex={1} paddingLeft={status ? 3 : 4} paddingRight={4} paddingVertical={4}>
             {title && (
               <Heading3 color="teal" marginBottom={2}>
                 {title}

--- a/src/components/silentBanner/silentBanner.stories.js
+++ b/src/components/silentBanner/silentBanner.stories.js
@@ -21,7 +21,7 @@ export default {
 };
 
 export const basic = () => (
-  <SilentBanner title={text('Title', 'I am the title of this message')}>
+  <SilentBanner inline={boolean('Inline', false)} title={text('Title', 'I am the title of this message')}>
     Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link> tempor
     invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
   </SilentBanner>
@@ -29,6 +29,7 @@ export const basic = () => (
 
 export const dismissable = () => (
   <SilentBanner
+    inline={boolean('Inline', false)}
     onClose={() => console.log('onClose click handler')}
     title={text('Title', 'I am the title of this message')}
   >
@@ -39,6 +40,7 @@ export const dismissable = () => (
 
 export const withActions = () => (
   <SilentBanner
+    inline={boolean('Inline', false)}
     primaryAction={{
       label: text('Primary action label', 'Primary action'),
       onClick: () => console.log('primaryAction.onClick'),
@@ -56,6 +58,7 @@ export const withActions = () => (
 
 export const withStatus = () => (
   <SilentBanner
+    inline={boolean('Inline', false)}
     showIcon={boolean('Show icon', false)}
     status={select('Status', statusValues, 'success')}
     title={text('Title', 'I am the title of this message')}
@@ -67,6 +70,7 @@ export const withStatus = () => (
 
 export const fullOption = () => (
   <SilentBanner
+    inline={boolean('Inline', false)}
     onClose={() => console.log('onClose click handler')}
     primaryAction={{
       label: text('Primary action label', 'Primary action'),


### PR DESCRIPTION
### Description

About our `SilentBanner` component.

This PR:
- changes the inline rendering into full width by default
- introduces the `inline` prop

#### Full width
![Screenshot 2020-07-06 14 45 56](https://user-images.githubusercontent.com/5336831/86594544-81fc8b80-bf97-11ea-8562-865eb7713e12.png)


#### Inline
![Screenshot 2020-07-06 14 45 42](https://user-images.githubusercontent.com/5336831/86594523-7741f680-bf97-11ea-8064-990f7d74abd0.png)

### :boom: Breaking changes

The default inline rendering has changed into full width.
