### PR TITLE
IconMenu: fix menu positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `IconMenu`: fixed postioning of the menu. ([@driesd](https://github.com/driesd) in [#1328])
+
 ### Dependency updates
 
 ## [1.0.9] - 2020-11-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixed
 
-- `IconMenu`: fixed postioning of the menu. ([@driesd](https://github.com/driesd) in [#1328])
+- `IconMenu`: fixed positioning of the menu. ([@driesd](https://github.com/driesd) in [#1328])
 
 ### Dependency updates
 

--- a/src/components/menu/theme.css
+++ b/src/components/menu/theme.css
@@ -9,7 +9,8 @@
   --menu-padding: calc(0.6 * var(--unit)) 0;
   --menu-outline-border-radius: var(--border-radius-medium);
   --menu-outline-box-shadow: 0 0 0 1px color(var(--color-teal-darkest) a(24%));
-  --menu-position-spacing: 7px; /* Spacing of 6px + 1px outline border */
+  --menu-position-spacing: 4px; /* Spacing of 3px + 1px outline border */
+  --menu-icon-button-height: 30px;
   --menu-item-background: var(--color-neutral-lightest);
   --menu-item-hover-background: var(--color-neutral-light);
   --menu-item-selected-background: var(--color-aqua-lightest);
@@ -31,7 +32,7 @@
   &.top-left {
     left: 1px;
     position: absolute;
-    top: calc(100% + var(--menu-position-spacing));
+    top: calc(var(--menu-icon-button-height) + var(--menu-position-spacing));
 
     & > .outline {
       transform-origin: 0 0;
@@ -41,7 +42,7 @@
   &.top-right {
     position: absolute;
     right: 1px;
-    top: calc(100% + var(--menu-position-spacing));
+    top: calc(var(--menu-icon-button-height) + var(--menu-position-spacing));
 
     & > .outline {
       transform-origin: 100% 0;
@@ -49,7 +50,7 @@
   }
 
   &.bottom-left {
-    bottom: calc(100% + var(--menu-position-spacing));
+    bottom: calc(var(--menu-icon-button-height) + var(--menu-position-spacing));
     left: 1px;
     position: absolute;
 
@@ -59,7 +60,7 @@
   }
 
   &.bottom-right {
-    bottom: calc(100% + var(--menu-position-spacing));
+    bottom: calc(var(--menu-icon-button-height) + var(--menu-position-spacing));
     position: absolute;
     right: 1px;
 


### PR DESCRIPTION
### Description

This PR fixes the menu positioning. This was a bug I introduced in [my previous PR](https://github.com/teamleadercrm/ui/pull/1324).

#### Screenshot before this PR
![Screenshot 2020-11-18 at 16 47 16](https://user-images.githubusercontent.com/5336831/99552911-d5f39400-29bd-11eb-9327-b32ad34e8da6.png)

#### Screenshot after this PR
![Screenshot 2020-11-18 at 16 45 21](https://user-images.githubusercontent.com/5336831/99552925-d8ee8480-29bd-11eb-9401-ffa604962639.png)


### Breaking changes

None.

### Fixing changes

One.