### PR TITLE
Menu: fix border width rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+`Menu`: fixed the border-width rendering which occasionally resulted in zero pixels. ([@driesd](https://github.com/driesd) in [#1325])
+
 ### Dependency updates
 
 ## [1.0.8] - 2020-10-28

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -239,7 +239,7 @@ class Menu extends PureComponent {
 
     return (
       <Box data-teamleader-ui="menu" className={classNames} style={this.getRootStyle()} {...boxProps}>
-        {outline ? <div className={outlineClassNames} style={{ width, height }} /> : null}
+        {outline ? <div className={outlineClassNames} style={{ width: Math.ceil(width), height }} /> : null}
         <ul ref={this.menuNode} className={theme['menu-inner']} style={this.getMenuStyle()}>
           {this.getItems()}
         </ul>


### PR DESCRIPTION
### Description

This PR fixes the `Menu`'s border-width rendering which occasionally resulted in zero pixels.

#### Screenshot before this PR
![Screenshot 2020-11-18 at 09 41 51](https://user-images.githubusercontent.com/5336831/99506403-54cadb80-2982-11eb-88d9-01aaecd3d72a.png)

#### Screenshot after this PR
![Screenshot 2020-11-18 at 09 40 44](https://user-images.githubusercontent.com/5336831/99506415-57c5cc00-2982-11eb-8834-5cf28c0db0ba.png)


### Breaking changes

None.
