### PR TITLE
Release 1.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@
 
 ### Fixed
 
-- `IconMenu`: fixed positioning of the menu. ([@driesd](https://github.com/driesd) in [#1328])
-
 ### Dependency updates
+
+## [1.0.10] - 2020-11-19
+
+### Fixed
+
+- `IconMenu`: fixed positioning of the menu. ([@driesd](https://github.com/driesd) in [#1328])
+- `Menu`: fixed warning when outline width is undefined. ([@driesd](https://github.com/driesd) in [#1327])
 
 ## [1.0.9] - 2020-11-18
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Fixed

- `IconMenu`: fixed positioning of the menu. ([@driesd](https://github.com/driesd) in [#1328])
- `Menu`: fixed warning when outline width is undefined. ([@driesd](https://github.com/driesd) in [#1327])