### PR TITLE
[CHORE] Remove "@storybook/addon-docs" as Dependency, and add it as DevDependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Dependencies`: Set "@storybook/addon-docs" as a DevDependency instead of a reguler dependency.
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- `Dependencies`: Set "@storybook/addon-docs" as a DevDependency instead of a reguler dependency.
+- `Dependencies`: Set "@storybook/addon-docs" as a DevDependency instead of a regular dependency.
 
 ### Deprecated
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "@babel/cli": "^7.10.5",
     "@babel/runtime": "^7.10.5",
-    "@storybook/addon-docs": "^6.0.0-rc.15",
     "@teamleader/ui-animations": "^0.0.3",
     "@teamleader/ui-colors": "^0.3.0",
     "@teamleader/ui-icons": "^0.2.29",
@@ -63,6 +62,7 @@
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-react": "^7.10.4",
     "@sambego/storybook-state": "^2.0.1",
+    "@storybook/addon-docs": "^6.0.0-rc.15",
     "@storybook/addon-backgrounds": "6.0.0-rc.15",
     "@storybook/addon-controls": "^6.0.0-beta.15",
     "@storybook/addon-knobs": "6.0.0-rc.15",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "Tarald Rotsaert <tarald.rotsaert@teamleader.eu>",
     "Bert Coppens <bert.coppens@teamleader.eu>",
     "Arnaud Weyts <arnaud.weyts@teamleader.eu>",
-    "Mike Verfaillie  <mike@teamleader.eu>"
+    "Mike Verfaillie  <mike@teamleader.eu>",
+    "Sander Brugge sander.brugge@teamleader.eu"
   ],
   "files": [
     "cjs",


### PR DESCRIPTION
### Description

- The newest version of "@storybook/addon-docs" is requiring a lot of dependencies, which are not needed. They now pollute `yarn.lock`-files from repositories that use this package with unnecessary dependencies.
- It's also throwing vulnerability reports that aren't needed on consuming repo's.

### Breaking changes

- This should not be a breaking change.