### PR TITLE
Menu: fix warning when outline width is undefined

### DIFF
--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -239,7 +239,9 @@ class Menu extends PureComponent {
 
     return (
       <Box data-teamleader-ui="menu" className={classNames} style={this.getRootStyle()} {...boxProps}>
-        {outline ? <div className={outlineClassNames} style={{ width: Math.ceil(width), height }} /> : null}
+        {outline ? (
+          <div className={outlineClassNames} style={{ ...(width && { width: Math.ceil(width) }), height }} />
+        ) : null}
         <ul ref={this.menuNode} className={theme['menu-inner']} style={this.getMenuStyle()}>
           {this.getItems()}
         </ul>


### PR DESCRIPTION
This PR fixes a warning when outline width is undefined.

![Screenshot 2020-11-18 at 16 38 21](https://user-images.githubusercontent.com/5336831/99551755-852f6b80-29bc-11eb-86c3-c741bba1b702.png)
