### PR TITLE
Storybook 6: replace Knobs addon with Controls part 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@babel/preset-react": "^7.10.4",
     "@sambego/storybook-state": "^2.0.1",
     "@storybook/addon-backgrounds": "6.0.0-rc.15",
+    "@storybook/addon-controls": "^6.0.0-beta.15",
     "@storybook/addon-knobs": "6.0.0-rc.15",
     "@storybook/addons": "6.0.0-rc.15",
     "@storybook/react": "6.0.0-rc.15",

--- a/src/components/advancedCollapsible/advancedCollapsible.stories.js
+++ b/src/components/advancedCollapsible/advancedCollapsible.stories.js
@@ -1,28 +1,14 @@
 import React from 'react';
 import { addStoryInGroup, MID_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { select, text } from '@storybook/addon-knobs';
 import { AdvancedCollapsible, TextBody } from '../../index';
-
-const colors = ['neutral', 'teal'];
-const sizes = ['small', 'medium', 'large'];
 
 export default {
   component: AdvancedCollapsible,
   title: addStoryInGroup(MID_LEVEL_BLOCKS, 'AdvancedCollapsible'),
-
-  parameters: {
-    info: {
-      propTablesExclude: [TextBody],
-    },
-  },
 };
 
-export const basic = () => (
-  <AdvancedCollapsible
-    color={select('Color', colors, 'teal')}
-    size={select('Size', sizes, 'medium')}
-    title={text('Title', 'Click this title to expand the content')}
-  >
+export const Basic = (args) => (
+  <AdvancedCollapsible {...args}>
     <TextBody color="teal">
       Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
       dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita
@@ -35,3 +21,7 @@ export const basic = () => (
     </TextBody>
   </AdvancedCollapsible>
 );
+
+Basic.args = {
+  title: 'Click this title to expand the content',
+};

--- a/src/components/badge/badge.stories.js
+++ b/src/components/badge/badge.stories.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { boolean, select } from '@storybook/addon-knobs';
 import { IconBuildingSmallOutline } from '@teamleader/ui-icons';
-import { Badge, TextDisplay } from '../../index';
-
-const iconPositions = ['left', 'right'];
-const sizes = ['small', 'medium', 'large'];
+import Badge from './Badge';
 
 export default {
   component: Badge,
@@ -16,45 +12,27 @@ export default {
       type: 'figma',
       url: 'https://www.figma.com/file/LHH25GN90ljQaBEUNMsdJn/Desktop-components?node-id=3943%3A715',
     },
-    info: {
-      propTablesExclude: [TextDisplay],
-    },
   },
 };
 
-export const basic = () => (
-  <Badge disabled={boolean('Disabled', false)} size={select('Size', sizes, 'medium')}>
-    I'm a badge
-  </Badge>
-);
+export const basic = (args) => <Badge {...args}>I'm a badge</Badge>;
 
-export const withIcon = () => (
-  <Badge
-    disabled={boolean('Disabled', false)}
-    icon={<IconBuildingSmallOutline />}
-    iconPlacement={select('Icon placement', iconPositions, 'left')}
-    selected={boolean('Selected', false)}
-    size={select('Size', sizes, 'medium')}
-  >
-    I'm a badge
-  </Badge>
-);
+export const withIcon = (args) => <Badge {...args}>I'm a badge</Badge>;
+
+withIcon.args = {
+  icon: <IconBuildingSmallOutline />,
+};
 
 withIcon.story = {
   name: 'With icon',
 };
 
-export const withCustomElement = () => (
-  <Badge
-    disabled={boolean('Disabled', false)}
-    element="a"
-    href="https://teamleader.eu"
-    selected={boolean('Selected', false)}
-    size={select('Size', sizes, 'medium')}
-  >
-    I'm a badge
-  </Badge>
-);
+export const withCustomElement = (args) => <Badge {...args}>I'm a badge</Badge>;
+
+withCustomElement.args = {
+  element: 'a',
+  href: 'https://teamleader.eu',
+};
 
 withCustomElement.story = {
   name: 'With custom element',

--- a/src/components/bullet/bullet.stories.js
+++ b/src/components/bullet/bullet.stories.js
@@ -1,91 +1,10 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { select } from '@storybook/addon-knobs';
-import {
-  Box,
-  Bullet,
-  Tooltip,
-  Heading1,
-  Heading2,
-  Heading3,
-  Heading4,
-  TextBody,
-  TextDisplay,
-  TextSmall,
-  COLORS,
-  TINTS,
-} from '../../index';
-
-const colors = ['neutral', 'mint', 'aqua', 'violet', 'teal', 'gold', 'ruby'];
-const sizes = ['small', 'medium', 'large'];
-
-const TooltippedBullet = Tooltip(Bullet);
+import Bullet from './Bullet';
 
 export default {
   component: Bullet,
   title: addStoryInGroup(LOW_LEVEL_BLOCKS, 'Bullet'),
-
-  parameters: {
-    info: {
-      propTablesExclude: [Box, Heading1, Heading2, Heading3, Heading4, TextBody, TextDisplay, TextSmall],
-    },
-  },
 };
 
-export const basic = () => (
-  <Bullet
-    borderColor={select('Border color', COLORS, 'neutral')}
-    borderTint={select('Border tint', TINTS, 'lightest')}
-    color={select('Color', colors, 'neutral')}
-    size={select('Size', sizes, 'medium')}
-  />
-);
-
-export const withTooltip = () => (
-  <TooltippedBullet
-    color={select('Color', colors, 'ruby')}
-    size={select('Size', sizes, 'medium')}
-    tooltip={<TextBody>I am the tooltip</TextBody>}
-  />
-);
-
-withTooltip.story = {
-  name: 'With tooltip',
-};
-
-export const inlineWithText = () => (
-  <Box>
-    <Heading1>
-      <Bullet color={select('Color', colors, 'aqua')} size="medium" />
-      I'm an Header 1 with a subtle status
-    </Heading1>
-    <Heading2 marginTop={4}>
-      <Bullet color={select('Color', colors, 'aqua')} size="medium" />
-      I'm an Header 2 with a subtle status
-    </Heading2>
-    <Heading3 marginTop={4}>
-      <Bullet color={select('Color', colors, 'aqua')} size="small" />
-      I'm an Header 3 with a subtle status
-    </Heading3>
-    <Heading4 marginTop={4}>
-      <Bullet color={select('Color', colors, 'aqua')} size="small" />
-      I'm an Header 4 with a subtle status
-    </Heading4>
-    <TextDisplay marginTop={4}>
-      <Bullet color={select('Color', colors, 'aqua')} size="small" />
-      I'm an text display with a subtle status
-    </TextDisplay>
-    <TextBody marginTop={4}>
-      <Bullet color={select('Color', colors, 'aqua')} size="small" />
-      I'm an text body with a subtle status
-    </TextBody>
-    <TextSmall marginTop={4}>
-      <Bullet color={select('Color', colors, 'aqua')} size="small" />
-      I'm an text small with a subtle status
-    </TextSmall>
-  </Box>
-);
-
-inlineWithText.story = {
-  name: 'Inline with text',
-};
+export const basic = (args) => <Bullet {...args} />;

--- a/src/components/button/button.stories.js
+++ b/src/components/button/button.stories.js
@@ -1,14 +1,7 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { boolean, select, text } from '@storybook/addon-knobs';
 import { IconAddMediumOutline, IconAddSmallOutline } from '@teamleader/ui-icons';
-import { Button } from '../../index';
-
-const colors = ['teal', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'white'];
-const elements = ['a', 'button'];
-const iconPositions = ['left', 'right'];
-const levels = ['primary', 'secondary', 'outline', 'destructive', 'link', 'timer'];
-const sizes = ['small', 'medium', 'large'];
+import Button from './Button';
 
 export default {
   component: Button,
@@ -22,76 +15,31 @@ export default {
   },
 };
 
-export const withText = () => (
-  <Button
-    active={boolean('Active', false)}
-    color={select('Color', colors, 'teal')}
-    label={text('Label', 'Button with label')}
-    level={select('Level', levels, 'secondary')}
-    disabled={boolean('Disabled', false)}
-    fullWidth={boolean('Full width', false)}
-    processing={boolean('Processing', false)}
-    inverse={boolean('Inverse', false)}
-    size={select('Size', sizes, 'medium')}
-  />
+export const withTextAndIcon = ({ size, ...args }) => (
+  <Button {...args} size={size} icon={size === 'small' ? <IconAddSmallOutline /> : <IconAddMediumOutline />} />
 );
 
-withText.story = {
-  name: 'With text',
+withTextAndIcon.args = {
+  label: 'Button with icon and text',
 };
-
-export const withIcon = () => (
-  <Button
-    active={boolean('Active', false)}
-    color={select('Color', colors, 'teal')}
-    icon={select('Size', sizes, 'medium') === 'small' ? <IconAddSmallOutline /> : <IconAddMediumOutline />}
-    level={select('Level', levels, 'secondary')}
-    disabled={boolean('Disabled', false)}
-    fullWidth={boolean('Full width', false)}
-    processing={boolean('Processing', false)}
-    inverse={boolean('Inverse', false)}
-    size={select('Size', sizes, 'medium')}
-  />
-);
-
-withIcon.story = {
-  name: 'With icon',
-};
-
-export const withTextAndIcon = () => (
-  <Button
-    active={boolean('Active', false)}
-    color={select('Color', colors, 'teal')}
-    icon={select('Size', sizes, 'medium') === 'small' ? <IconAddSmallOutline /> : <IconAddMediumOutline />}
-    iconPlacement={select('Icon placement', iconPositions, 'left')}
-    label={text('Label', 'Button with icon and label')}
-    level={select('Level', levels, 'secondary')}
-    disabled={boolean('Disabled', false)}
-    fullWidth={boolean('Full width', false)}
-    processing={boolean('Processing', false)}
-    inverse={boolean('Inverse', false)}
-    size={select('Size', sizes, 'medium')}
-  />
-);
 
 withTextAndIcon.story = {
   name: 'With text and icon',
 };
 
-export const withCustomElement = () => (
-  <Button
-    active={boolean('Active', false)}
-    color={select('Color', colors, 'teal')}
-    element={select('Element', elements, 'a')}
-    label={text('Label', 'Button with custom element')}
-    level={select('Level', levels, 'secondary')}
-    disabled={boolean('Disabled', false)}
-    fullWidth={boolean('Full width', false)}
-    processing={boolean('Processing', false)}
-    inverse={boolean('Inverse', false)}
-    size={select('Size', sizes, 'medium')}
-  />
-);
+export const WithText = () => <Button label="Button with text" />;
+
+WithText.story = {
+  name: 'With text',
+};
+
+export const withIcon = () => <Button icon={<IconAddMediumOutline />} />;
+
+withIcon.story = {
+  name: 'With icon',
+};
+
+export const withCustomElement = () => <Button element="a" label="Button with custom element" />;
 
 withCustomElement.story = {
   name: 'With custom element',

--- a/src/components/buttonGroup/buttonGroup.stories.js
+++ b/src/components/buttonGroup/buttonGroup.stories.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { boolean } from '@storybook/addon-knobs';
 import { Store, State } from '@sambego/storybook-state';
 import { IconAddMediumOutline } from '@teamleader/ui-icons';
 import Button from '../button';
@@ -17,16 +16,10 @@ const handleChangeValue = (value, event) => {
 export default {
   component: ButtonGroup,
   title: addStoryInGroup(LOW_LEVEL_BLOCKS, 'Button group'),
-
-  parameters: {
-    info: {
-      propTablesExclude: [Button, State],
-    },
-  },
 };
 
-export const normal = () => (
-  <ButtonGroup segmented={boolean('Segmented', false)}>
+export const Normal = (args) => (
+  <ButtonGroup {...args}>
     <Button label="Button 1" />
     <Button label="Button 2" />
     <Button icon={<IconAddMediumOutline />} />
@@ -35,7 +28,7 @@ export const normal = () => (
 
 export const withActive = () => (
   <State store={store}>
-    <ButtonGroup segmented={boolean('Segmented', true)} value="option2" onChange={handleChangeValue} level="secondary">
+    <ButtonGroup segmented value="option2" onChange={handleChangeValue} level="secondary">
       <Button label="Option 1" value="option1" />
       <Button label="Option 2" value="option2" />
       <Button label="Option 3" value="option3" />

--- a/src/components/checkbox/checkbox.stories.js
+++ b/src/components/checkbox/checkbox.stories.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { boolean, select, text } from '@storybook/addon-knobs';
 import { Checkbox, Link, TextBody } from '../../index';
-
-const sizes = ['small', 'medium', 'large'];
 
 export default {
   component: Checkbox,
@@ -14,31 +11,21 @@ export default {
       type: 'figma',
       url: 'https://www.figma.com/file/LHH25GN90ljQaBEUNMsdJn/Desktop-components?node-id=6454%3A21716',
     },
-    info: {
-      propTablesExclude: [Link, TextBody],
-    },
   },
 };
 
-export const defaultStory = () => (
-  <Checkbox
-    checked={boolean('Checked', false)}
-    disabled={boolean('Disabled', false)}
-    label={text('Label', 'I am the label')}
-    size={select('Size', sizes, 'medium')}
-  />
-);
+export const DefaultStory = (args) => <Checkbox {...args} />;
 
-defaultStory.story = {
+DefaultStory.args = {
+  label: 'I am the label',
+};
+
+DefaultStory.story = {
   name: 'Default',
 };
 
-export const withLinkInLabel = () => (
-  <Checkbox
-    checked={boolean('Checked', false)}
-    disabled={boolean('Disabled', false)}
-    size={select('Size', sizes, 'medium')}
-  >
+export const WithLinkInLabel = () => (
+  <Checkbox>
     <TextBody>
       I'm a medium label with a{' '}
       <Link href="#" inherit={false}>
@@ -49,18 +36,12 @@ export const withLinkInLabel = () => (
   </Checkbox>
 );
 
-withLinkInLabel.story = {
+WithLinkInLabel.story = {
   name: 'With link in label',
 };
 
-export const withIndeterminateState = () => (
-  <Checkbox
-    indeterminate={boolean('Indeterminate', false)}
-    label={text('Label', 'I am the label')}
-    size={select('Size', sizes, 'medium')}
-  />
-);
+export const WithIndeterminateState = () => <Checkbox indeterminate />;
 
-withIndeterminateState.story = {
+WithIndeterminateState.story = {
   name: 'With indeterminate state',
 };

--- a/src/components/container/container.stories.js
+++ b/src/components/container/container.stories.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { boolean } from '@storybook/addon-knobs';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
 import Container from '../container';
 import Box from '../box';
@@ -7,16 +6,11 @@ import Box from '../box';
 export default {
   component: Container,
   title: addStoryInGroup(LOW_LEVEL_BLOCKS, 'Container'),
-  parameters: {
-    info: {
-      propTables: [Container],
-    },
-  },
 };
 
-export const basic = () => (
+export const Basic = (args) => (
   <Box backgroundColor="gold" backgroundTint="lightest">
-    <Container fixed={boolean('Fixed width', false)} backgroundColor="violet" backgroundTint="light">
+    <Container {...args} backgroundColor="violet" backgroundTint="light">
       <Box backgroundColor="aqua" backgroundTint="light" style={{ height: 400 }} />
     </Container>
   </Box>

--- a/src/components/counter/counter.stories.js
+++ b/src/components/counter/counter.stories.js
@@ -1,12 +1,6 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { number, select } from '@storybook/addon-knobs';
-import { Counter, Tooltip, TextBody } from '../../index';
-
-const colors = ['neutral', 'mint', 'aqua', 'violet', 'teal', 'gold', 'ruby'];
-const sizes = ['small', 'medium'];
-
-const TooltippedCounter = Tooltip(Counter);
+import Counter from './Counter';
 
 export default {
   component: Counter,
@@ -20,42 +14,18 @@ export default {
   },
 };
 
-export const basic = () => (
-  <Counter
-    count={number('Count', 99)}
-    color={select('Color', colors, 'neutral')}
-    size={select('Size', sizes, 'medium')}
-    maxCount={number('Maximum count', 100)}
-  />
-);
+export const Basic = (args) => <Counter {...args} />;
+Basic.args = { count: 99 };
 
-export const withExtraText = () => (
-  <Counter
-    count={number('Count', 99)}
-    color={select('Color', colors, 'neutral')}
-    size={select('Size', sizes, 'medium')}
-    maxCount={number('Maximum count', 100)}
-  >
-    Tasks
-  </Counter>
-);
-
-withExtraText.story = {
-  name: 'With extra text',
+export const WithMaxCount = (args) => <Counter {...args} />;
+WithMaxCount.args = { count: 99, maxCount: 98 };
+WithMaxCount.story = {
+  name: 'With maxCount',
 };
 
-export const withTooltip = () => (
-  <TooltippedCounter
-    count={number('Count', 99)}
-    color={select('Color', colors, 'neutral')}
-    size={select('Size', sizes, 'medium')}
-    maxCount={number('Maximum count', 100)}
-    tooltip={<TextBody>I am the tooltip</TextBody>}
-  >
-    tasks
-  </TooltippedCounter>
-);
+export const WithExtraText = (args) => <Counter {...args} />;
+WithExtraText.args = { children: 'Tasks', count: 99 };
 
-withTooltip.story = {
-  name: 'With tooltip',
+WithExtraText.story = {
+  name: 'With extra text',
 };

--- a/src/components/emptyState/emptyState.stories.js
+++ b/src/components/emptyState/emptyState.stories.js
@@ -1,10 +1,8 @@
 import React from 'react';
-import { boolean, select } from '@storybook/addon-knobs';
 import { addStoryInGroup, MID_LEVEL_BLOCKS } from '../../../.storybook/utils';
 import EmptyState from './EmptyState';
 import { Marker } from '../typography';
 
-const sizes = ['small', 'medium', 'large'];
 const title = (
   <>
     I am the empty state title that <Marker>highlights</Marker> a keyword
@@ -23,13 +21,16 @@ export default {
   },
 };
 
-export const basic = () => <EmptyState metaText="I am the meta information of the EmptyState" />;
+export const Basic = (args) => <EmptyState {...args} />;
 
-export const withTitle = () => (
-  <EmptyState
-    hidePointer={boolean('Hide pointer', false)}
-    metaText="I am the meta information and I basically explain that you can start adding content via the add button above."
-    size={select('Size', sizes, 'medium')}
-    title={title}
-  />
-);
+Basic.args = {
+  metaText: 'I am the meta information of the EmptyState',
+};
+
+export const WithTitle = (args) => <EmptyState {...args} />;
+
+WithTitle.args = {
+  metaText:
+    'I am the meta information and I basically explain that you can start adding content via the add button above.',
+  title: title,
+};

--- a/src/components/iconButton/iconButton.stories.js
+++ b/src/components/iconButton/iconButton.stories.js
@@ -1,13 +1,7 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { boolean, select } from '@storybook/addon-knobs';
 import { IconAddMediumOutline, IconAddSmallOutline } from '@teamleader/ui-icons';
 import IconButton from './IconButton';
-
-const colors = ['white', 'neutral', 'mint', 'aqua', 'violet', 'teal', 'gold', 'ruby'];
-const tints = ['lightest', 'light', 'normal', 'dark', 'darkest'];
-const elements = ['a', 'button'];
-const sizes = ['small', 'medium', 'large'];
 
 export default {
   component: IconButton,
@@ -21,28 +15,11 @@ export default {
   },
 };
 
-export const basic = () => (
-  <IconButton
-    icon={select('Size', sizes, 'medium') === 'small' ? <IconAddSmallOutline /> : <IconAddMediumOutline />}
-    color={select('Color', colors, 'neutral')}
-    tint={select('Tint', tints, 'darkest')}
-    size={select('Size', sizes, 'medium')}
-    disabled={boolean('Disabled', false)}
-    selected={boolean('Selected', false)}
-  />
+export const basic = ({ size, ...args }) => (
+  <IconButton {...args} icon={size === 'small' ? <IconAddSmallOutline /> : <IconAddMediumOutline />} />
 );
 
-export const withCustomElement = () => (
-  <IconButton
-    icon={select('Size', sizes, 'medium') === 'small' ? <IconAddSmallOutline /> : <IconAddMediumOutline />}
-    color={select('Color', colors, 'neutral')}
-    tint={select('Tint', tints, 'darkest')}
-    element={select('Element', elements, 'a')}
-    size={select('Size', sizes, 'medium')}
-    disabled={boolean('Disabled', false)}
-    selected={boolean('Selected', false)}
-  />
-);
+export const withCustomElement = () => <IconButton icon={<IconAddMediumOutline />} element="a" href="#" />;
 
 withCustomElement.story = {
   name: 'With custom element',

--- a/src/components/island/island.stories.js
+++ b/src/components/island/island.stories.js
@@ -1,94 +1,14 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { boolean, number, select } from '@storybook/addon-knobs';
-import {
-  IllustrationInvoices120X120Static,
-  IllustrationMeetings120X120Static,
-  IllustrationDeals120X120Static,
-  IllustrationContacts120X120Static,
-} from '@teamleader/ui-illustrations';
-import { Island, IslandGroup, Link, TextBody, TextSmall, Heading3 } from '../../index';
-import { IconChevronRightSmallOutline } from '@teamleader/ui-icons';
-
-const colors = ['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'white'];
-const directions = ['horizontal', 'vertical'];
-const sizes = ['small', 'medium', 'large'];
-
-const islandData = [
-  {
-    illustration: <IllustrationContacts120X120Static />,
-    title: 'Contacts',
-    text: 'Manage your clients directly in Teamleader',
-  },
-  {
-    illustration: <IllustrationInvoices120X120Static />,
-    title: 'Invoices',
-    text: 'Send invoices to your clients straight from Teamleader.',
-  },
-  {
-    illustration: <IllustrationMeetings120X120Static />,
-    title: 'Meetings',
-    text: 'Plan meetings and see them straight away in your favourite calendar.',
-  },
-  {
-    illustration: <IllustrationDeals120X120Static />,
-    title: 'Deals',
-    text: 'Keep track of all your deals with our fully integrated module.',
-  },
-];
-
-const islandAmountOptions = {
-  range: true,
-  min: 1,
-  max: islandData.length,
-  step: 1,
-};
+import { Island, TextBody } from '../../index';
 
 export default {
   component: Island,
   title: addStoryInGroup(LOW_LEVEL_BLOCKS, 'Island'),
-
-  parameters: {
-    info: {
-      propTablesExclude: [
-        TextBody,
-        TextSmall,
-        Heading3,
-        Link,
-        IconChevronRightSmallOutline,
-        IllustrationInvoices120X120Static,
-        IllustrationMeetings120X120Static,
-        IllustrationDeals120X120Static,
-      ],
-    },
-  },
 };
 
-export const basic = () => (
-  <Island color={select('Color', colors, 'white')} dark={boolean('Dark', false)} size={select('Size', sizes, 'medium')}>
+export const DefaultStory = (args) => (
+  <Island {...args}>
     <TextBody>I am an island.</TextBody>
   </Island>
 );
-
-export const group = () => (
-  <IslandGroup
-    dark={boolean('Dark', false)}
-    color={select('Color', colors, 'white')}
-    direction={select('Direction', directions, directions[0])}
-    size={select('Size', sizes, 'medium')}
-  >
-    {islandData
-      .slice(0, number('Island amount', 3, islandAmountOptions))
-      .map(({ illustration, title, text }, index) => (
-        <Island key={index} alignItems="center" display="flex" flex={1} flexDirection="column" textAlign="center">
-          {illustration}
-          <Heading3 marginBottom={3}>{title}</Heading3>
-          <TextBody>{text}</TextBody>
-        </Island>
-      ))}
-  </IslandGroup>
-);
-
-group.story = {
-  name: 'IslandGroup',
-};

--- a/src/components/island/islandGroup.stories.js
+++ b/src/components/island/islandGroup.stories.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
+import {
+  IllustrationInvoices120X120Static,
+  IllustrationMeetings120X120Static,
+  IllustrationDeals120X120Static,
+  IllustrationContacts120X120Static,
+} from '@teamleader/ui-illustrations';
+import { Island, IslandGroup, TextBody, Heading3 } from '../../index';
+
+const islandData = [
+  {
+    illustration: <IllustrationContacts120X120Static />,
+    title: 'Contacts',
+    text: 'Manage your clients directly in Teamleader',
+  },
+  {
+    illustration: <IllustrationInvoices120X120Static />,
+    title: 'Invoices',
+    text: 'Send invoices to your clients straight from Teamleader.',
+  },
+  {
+    illustration: <IllustrationMeetings120X120Static />,
+    title: 'Meetings',
+    text: 'Plan meetings and see them straight away in your favourite calendar.',
+  },
+  {
+    illustration: <IllustrationDeals120X120Static />,
+    title: 'Deals',
+    text: 'Keep track of all your deals with our fully integrated module.',
+  },
+];
+
+export default {
+  component: IslandGroup,
+  title: addStoryInGroup(LOW_LEVEL_BLOCKS, 'IslandGroup'),
+};
+
+export const DefaultStory = (args) => (
+  <IslandGroup {...args}>
+    {islandData.map(({ illustration, title, text }, index) => (
+      <Island key={index} alignItems="center" display="flex" flex={1} flexDirection="column" textAlign="center">
+        {illustration}
+        <Heading3 marginBottom={3}>{title}</Heading3>
+        <TextBody>{text}</TextBody>
+      </Island>
+    ))}
+  </IslandGroup>
+);

--- a/src/components/loadingBar/loadingBar.stories.js
+++ b/src/components/loadingBar/loadingBar.stories.js
@@ -1,21 +1,10 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { select } from '@storybook/addon-knobs';
-import { LoadingBar } from '../../index';
-
-const colors = ['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'teal'];
-const sizes = ['small', 'medium', 'large'];
-const tints = ['lightest', 'light', 'normal', 'dark', 'darkest'];
+import LoadingBar from './LoadingBar';
 
 export default {
   component: LoadingBar,
   title: addStoryInGroup(LOW_LEVEL_BLOCKS, 'LoadingBar'),
 };
 
-export const basic = () => (
-  <LoadingBar
-    color={select('Color', colors, 'mint')}
-    size={select('Size', sizes, 'small')}
-    tint={select('Tint', tints, 'normal')}
-  />
-);
+export const basic = (args) => <LoadingBar {...args} />;

--- a/src/components/loadingSpinner/loadingSpinner.stories.js
+++ b/src/components/loadingSpinner/loadingSpinner.stories.js
@@ -1,21 +1,10 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { select } from '@storybook/addon-knobs';
-import { LoadingSpinner } from '../../index';
-
-const colors = ['neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua', 'teal'];
-const sizes = ['small', 'medium'];
-const tints = ['lightest', 'light', 'normal', 'dark', 'darkest'];
+import LoadingSpinner from './LoadingSpinner';
 
 export default {
   component: LoadingSpinner,
   title: addStoryInGroup(LOW_LEVEL_BLOCKS, 'Loading spinner'),
 };
 
-export const basic = () => (
-  <LoadingSpinner
-    color={select('Color', colors, 'teal')}
-    size={select('Size', sizes, 'medium')}
-    tint={select('Tint', tints, 'darkest')}
-  />
-);
+export const DefaultStory = (args) => <LoadingSpinner {...args} />;

--- a/src/components/pagination/pagination.stories.js
+++ b/src/components/pagination/pagination.stories.js
@@ -1,63 +1,36 @@
 import React from 'react';
 import { addStoryInGroup, MID_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { boolean, number } from '@storybook/addon-knobs';
-import { Island, Pagination, Button } from '../../index';
+import { Pagination, Button } from '../../index';
 
 export default {
   component: Pagination,
   title: addStoryInGroup(MID_LEVEL_BLOCKS, 'Pagination'),
-
-  parameters: {
-    info: {
-      propTablesExclude: [Island],
-    },
-  },
 };
 
-export const compact = () => (
-  <Island style={boolean('Inverse', false) ? { backgroundColor: '#2a3b4d' } : {}}>
-    <Pagination
-      numPages={number('Number of pages', 21)}
-      currentPage={number('Current page', 1)}
-      inverse={boolean('Inverse', false)}
-    >
-      {({ number, text, isActive, ...others }) => {
-        return (
-          <Button
-            level="link"
-            label={text}
-            disabled={isActive}
-            inverse={boolean('Inverse', false)}
-            size="small"
-            {...others}
-          />
-        );
-      }}
-    </Pagination>
-  </Island>
+export const Full = ({ inverse, ...args }) => (
+  <Pagination inverse={inverse} {...args}>
+    {({ number, text, isActive, ...others }) => {
+      return <Button level="link" label={text} disabled={isActive} inverse={inverse} size="small" {...others} />;
+    }}
+  </Pagination>
 );
 
-export const normal = () => (
-  <Island style={boolean('Inverse', false) ? { backgroundColor: '#2a3b4d' } : {}}>
-    <Pagination
-      numPages={number('Number of pages', 21)}
-      currentPage={number('Current page', 1)}
-      inverse={boolean('Inverse', false)}
-      prevPageText="previous"
-      nextPageText="next"
-    >
-      {({ number, text, isActive, ...others }) => {
-        return (
-          <Button
-            level="link"
-            label={text}
-            disabled={isActive}
-            inverse={boolean('Inverse', false)}
-            size="small"
-            {...others}
-          />
-        );
-      }}
-    </Pagination>
-  </Island>
+Full.args = {
+  currentPage: 3,
+  nextPageText: 'next',
+  numPages: 21,
+  prevPageText: 'previous',
+};
+
+export const Compact = (args) => (
+  <Pagination {...args}>
+    {({ number, text, isActive, ...others }) => {
+      return <Button level="link" label={text} disabled={isActive} size="small" {...others} />;
+    }}
+  </Pagination>
 );
+
+Compact.args = {
+  currentPage: 3,
+  numPages: 21,
+};

--- a/src/components/section/section.stories.js
+++ b/src/components/section/section.stories.js
@@ -1,28 +1,14 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { boolean, select } from '@storybook/addon-knobs';
 import { Section, TextBody } from '../../index';
-
-const colors = ['mint', 'violet', 'ruby', 'gold', 'aqua', 'white', 'neutral'];
-const sizes = ['small', 'medium', 'large'];
 
 export default {
   component: Section,
   title: addStoryInGroup(LOW_LEVEL_BLOCKS, 'Section'),
-
-  parameters: {
-    info: {
-      propTablesExclude: [TextBody],
-    },
-  },
 };
 
-export const basic = () => (
-  <Section
-    color={select('Color', colors, 'white')}
-    dark={boolean('Dark', false)}
-    size={select('Size', sizes, 'medium')}
-  >
+export const Basic = (args) => (
+  <Section {...args}>
     <TextBody>I am a section</TextBody>
   </Section>
 );

--- a/src/components/statusBullet/statusBullet.stories.js
+++ b/src/components/statusBullet/statusBullet.stories.js
@@ -1,24 +1,14 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { select } from '@storybook/addon-knobs';
 import { StatusBullet, TextBody } from '../../index';
-
-const colors = ['mint', 'violet', 'ruby', 'gold', 'aqua', 'neutral'];
-const sizes = ['small', 'medium'];
 
 export default {
   component: StatusBullet,
   title: addStoryInGroup(LOW_LEVEL_BLOCKS, 'Status Bullet'),
-
-  parameters: {
-    info: {
-      propTablesExclude: [TextBody],
-    },
-  },
 };
 
-export const basic = () => (
-  <StatusBullet color={select('Color', colors, 'neutral')} size={select('Size', sizes, 'medium')}>
+export const Basic = (args) => (
+  <StatusBullet {...args}>
     <TextBody>label</TextBody>
   </StatusBullet>
 );

--- a/src/components/statusLabel/statusLabel.stories.js
+++ b/src/components/statusLabel/statusLabel.stories.js
@@ -1,20 +1,6 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { select } from '@storybook/addon-knobs';
-import {
-  Box,
-  Heading1,
-  Heading2,
-  Heading3,
-  Heading4,
-  StatusLabel,
-  TextBody,
-  TextDisplay,
-  TextSmall,
-} from '../../index';
-
-const colors = ['mint', 'violet', 'ruby', 'gold', 'aqua', 'neutral'];
-const sizes = ['small', 'medium'];
+import StatusLabel from './StatusLabel';
 
 export default {
   component: StatusLabel,
@@ -25,65 +11,7 @@ export default {
       type: 'figma',
       url: 'https://www.figma.com/file/LHH25GN90ljQaBEUNMsdJn/Desktop-components?node-id=246%3A1041',
     },
-    info: {
-      propTablesExclude: [Box, Heading1, Heading2, Heading3, Heading4, TextBody, TextDisplay, TextSmall],
-    },
   },
 };
 
-export const basic = () => (
-  <StatusLabel color={select('Color', colors, 'neutral')} size={select('Size', sizes, 'medium')}>
-    Status label
-  </StatusLabel>
-);
-
-export const inlineWithText = () => (
-  <Box>
-    <Heading1>
-      I'm an Header 1 with a
-      <StatusLabel color={select('Color', colors, 'neutral')} size="medium" marginLeft={2}>
-        Status label
-      </StatusLabel>
-    </Heading1>
-    <Heading2 marginTop={4}>
-      I'm an Header 2 with a
-      <StatusLabel color={select('Color', colors, 'neutral')} size="medium" marginLeft={2}>
-        Status label
-      </StatusLabel>
-    </Heading2>
-    <Heading3 marginTop={4}>
-      I'm an Header 3 with a
-      <StatusLabel color={select('Color', colors, 'neutral')} size="medium" marginLeft={2}>
-        Status label
-      </StatusLabel>
-    </Heading3>
-    <Heading4 marginTop={4}>
-      I'm an Header 4 with a
-      <StatusLabel color={select('Color', colors, 'neutral')} size="medium" marginLeft={2}>
-        Status label
-      </StatusLabel>
-    </Heading4>
-    <TextDisplay marginTop={4}>
-      I'm an text display with a
-      <StatusLabel color={select('Color', colors, 'neutral')} size="medium" marginLeft={2}>
-        Status label
-      </StatusLabel>
-    </TextDisplay>
-    <TextBody marginTop={4}>
-      I'm an text body with a
-      <StatusLabel color={select('Color', colors, 'neutral')} size="small" marginLeft={2}>
-        Status label
-      </StatusLabel>
-    </TextBody>
-    <TextSmall marginTop={4}>
-      I'm an text small with a
-      <StatusLabel color={select('Color', colors, 'neutral')} size="small" marginLeft={2}>
-        Status label
-      </StatusLabel>
-    </TextSmall>
-  </Box>
-);
-
-inlineWithText.story = {
-  name: 'Inline with text',
-};
+export const Basic = (args) => <StatusLabel {...args}>Status label</StatusLabel>;

--- a/src/components/timer/timer.stories.js
+++ b/src/components/timer/timer.stories.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { boolean } from '@storybook/addon-knobs';
 import Timer from './Timer';
 
 export default {
@@ -8,8 +7,4 @@ export default {
   title: addStoryInGroup(LOW_LEVEL_BLOCKS, 'Timer'),
 };
 
-export const basic = () => (
-  <Timer loading={boolean('Loading', false)} running={boolean('Running', false)}>
-    01:26
-  </Timer>
-);
+export const Basic = (args) => <Timer {...args}>01:26</Timer>;

--- a/src/components/timerPulser/timerPulser.stories.js
+++ b/src/components/timerPulser/timerPulser.stories.js
@@ -1,13 +1,10 @@
 import React from 'react';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { select } from '@storybook/addon-knobs';
-import { TimerPulser } from '../../index';
-
-const sizes = ['small', 'medium', 'large'];
+import TimerPulser from './TimerPulser';
 
 export default {
   component: TimerPulser,
   title: addStoryInGroup(LOW_LEVEL_BLOCKS, 'TimerPulser'),
 };
 
-export const basic = () => <TimerPulser size={select('Size', sizes, 'medium')} />;
+export const Basic = (args) => <TimerPulser {...args} />;

--- a/src/components/widget/widget.stories.js
+++ b/src/components/widget/widget.stories.js
@@ -1,82 +1,16 @@
 import React from 'react';
 import { addStoryInGroup, COMPOSITIONS } from '../../../.storybook/utils';
-import { select } from '@storybook/addon-knobs';
-import {
-  Box,
-  ButtonGroup,
-  DatePicker,
-  Heading3,
-  Heading5,
-  IconButton,
-  IconMenu,
-  MenuItem,
-  TextBody,
-  Widget,
-  MenuDivider,
-} from '../../index';
+import { Box, ButtonGroup, Heading3, IconButton, IconMenu, MenuItem, TextBody, Widget, MenuDivider } from '../../index';
 import { IconAddMediumOutline, IconEditMediumOutline } from '@teamleader/ui-icons';
-import { basic as DataGrid } from '../datagrid/datagrid.stories';
-import { basic as EmptyState, withTitle as EmptyStateWithTitle } from '../emptyState/emptyState.stories';
-
-const colors = ['mint', 'violet', 'ruby', 'gold', 'aqua', 'white', 'neutral'];
-const sizes = ['small', 'medium', 'large'];
 
 export default {
   component: Widget,
   title: addStoryInGroup(COMPOSITIONS, 'Widget'),
 };
 
-export const basic = () => (
-  <Widget size={select('Size', sizes, 'medium')}>
-    <Widget.Body>
-      <EmptyState />
-    </Widget.Body>
-  </Widget>
-);
-
-export const withHeader = () => (
-  <Widget size={select('Size', sizes, 'medium')}>
-    <Widget.Header color={select('Header color', colors, 'white')}>
-      <Heading3>I am the widget header title</Heading3>
-    </Widget.Header>
-    <Widget.Body>
-      <EmptyState />
-    </Widget.Body>
-  </Widget>
-);
-
-withHeader.story = {
-  name: 'With header',
-};
-
-export const withHeaderAndAction = () => (
-  <Widget size={select('Size', sizes, 'medium')}>
-    <Widget.Header color={select('Header color', colors, 'white')} display="flex" alignItems="center">
-      <Box flex={1}>
-        <Heading3>I am the widget header title</Heading3>
-      </Box>
-      <Box>
-        <IconButton icon={<IconAddMediumOutline />} />
-      </Box>
-    </Widget.Header>
-    <Widget.Body>
-      <EmptyStateWithTitle />
-    </Widget.Body>
-  </Widget>
-);
-
-withHeaderAndAction.story = {
-  name: 'With header and action',
-};
-
-export const withHeaderAndMulipleActions = () => (
-  <Widget size={select('Size', sizes, 'medium')}>
-    <Widget.Header
-      color={select('header color', colors, 'white')}
-      display="flex"
-      alignItems="center"
-      justifyContent="space-between"
-    >
+export const FullWidget = (args) => (
+  <Widget {...args}>
+    <Widget.Header display="flex" alignItems="center" justifyContent="space-between">
       <Heading3>I am the widget header title</Heading3>
       <ButtonGroup>
         <IconButton icon={<IconEditMediumOutline />} />
@@ -95,12 +29,43 @@ export const withHeaderAndMulipleActions = () => (
   </Widget>
 );
 
-withHeaderAndMulipleActions.story = {
-  name: 'With header and muliple actions',
-};
+export const Basic = () => (
+  <Widget>
+    <Widget.Body>
+      <TextBody>Here you can add arbitrary content.</TextBody>
+    </Widget.Body>
+  </Widget>
+);
 
-export const withFooter = () => (
-  <Widget size={select('Size', sizes, 'medium')}>
+export const WithHeader = () => (
+  <Widget>
+    <Widget.Header>
+      <Heading3>I am the widget header title</Heading3>
+    </Widget.Header>
+    <Widget.Body>
+      <TextBody>Here you can add arbitrary content.</TextBody>
+    </Widget.Body>
+  </Widget>
+);
+
+export const WithHeaderAndAction = () => (
+  <Widget>
+    <Widget.Header display="flex" alignItems="center">
+      <Box flex={1}>
+        <Heading3>I am the widget header title</Heading3>
+      </Box>
+      <Box>
+        <IconButton icon={<IconAddMediumOutline />} />
+      </Box>
+    </Widget.Header>
+    <Widget.Body>
+      <TextBody>Here you can add arbitrary content.</TextBody>
+    </Widget.Body>
+  </Widget>
+);
+
+export const WithFooter = () => (
+  <Widget>
     <Widget.Body>
       <TextBody>Here you can add arbitrary content.</TextBody>
     </Widget.Body>
@@ -111,106 +76,3 @@ export const withFooter = () => (
     </Widget.Footer>
   </Widget>
 );
-
-withFooter.story = {
-  name: 'With footer',
-};
-
-export const fullWidget = () => (
-  <Widget size={select('Size', sizes, 'medium')}>
-    <Widget.Header color={select('Header color', colors, 'white')}>
-      <Heading3>I am the widget header title</Heading3>
-    </Widget.Header>
-    <Widget.Body>
-      <TextBody>Here you can add arbitrary content.</TextBody>
-    </Widget.Body>
-    <Widget.Footer>
-      <Box display="flex" alignItems="center" justifyContent="space-between">
-        <TextBody>I am the widget footer</TextBody>
-      </Box>
-    </Widget.Footer>
-  </Widget>
-);
-
-fullWidget.story = {
-  name: 'Full widget',
-};
-
-export const fullWidget2Cols = () => (
-  <Widget size={select('Size', sizes, 'medium')}>
-    <Widget.Header color={select('Header color', colors, 'white')}>
-      <Heading3>I am the widget header title</Heading3>
-    </Widget.Header>
-    <Widget.Body display="flex">
-      <Box flex={1}>
-        <Heading5>Column 1 header</Heading5>
-        <TextBody>Here you can add arbitrary content.</TextBody>
-      </Box>
-      <Box flex={1}>
-        <Heading5>Column 2 header</Heading5>
-        <TextBody>Here you can add arbitrary content.</TextBody>
-      </Box>
-    </Widget.Body>
-    <Widget.Footer>
-      <Box display="flex" alignItems="center" justifyContent="space-between">
-        <TextBody>I am the widget footer</TextBody>
-      </Box>
-    </Widget.Footer>
-  </Widget>
-);
-
-fullWidget2Cols.story = {
-  name: 'Full widget 2 cols',
-};
-
-export const withDatePicker = () => (
-  <Widget size={select('Size', sizes, 'medium')}>
-    <Widget.Header color={select('Header color', colors, 'white')}>
-      <Heading3>I am the widget header title</Heading3>
-    </Widget.Header>
-    <Widget.Body padding={0}>
-      <DatePicker
-        locale="nl-BE"
-        numberOfMonths={12}
-        onChange={() => console.log('Date changed')}
-        selectedDate={new Date()}
-      />
-    </Widget.Body>
-  </Widget>
-);
-
-withDatePicker.story = {
-  name: 'With DatePicker',
-};
-
-export const withDataGridOnly = () => (
-  <Widget size={select('Size', sizes, 'medium')}>
-    <Widget.Body padding={0}>
-      <DataGrid />
-    </Widget.Body>
-  </Widget>
-);
-
-withDataGridOnly.story = {
-  name: 'With DataGrid only',
-};
-
-export const withDataGrid = () => (
-  <Widget size={select('Size', sizes, 'medium')}>
-    <Widget.Header color={select('Header color', colors, 'white')}>
-      <Heading3>I am the widget header title</Heading3>
-    </Widget.Header>
-    <Widget.Body padding={0}>
-      <DataGrid />
-    </Widget.Body>
-    <Widget.Footer>
-      <Box display="flex" alignItems="center" justifyContent="space-between">
-        <TextBody>I am the widget footer</TextBody>
-      </Box>
-    </Widget.Footer>
-  </Widget>
-);
-
-withDataGrid.story = {
-  name: 'With DataGrid',
-};

--- a/src/components/wysiwygEditor/wysiwygEditor.stories.js
+++ b/src/components/wysiwygEditor/wysiwygEditor.stories.js
@@ -1,21 +1,14 @@
 import React from 'react';
-import { text } from '@storybook/addon-knobs';
-
 import { addStoryInGroup, MID_LEVEL_BLOCKS } from '../../../.storybook/utils';
-import { WysiwygEditor } from '../../index';
+import WysiwygEditor from './WysiwygEditor';
 
 export default {
   component: WysiwygEditor,
   title: addStoryInGroup(MID_LEVEL_BLOCKS, 'WysiwygEditor'),
 };
 
-export const wysiwygEditor = () => (
-  <WysiwygEditor
-    placeholder="Placeholder text"
-    error={text('Error', '')}
-    success={text('Success', '')}
-    warning={text('Warning', '')}
-    helpText={text('Help text', '')}
-    width={text('Width', undefined)}
-  />
-);
+export const Basic = (args) => <WysiwygEditor {...args} />;
+
+Basic.args = {
+  placeholder: 'Placeholder text',
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2281,6 +2281,17 @@
     react "^16.8.3"
     regenerator-runtime "^0.13.3"
 
+"@storybook/addon-controls@^6.0.0-beta.15":
+  version "6.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-6.0.0-beta.15.tgz#252cbdb65fe02c0b49ab3d3da0372279b712b7ca"
+  integrity sha512-zfBgETnKLefY9EBbUmZakXqm0ebsmXhDfiAT9XFMmAcDoIYeuvkJoTGgc4SRAczHMKAUL7aVbcoUIX2I6txqPA==
+  dependencies:
+    "@storybook/addons" "6.0.0-beta.15"
+    "@storybook/api" "6.0.0-beta.15"
+    "@storybook/client-api" "6.0.0-beta.15"
+    "@storybook/components" "6.0.0-beta.15"
+    core-js "^3.0.1"
+
 "@storybook/addon-docs@^6.0.0-rc.15":
   version "6.0.0-rc.15"
   resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-6.0.0-rc.15.tgz#00ded1dca81dea8705cf975531392ba847fa1bfe"
@@ -2365,6 +2376,21 @@
     global "^4.3.2"
     util-deprecate "^1.0.2"
 
+"@storybook/addons@6.0.0-beta.15":
+  version "6.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.0.0-beta.15.tgz#a0e56cda0326ef74c146676f5a8b30e210365a7d"
+  integrity sha512-LbRbYJjzJbRk31pmNIB3TdvWa464WiDQk1CQ8SNwpV27R9KkwLar0eAiZUIkHDxyaKa0xWr/o/dZw4a6PYPNtw==
+  dependencies:
+    "@storybook/api" "6.0.0-beta.15"
+    "@storybook/channels" "6.0.0-beta.15"
+    "@storybook/client-logger" "6.0.0-beta.15"
+    "@storybook/core-events" "6.0.0-beta.15"
+    "@storybook/router" "6.0.0-beta.15"
+    "@storybook/theming" "6.0.0-beta.15"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    regenerator-runtime "^0.13.3"
+
 "@storybook/addons@6.0.0-rc.15":
   version "6.0.0-rc.15"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.0.0-rc.15.tgz#070808b3813d9d012b62b0d115c3d3bbabac3e79"
@@ -2406,6 +2432,32 @@
     telejson "^3.2.0"
     util-deprecate "^1.0.2"
 
+"@storybook/api@6.0.0-beta.15":
+  version "6.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.0.0-beta.15.tgz#b82d882ea90a005a010d363a3f203690b4fa9dc4"
+  integrity sha512-q6p8YMiisDLN/07Zf0LehZ0fxbGwFNkHHhUHkYtlwU7Rk+XerX1qSt8v1FUkQrF+DCNXvAvqqf15i5FkyOcqXw==
+  dependencies:
+    "@reach/router" "^1.3.3"
+    "@storybook/channels" "6.0.0-beta.15"
+    "@storybook/client-logger" "6.0.0-beta.15"
+    "@storybook/core-events" "6.0.0-beta.15"
+    "@storybook/csf" "0.0.1"
+    "@storybook/router" "6.0.0-beta.15"
+    "@storybook/theming" "6.0.0-beta.15"
+    "@types/reach__router" "^1.3.5"
+    core-js "^3.0.1"
+    fast-deep-equal "^3.1.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    react "^16.8.3"
+    regenerator-runtime "^0.13.3"
+    semver "^7.3.2"
+    store2 "^2.7.1"
+    telejson "^4.0.0"
+    ts-dedent "^1.1.1"
+    util-deprecate "^1.0.2"
+
 "@storybook/api@6.0.0-rc.15":
   version "6.0.0-rc.15"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.0.0-rc.15.tgz#ccfcdf10df2ce2f049c067030fed41ab3128b4c6"
@@ -2443,6 +2495,18 @@
     global "^4.3.2"
     telejson "^3.2.0"
 
+"@storybook/channel-postmessage@6.0.0-beta.15":
+  version "6.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-6.0.0-beta.15.tgz#d6d05918d3a178d1ba85639faa9ead1c2023cd76"
+  integrity sha512-dYbwwaVnylB6E2l/QvzN0e5eK+T06CVSWWjdIEeQIqJL54NxPoxLjvj2+foNW+RW/aEWVoq6Cq9OfWIuqqOwXA==
+  dependencies:
+    "@storybook/channels" "6.0.0-beta.15"
+    "@storybook/client-logger" "6.0.0-beta.15"
+    "@storybook/core-events" "6.0.0-beta.15"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    telejson "^4.0.0"
+
 "@storybook/channel-postmessage@6.0.0-rc.15":
   version "6.0.0-rc.15"
   resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-6.0.0-rc.15.tgz#76badac4d7308bcb7a96f26d99a65f4fded09ffa"
@@ -2462,6 +2526,15 @@
   integrity sha512-38seaeyshRGotTEZJppyYMg/Vx2zRKgFv1L6uGqkJT0LYoNSYtJhsiNFCJ2/KUJu2chAJ/j8h80bpVBVLQ/+WA==
   dependencies:
     core-js "^3.0.1"
+
+"@storybook/channels@6.0.0-beta.15":
+  version "6.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-6.0.0-beta.15.tgz#7e17ff19be5891042eee6c546f21369860f7443a"
+  integrity sha512-7YBJaeehrulpGR8weVF7Ko5aNODoVnVFIpaec8d++Ta4FRwxT7FDfK0uUZk0gum288maLOupE+E7d1pDj5AyPw==
+  dependencies:
+    core-js "^3.0.1"
+    ts-dedent "^1.1.1"
+    util-deprecate "^1.0.2"
 
 "@storybook/channels@6.0.0-rc.15":
   version "6.0.0-rc.15"
@@ -2495,6 +2568,28 @@
     ts-dedent "^1.1.0"
     util-deprecate "^1.0.2"
 
+"@storybook/client-api@6.0.0-beta.15":
+  version "6.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-6.0.0-beta.15.tgz#156aefbca2ab6cc027efc3cf04626f704a68bbde"
+  integrity sha512-jJoDQsUCXusc/P6pxbn++wJukT97Q5frDi+ovVnn7ouvQYMsk+BW7EsaBiG4YPTwgiDzZSUsm0EEb6EvwqI+Mg==
+  dependencies:
+    "@storybook/addons" "6.0.0-beta.15"
+    "@storybook/channel-postmessage" "6.0.0-beta.15"
+    "@storybook/channels" "6.0.0-beta.15"
+    "@storybook/client-logger" "6.0.0-beta.15"
+    "@storybook/core-events" "6.0.0-beta.15"
+    "@storybook/csf" "0.0.1"
+    "@types/webpack-env" "^1.15.2"
+    core-js "^3.0.1"
+    eventemitter3 "^4.0.0"
+    global "^4.3.2"
+    is-plain-object "^3.0.0"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    qs "^6.6.0"
+    stable "^0.1.8"
+    ts-dedent "^1.1.1"
+
 "@storybook/client-api@6.0.0-rc.15":
   version "6.0.0-rc.15"
   resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-6.0.0-rc.15.tgz#ac0b9c365303d28ab33bafd8ce20ecdb27f6e78f"
@@ -2522,6 +2617,13 @@
   version "5.3.19"
   resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-5.3.19.tgz#fbbd186e82102eaca1d6a5cca640271cae862921"
   integrity sha512-nHftT9Ow71YgAd2/tsu79kwKk30mPuE0sGRRUHZVyCRciGFQweKNOS/6xi2Aq+WwBNNjPKNlbgxwRt1yKe1Vkg==
+  dependencies:
+    core-js "^3.0.1"
+
+"@storybook/client-logger@6.0.0-beta.15":
+  version "6.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.0.0-beta.15.tgz#f519cf44242a734a1e843ecf6f7ea625c5cbbe23"
+  integrity sha512-Zo3dQulSEmn3TP/OWDf+c75yCE2FCVEOFU0Pjjo1FwqO6WBnm2cyKCYCmV7vWjkjkMAbYGXOGGca5iLOi1EIWw==
   dependencies:
     core-js "^3.0.1"
 
@@ -2560,6 +2662,38 @@
     simplebar-react "^1.0.0-alpha.6"
     ts-dedent "^1.1.0"
 
+"@storybook/components@6.0.0-beta.15":
+  version "6.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.0.0-beta.15.tgz#dc8c2ae70cbdca30e2f4dff3347635f6aa283b83"
+  integrity sha512-Jy6pYHphos1n1YKqDYNCMse3s9BqHMpBLclVa3TktDbtq7ALBWKz9O45qkUg+JgdLsK4UnxggQeYDH7sfNbK4g==
+  dependencies:
+    "@storybook/client-logger" "6.0.0-beta.15"
+    "@storybook/csf" "0.0.1"
+    "@storybook/theming" "6.0.0-beta.15"
+    "@types/overlayscrollbars" "^1.9.0"
+    "@types/react-color" "^3.0.1"
+    "@types/react-syntax-highlighter" "11.0.4"
+    "@types/react-textarea-autosize" "^4.3.3"
+    core-js "^3.0.1"
+    fast-deep-equal "^3.1.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    markdown-to-jsx "^6.11.4"
+    memoizerific "^1.11.3"
+    overlayscrollbars "^1.10.2"
+    overlayscrollbars-react "^0.2.1"
+    polished "^3.4.4"
+    popper.js "^1.14.7"
+    react "^16.8.3"
+    react-color "^2.17.0"
+    react-dom "^16.8.3"
+    react-helmet-async "^1.0.2"
+    react-popper-tooltip "^2.11.0"
+    react-select "^3.0.8"
+    react-syntax-highlighter "^12.2.1"
+    react-textarea-autosize "^7.1.0"
+    ts-dedent "^1.1.1"
+
 "@storybook/components@6.0.0-rc.15":
   version "6.0.0-rc.15"
   resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.0.0-rc.15.tgz#74708c2e86fedb5bba53495d3cf04518d2e8cd04"
@@ -2592,6 +2726,13 @@
   version "5.3.19"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-5.3.19.tgz#18020cd52e0d8ef0973a8e9622a10d5f99796f79"
   integrity sha512-lh78ySqMS7pDdMJAQAe35d1I/I4yPTqp09Cq0YIYOxx9BQZhah4DZTV1QIZt22H5p2lPb5MWLkWSxBaexZnz8A==
+  dependencies:
+    core-js "^3.0.1"
+
+"@storybook/core-events@6.0.0-beta.15":
+  version "6.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.0.0-beta.15.tgz#7e326eefbb7e79baad36a800f573e8c46163bd4e"
+  integrity sha512-nWIKNeOVI+eKUG5PULz0d1JaWCQSy0zDUxJkt5CzF2RO7xWlqtoKT8vVMoHaTSYQp6hxs2ZTPCwMB7KSgqc8hQ==
   dependencies:
     core-js "^3.0.1"
 
@@ -2888,6 +3029,20 @@
     qs "^6.6.0"
     util-deprecate "^1.0.2"
 
+"@storybook/router@6.0.0-beta.15":
+  version "6.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-6.0.0-beta.15.tgz#2c9161be991f2d10d889301d5013a2b3b5536c7c"
+  integrity sha512-9tMMohGP0VHf/ebZ6DSy5RAbZ2KecJuYRqiKeSoWtlhngbfk1BUrld+xEMnqp1ToA71DYv6RYEwhSdDnC3YZiw==
+  dependencies:
+    "@reach/router" "^1.3.3"
+    "@storybook/csf" "0.0.1"
+    "@types/reach__router" "^1.3.5"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    qs "^6.6.0"
+
 "@storybook/router@6.0.0-rc.15":
   version "6.0.0-rc.15"
   resolved "https://registry.yarnpkg.com/@storybook/router/-/router-6.0.0-rc.15.tgz#58d77a131873265808b8711b03accd5c834210d8"
@@ -2940,6 +3095,24 @@
     prop-types "^15.7.2"
     resolve-from "^5.0.0"
     ts-dedent "^1.1.0"
+
+"@storybook/theming@6.0.0-beta.15":
+  version "6.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.0.0-beta.15.tgz#4a7047a44f491000aca7c6622c6814e013a080b4"
+  integrity sha512-CvxFqZPE6QMDz/1eLOHmnVYh1Xd8IazI+vraJ+7c/0iJwrDlLJYKSRWhZMoR7XIoKoIVh+nHeOtrUqGLIk0uiw==
+  dependencies:
+    "@emotion/core" "^10.0.20"
+    "@emotion/is-prop-valid" "^0.8.6"
+    "@emotion/styled" "^10.0.17"
+    "@storybook/client-logger" "6.0.0-beta.15"
+    core-js "^3.0.1"
+    deep-object-diff "^1.1.0"
+    emotion-theming "^10.0.19"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    polished "^3.4.4"
+    resolve-from "^5.0.0"
+    ts-dedent "^1.1.1"
 
 "@storybook/theming@6.0.0-rc.15", "@storybook/theming@^6.0.0-rc.15":
   version "6.0.0-rc.15"
@@ -10974,6 +11147,11 @@ osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+overlayscrollbars-react@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/overlayscrollbars-react/-/overlayscrollbars-react-0.2.2.tgz#330b5d298090d714af660ef45a73d89964f9172e"
+  integrity sha512-sRJDaKIxD+No6ygMRaCxejuIH2CksSCUTfaDOzDhPt22lI3IPZq/+Ifw2RT4j+U7hgXLn9P5QqA00f2bsZVwPA==
+
 overlayscrollbars@^1.10.2:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/overlayscrollbars/-/overlayscrollbars-1.12.0.tgz#e3e257bbb8a179760c2c712ad08ac2c78583c9f6"
@@ -13733,7 +13911,7 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1:
+semver@^7.2.1, semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
@@ -14582,7 +14760,7 @@ telejson@^3.2.0:
     lodash "^4.17.15"
     memoizerific "^1.11.3"
 
-telejson@^4.0.1:
+telejson@^4.0.0, telejson@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/telejson/-/telejson-4.0.1.tgz#74030dd4456bb99f9e6a5add9a40f71794aba158"
   integrity sha512-NsZukWlbwMYf56bMxnno1K7lMtv2eRO882YU5JlmzXaH5KpkC5tZTh5oMoKhkORHMNSafO+v4W5wayoQnX8Geg==


### PR DESCRIPTION
### Description

This is **part 1** of replacing the old Storybook `Knobs` with their brand new `Controls`.

#### Screenshot before this PR
![Screenshot 2020-07-29 11 52 55](https://user-images.githubusercontent.com/5336831/88785882-12db1700-d192-11ea-9c39-c34992deec64.png)

#### Screenshot after this PR
![Screenshot 2020-07-29 11 52 18](https://user-images.githubusercontent.com/5336831/88785898-179fcb00-d192-11ea-8b3b-860b4bb26346.png)

### Breaking changes

None.
