### PR TITLE
[FIX] Make sure full height avatar overlays are rounded at the top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `AvatarOverlay` Full height overlays are now correctly rounded for round and medium Avatars. ([@sanderbrugge](https://github.com/sanderbrugge) in [#1292])
+
 ### Dependency updates
 
 ## [1.0.3] - 2020-09-02

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -231,7 +231,13 @@
   }
 
   .overlay {
-    border-radius: 0 0 var(--shape-rounded-image-border-radius) var(--shape-rounded-image-border-radius);
+    .default-height {
+      border-radius: 0 0 var(--shape-rounded-image-border-radius) var(--shape-rounded-image-border-radius);
+    }
+
+    .full-height {
+      border-radius: var(--shape-rounded-image-border-radius);
+    }
   }
 }
 


### PR DESCRIPTION
### Description

- I noticed there were rounding issues on the full-height avatar overlays, this is now fixed.

#### Screenshot before this PR

![image](https://user-images.githubusercontent.com/17139460/92081745-d66b8e00-edc3-11ea-8414-4bcdeb1872e9.png)

#### Screenshot after this PR

![image](https://user-images.githubusercontent.com/17139460/92081772-e3887d00-edc3-11ea-92d6-64e91a1617bf.png)

### Breaking changes

None.
