### PR TITLE
Avatar: no text-decoration when element is an anchor tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Avatar`: fixed unwanted text-decoration when `element` is an anchor tag ([@driesd](https://github.com/driesd) in [#1319])
+
 ### Dependency updates
 
 ## [1.0.7] - 2020-10-20

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -18,6 +18,11 @@
 
 .wrapper {
   position: relative;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: none;
+  }
 }
 
 .children {


### PR DESCRIPTION
### Description

This PR makes sure Avatars have no text-decoration when the element is an anchor tag. In `Core` this was only on hover, but in other projects, it might be initially as well...

#### Screenshot before this PR
![Screenshot 2020-10-27 at 15 45 09](https://user-images.githubusercontent.com/5336831/97317757-6df0d880-186b-11eb-9577-7172723214cb.png)

#### Screenshot after this PR
![Screenshot 2020-10-27 at 15 40 19](https://user-images.githubusercontent.com/5336831/97317549-3550ff00-186b-11eb-8587-6dea59631e9a.png)

### Breaking changes

None.
