### PR TITLE
Not clickable Badge/Tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 
+- `Badge/Tag`: when a Badge/Tag is not clickable, it now uses a div as element by default instead of a button ([@lowiebenoot](https://github.com/lowiebenoot) in [#1269])
+- `Badge/Tag`: a clickable Badge/Tag now has a `type="button"` to avoid submitting forms when clicking on the Badge/Tag ([@lowiebenoot](https://github.com/lowiebenoot) in [#1269])
+
 ### Dependency updates
 
 ## [1.0.2] - 2020-07-13

--- a/src/components/badge/Badge.js
+++ b/src/components/badge/Badge.js
@@ -66,7 +66,7 @@ class Badge extends PureComponent {
       <Box
         className={classNames}
         data-teamleader-ui="badge"
-        element={element}
+        element={element || onClick ? 'button' : 'div'}
         ref={this.badgeNode}
         onClick={onClick}
         onMouseUp={this.handleMouseUp}
@@ -113,7 +113,6 @@ Badge.propTypes = {
 
 Badge.defaultProps = {
   disabled: false,
-  element: 'button',
   iconPlacement: 'left',
   size: 'medium',
 };

--- a/src/components/badge/Badge.js
+++ b/src/components/badge/Badge.js
@@ -36,12 +36,24 @@ class Badge extends PureComponent {
   };
 
   render() {
-    const { children, className, disabled, element, icon, iconPlacement, selected, size, ...others } = this.props;
+    const {
+      children,
+      className,
+      disabled,
+      element,
+      icon,
+      iconPlacement,
+      selected,
+      size,
+      onClick,
+      ...others
+    } = this.props;
 
     const classNames = cx(
       theme['badge'],
       theme[`is-${size}`],
       {
+        [theme['is-clickable']]: onClick,
         [theme['is-disabled']]: disabled,
         [theme['is-selected']]: selected,
       },
@@ -56,6 +68,7 @@ class Badge extends PureComponent {
         data-teamleader-ui="badge"
         element={element}
         ref={this.badgeNode}
+        onClick={onClick}
         onMouseUp={this.handleMouseUp}
         onMouseLeave={this.handleMouseLeave}
         paddingHorizontal={2}
@@ -86,6 +99,8 @@ Badge.propTypes = {
   icon: PropTypes.element,
   /** The position of the icon inside the badge. */
   iconPlacement: PropTypes.oneOf(['left', 'right']),
+  /** Callback function that is fired when clicking on the component. */
+  onClick: PropTypes.func,
   /** Callback function that is fired when mouse leaves the component. */
   onMouseLeave: PropTypes.func,
   /** Callback function that is fired when the mouse button is released. */

--- a/src/components/badge/Badge.js
+++ b/src/components/badge/Badge.js
@@ -61,17 +61,19 @@ class Badge extends PureComponent {
     );
 
     const TextElement = size === 'small' ? UITextSmall : size === 'large' ? UITextDisplay : UITextBody;
+    const boxElement = element || onClick ? 'button' : 'div';
 
     return (
       <Box
         className={classNames}
         data-teamleader-ui="badge"
-        element={element || onClick ? 'button' : 'div'}
+        element={boxElement}
         ref={this.badgeNode}
         onClick={onClick}
         onMouseUp={this.handleMouseUp}
         onMouseLeave={this.handleMouseLeave}
         paddingHorizontal={2}
+        type={boxElement === 'button' ? 'button' : undefined}
         {...others}
       >
         {icon && iconPlacement === 'left' && this.renderIcon()}

--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -13,7 +13,6 @@
   border: var(--badge-border-width) solid color(var(--color-neutral-darkest) a(12%));
   border-radius: var(--badge-border-radius);
   color: var(--color-teal-darkest);
-  cursor: pointer;
   display: inline-flex;
   align-items: center;
   outline: none;
@@ -37,9 +36,10 @@
     white-space: nowrap;
   }
 
-  &:not(.is-disabled) {
+  &.is-clickable:not(.is-disabled) {
     &:hover {
       background-color: color(var(--color-neutral-darkest) a(18%));
+      cursor: pointer;
     }
 
     &:focus {


### PR DESCRIPTION
### Description

Badges and Tags (because Tag uses Badge internally) that are not clickable appear clickable and interactable. When there's no onClick handler, they still used a button as element and had :hover interaction.

Also made sure that when the Badge is using a button as element, it has a `type="button"` to avoid submitting forms with the Badges/Tags.

