### PR TITLE
NumericInput: call onBlur when stepper buttons get blurred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `NumericInput`: call onBlur function if any of the steppers get blurred as well ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1223])
+
 ### Deprecated
 
 ### Removed

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -78,6 +78,12 @@ class NumericInput extends PureComponent {
     this.updateStep(-1);
   };
 
+  handleBlur = (...parameters) => {
+    const { onBlur } = this.props;
+
+    onBlur && onBlur(...parameters);
+  };
+
   isMaxReached = () => this.state.value >= this.props.max;
 
   isMinReached = () => this.state.value <= this.props.min;
@@ -91,6 +97,7 @@ class NumericInput extends PureComponent {
           disabled={this.isMaxReached()}
           icon={<IconAddSmallOutline />}
           onClick={this.handleIncreaseValue}
+          onBlur={this.handleBlur}
           size={size}
         />
       );
@@ -108,6 +115,7 @@ class NumericInput extends PureComponent {
           disabled={this.isMinReached()}
           icon={<IconMinusSmallOutline />}
           onClick={this.handleDecreaseValue}
+          onBlur={this.handleBlur}
           size={size}
         />
       );
@@ -127,10 +135,12 @@ class NumericInput extends PureComponent {
           inverse={inverse}
           stepperUpProps={{
             onClick: this.handleIncreaseValue,
+            onBlur: this.handleBlur,
             disabled: this.isMaxReached(),
           }}
           stepperDownProps={{
             onClick: this.handleDecreaseValue,
+            onBlur: this.handleBlur,
             disabled: this.isMinReached(),
           }}
         />,


### PR DESCRIPTION
### Description

* NumericInput: call the onBlur function when one of the buttons get blurred as well

We should either implement a single onBlur call for the entire input (don't blur when switching from the input to the buttons or the other way around), or always call the onBlur function if you blur the input / buttons, I decided to go for the latter for now.