### PR TITLE
IconMenu: preserve visibility of the IconButton when menu is open

### DIFF
--- a/src/components/menu/theme.css
+++ b/src/components/menu/theme.css
@@ -9,6 +9,7 @@
   --menu-padding: calc(0.6 * var(--unit)) 0;
   --menu-outline-border-radius: var(--border-radius-medium);
   --menu-outline-box-shadow: 0 0 0 1px color(var(--color-teal-darkest) a(24%));
+  --menu-position-spacing: 7px; /* Spacing of 6px + 1px outline border */
   --menu-item-background: var(--color-neutral-lightest);
   --menu-item-hover-background: var(--color-neutral-light);
   --menu-item-selected-background: var(--color-aqua-lightest);
@@ -28,9 +29,9 @@
   position: relative;
 
   &.top-left {
-    left: 0;
+    left: 1px;
     position: absolute;
-    top: 0;
+    top: calc(100% + var(--menu-position-spacing));
 
     & > .outline {
       transform-origin: 0 0;
@@ -39,8 +40,8 @@
 
   &.top-right {
     position: absolute;
-    right: 0;
-    top: 0;
+    right: 1px;
+    top: calc(100% + var(--menu-position-spacing));
 
     & > .outline {
       transform-origin: 100% 0;
@@ -48,8 +49,8 @@
   }
 
   &.bottom-left {
-    bottom: 0;
-    left: 0;
+    bottom: calc(100% + var(--menu-position-spacing));
+    left: 1px;
     position: absolute;
 
     & > .outline {
@@ -58,9 +59,9 @@
   }
 
   &.bottom-right {
-    bottom: 0;
+    bottom: calc(100% + var(--menu-position-spacing));
     position: absolute;
-    right: 0;
+    right: 1px;
 
     & > .outline {
       transform-origin: 100% 100%;


### PR DESCRIPTION
### Description

This PR preserves the visibility of the `IconButton` when the `IconMenu` is open. By doing this, we make sure there's no action triggered when our users click the IconButton accidentally twice. When that would happen, the IconMenu would just close.

| ![Screenshot 2020-11-17 at 17 41 02](https://user-images.githubusercontent.com/5336831/99419525-7f725100-28fc-11eb-98e2-c140ff118ebc.png) | ![Screenshot 2020-11-17 at 17 40 31](https://user-images.githubusercontent.com/5336831/99419551-8731f580-28fc-11eb-8678-6502640bac70.png) |
|---|---|
| ![Screenshot 2020-11-17 at 17 41 23](https://user-images.githubusercontent.com/5336831/99419800-ca8c6400-28fc-11eb-8a17-2c2a34e4876f.png) | ![Screenshot 2020-11-17 at 17 41 37](https://user-images.githubusercontent.com/5336831/99419862-dd069d80-28fc-11eb-9520-b31bdfb8ff59.png) |

### Breaking changes

Should be none, because we only changed the menu position vertically.
