### PR TITLE
Add Edit-action for medium-sized Avatars (on hover)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `AvatarImage/AvatarInitials`: Added hover functionality for the AvatarInitials and AvatarImage components, which allows medium-sized Avatars to display a full height edit action ([@sanderbrugge](https://github.com/sanderbrugge) in [#1290])
+
 ### Changed
 
 ### Deprecated

--- a/src/components/avatar/AvatarImage.js
+++ b/src/components/avatar/AvatarImage.js
@@ -5,13 +5,33 @@ import theme from './theme.css';
 import AvatarOverlay from './AvatarOverlay';
 
 class AvatarImage extends PureComponent {
+  state = {
+    displayAvatarOverlay: false,
+  };
+
+  handleOnMouseEnter = () => {
+    this.setState({ displayAvatarOverlay: true });
+  };
+
+  handleOnMouseLeave = () => {
+    this.setState({ displayAvatarOverlay: false });
+  };
+
   render() {
     const { children, editable, image, imageAlt, onImageChange, size, onImageLoadFailure } = this.props;
+    const { displayAvatarOverlay } = this.state;
+    const shouldShowAvatarOverlay =
+      editable && (size === 'large' || size === 'hero' || (size === 'medium' && displayAvatarOverlay));
 
     return (
-      <div className={cx(theme['avatar'], theme['avatar-image'])} data-teamleader-ui="avatar-image">
+      <div
+        className={cx(theme['avatar'], theme['avatar-image'])}
+        data-teamleader-ui="avatar-image"
+        onMouseEnter={this.handleOnMouseEnter}
+        onMouseLeave={this.handleOnMouseLeave}
+      >
         <img alt={imageAlt} onError={onImageLoadFailure} src={image} className={theme['image']} />
-        {editable && (size === 'large' || size === 'hero') && <AvatarOverlay onClick={onImageChange} />}
+        {shouldShowAvatarOverlay && <AvatarOverlay onClick={onImageChange} size={size} />}
         {children && <div className={theme['children']}>{children}</div>}
       </div>
     );

--- a/src/components/avatar/AvatarInitials.js
+++ b/src/components/avatar/AvatarInitials.js
@@ -11,6 +11,10 @@ const colors = colorsWithout(['neutral']);
 const hashCode = (hexString) => parseInt(hexString.substr(-5), 16);
 
 class AvatarInitials extends PureComponent {
+  state = {
+    displayAvatarOverlay: false,
+  };
+
   getBackgroundColor = () => {
     const { id } = this.props;
 
@@ -32,8 +36,19 @@ class AvatarInitials extends PureComponent {
     return firstLetter;
   };
 
+  handleOnMouseEnter = () => {
+    this.setState({ displayAvatarOverlay: true });
+  };
+
+  handleOnMouseLeave = () => {
+    this.setState({ displayAvatarOverlay: false });
+  };
+
   render() {
     const { children, editable, id, onImageChange, size } = this.props;
+    const { displayAvatarOverlay } = this.state;
+    const shouldShowAvatarOverlay =
+      editable && (size === 'large' || size === 'hero' || (size === 'medium' && displayAvatarOverlay));
 
     return (
       <Box
@@ -44,11 +59,13 @@ class AvatarInitials extends PureComponent {
         data-teamleader-ui="avatar-initials"
         display="flex"
         justifyContent="center"
+        onMouseEnter={this.handleOnMouseEnter}
+        onMouseLeave={this.handleOnMouseLeave}
       >
         <Heading4 className={theme['initials']} color="neutral" tint={id ? 'lightest' : 'darkest'}>
           {this.getInitials()}
         </Heading4>
-        {editable && (size === 'large' || size === 'hero') && <AvatarOverlay onClick={onImageChange} />}
+        {shouldShowAvatarOverlay && <AvatarOverlay onClick={onImageChange} size={size} />}
         {children && <div className={theme['children']}>{children}</div>}
       </Box>
     );

--- a/src/components/avatar/AvatarOverlay.js
+++ b/src/components/avatar/AvatarOverlay.js
@@ -13,8 +13,6 @@ class AvatarOverlay extends PureComponent {
       size === 'medium' ? theme['full-height'] : theme['default-height'],
     );
 
-    console.log(classNames);
-
     return (
       <div {...this.props} className={theme['overlay']}>
         <Box className={classNames} display="flex" justifyContent="center">

--- a/src/components/avatar/AvatarOverlay.js
+++ b/src/components/avatar/AvatarOverlay.js
@@ -3,12 +3,21 @@ import theme from './theme.css';
 import Box from '../box';
 import Icon from '../icon';
 import { IconEditSmallFilled } from '@teamleader/ui-icons';
+import cx from 'classnames';
 
 class AvatarOverlay extends PureComponent {
   render() {
+    const { size } = this.props;
+    const classNames = cx(
+      theme['overlay-background'],
+      size === 'medium' ? theme['full-height'] : theme['default-height'],
+    );
+
+    console.log(classNames);
+
     return (
       <div {...this.props} className={theme['overlay']}>
-        <Box className={theme['overlay-background']} display="flex" justifyContent="center">
+        <Box className={classNames} display="flex" justifyContent="center">
           <Icon color="neutral" tint="lightest">
             <IconEditSmallFilled />
           </Icon>

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -57,13 +57,21 @@
 }
 
 .overlay-background {
-  background-color: color(var(--color-teal-darkest) a(0.84));
   cursor: pointer;
-  height: 24px;
   left: 0;
   bottom: 0;
   position: absolute;
   width: 100%;
+}
+
+.default-height {
+  background-color: color(var(--color-teal-darkest) a(0.84));
+  height: 24px;
+}
+
+.full-height {
+  background-color: color(var(--color-teal-darkest) a(0.48));
+  height: 100%;
 }
 
 .dark {


### PR DESCRIPTION
### Description

- Added hover functionality for the AvatarInitial and AvatarImage, which allows the medium-sized Avatars to display a full height edit action.
- No breaking changes, will fallback on default css for existing behaviour.
