### PR TITLE
Add tabIndex property to date picker footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- `DatePicker`: add tabIndex property to footer ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1226])
+- `DatePicker`: add tabIndex property to footer, add onBlur property ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1226])
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `DatePicker`: add tabIndex property to footer ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1226])
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- `DatePicker`: add tabIndex property to footer, add onBlur property ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1226])
+- `DatePicker`: add tabIndex property to footer, add onBlur property, and remove call to optional onClick ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1226])
 
 ### Deprecated
 

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -77,7 +77,7 @@ class DatePickerInput extends PureComponent {
       );
     }
 
-    onClick(event);
+    onClick && onClick(event);
   };
 
   handlePopoverClose = () => {

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -164,6 +164,7 @@ class DatePickerInput extends PureComponent {
               overflowX="hidden"
               paddingHorizontal={3}
               paddingVertical={3}
+              tabIndex="0"
             >
               {footer}
             </Box>

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -81,6 +81,8 @@ class DatePickerInput extends PureComponent {
   };
 
   handlePopoverClose = () => {
+    const { onBlur } = this.props;
+    onBlur && onBlur({ relatedTarget: null });
     this.setState({ isPopoverActive: false });
   };
 
@@ -192,6 +194,8 @@ DatePickerInput.propTypes = {
   locale: PropTypes.string,
   /** Callback function that is fired when the date has changed. */
   onChange: PropTypes.func,
+  /** Callback function that is fired when the popover with the calendar gets closed (unfocused) */
+  onBlur: PropTypes.func,
   /** Object with props for the Popover component. */
   popoverProps: PropTypes.object,
   /** The current selected date. */


### PR DESCRIPTION
### Description

* This will make sure we can detect clicking outside of the DatePicker (there was already a tabindex on the DayPicker itself)

