### PR TITLE
SilentBanner: remove children's TextBody wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Removed
 
+- :boom: `SilentBanner`: removed children's `TextBody` wrapper. ([@driesd](https://github.com/driesd) in [#1221])
+
 ### Fixed
 
 ### Dependency updates

--- a/src/components/silentBanner/SilentBanner.js
+++ b/src/components/silentBanner/SilentBanner.js
@@ -105,7 +105,7 @@ class SilentBanner extends PureComponent {
                 {title}
               </Heading3>
             )}
-            {children && <TextBody color="teal">{children}</TextBody>}
+            {children}
             {hasActions && (
               <ButtonGroup display="flex" justifyContent="flex-end" marginTop={4}>
                 {secondaryAction && <Button level="link" size="small" {...secondaryAction} />}

--- a/src/components/silentBanner/SilentBanner.js
+++ b/src/components/silentBanner/SilentBanner.js
@@ -11,7 +11,7 @@ import Button from '../button';
 import ButtonGroup from '../buttonGroup';
 import Icon from '../icon';
 import { IconButton } from '../iconButton';
-import { Heading3, TextBody } from '../typography';
+import { Heading3 } from '../typography';
 
 const backgroundColorMap = {
   error: 'ruby',

--- a/src/components/silentBanner/silentBanner.stories.js
+++ b/src/components/silentBanner/silentBanner.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { addStoryInGroup, MID_LEVEL_BLOCKS } from '../../../.storybook/utils';
 import { boolean, select, text } from '@storybook/addon-knobs/react';
+import { TextBody } from '../typography';
 import SilentBanner from './SilentBanner';
 import Link from '../link';
 
@@ -22,8 +23,10 @@ export default {
 
 export const basic = () => (
   <SilentBanner inline={boolean('Inline', false)} title={text('Title', 'I am the title of this message')}>
-    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link> tempor
-    invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+    <TextBody color="teal">
+      Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link>{' '}
+      tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+    </TextBody>
   </SilentBanner>
 );
 
@@ -33,8 +36,10 @@ export const dismissable = () => (
     onClose={() => console.log('onClose click handler')}
     title={text('Title', 'I am the title of this message')}
   >
-    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link> tempor
-    invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+    <TextBody color="teal">
+      Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link>{' '}
+      tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+    </TextBody>
   </SilentBanner>
 );
 
@@ -51,8 +56,10 @@ export const withActions = () => (
     }}
     title={text('Title', 'I am the title of this message')}
   >
-    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link> tempor
-    invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+    <TextBody color="teal">
+      Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link>{' '}
+      tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+    </TextBody>
   </SilentBanner>
 );
 
@@ -63,8 +70,10 @@ export const withStatus = () => (
     status={select('Status', statusValues, 'success')}
     title={text('Title', 'I am the title of this message')}
   >
-    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link> tempor
-    invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+    <TextBody color="teal">
+      Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link>{' '}
+      tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+    </TextBody>
   </SilentBanner>
 );
 
@@ -84,7 +93,9 @@ export const fullOption = () => (
     status={select('Status', statusValues, 'success')}
     title={text('Title', 'I am the title of this message')}
   >
-    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link> tempor
-    invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+    <TextBody color="teal">
+      Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link>{' '}
+      tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+    </TextBody>
   </SilentBanner>
 );


### PR DESCRIPTION
### Description

This PR removes the children's `TextBody` wrapper from our `SilentBanner ` component.

### :boom: Breaking changes

Removed the children's `TextBody` wrapper.
