### PR TITLE
[AHOY-424] DatePicker: improve display month picker content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### Added
 
+- `Select`: added `truncateOptionText` boolean prop (default false) which enable truncation of long option text words, but still makes multiline possible. ([@driesd](https://github.com/driesd) in [#1335])
+
 ### Changed
+
+- `DatePicker`: changed the `MonthPicker` to have better text-overflow handling. ([@driesd](https://github.com/driesd) in [#1335])
 
 ### Deprecated
 

--- a/src/components/datepicker/MonthPicker.js
+++ b/src/components/datepicker/MonthPicker.js
@@ -28,16 +28,11 @@ const getMonthOptions = (localeUtils, locale) => {
   return monthOptions;
 };
 
-// e.g. "February 2020" => "Feb"
-// Exception for French language: we use 4 characters
-const formatSelectedMonth = ({ label, value }, locale) => {
-  const isFrench = locale === 'fr' || locale.startsWith('fr-');
-
-  return {
-    value,
-    label: label.substring(0, isFrench ? 4 : 3),
-  };
-};
+// e.g. "February 2020" => "February"
+const formatSelectedMonth = ({ label, value }) => ({
+  value,
+  label: label.split(' ')[0],
+});
 
 // e.g. "February 2020" => "Feb 2020"
 // Exception for French language: we use 4 characters
@@ -109,7 +104,7 @@ const MonthPickerSplit = ({ date, locale, localeUtils, onChange, size }) => {
     <Box className={theme['caption']}>
       <Box display="flex" justifyContent="center">
         <Select
-          value={formatSelectedMonth(selectedMonth, locale)}
+          value={formatSelectedMonth(selectedMonth)}
           className={theme['month-picker-field']}
           options={months}
           onChange={handleChangeMonth}

--- a/src/components/datepicker/MonthPicker.js
+++ b/src/components/datepicker/MonthPicker.js
@@ -114,6 +114,7 @@ const MonthPickerSplit = ({ date, locale, localeUtils, onChange, size }) => {
           options={months}
           onChange={handleChangeMonth}
           width={size === 'small' ? '88px' : '112px'}
+          singleLineOptions
           size="small"
         />
         <NumericInput

--- a/src/components/datepicker/MonthPicker.js
+++ b/src/components/datepicker/MonthPicker.js
@@ -109,7 +109,7 @@ const MonthPickerSplit = ({ date, locale, localeUtils, onChange, size }) => {
           options={months}
           onChange={handleChangeMonth}
           width={size === 'small' ? '88px' : '112px'}
-          singleLineOptions
+          truncateOptionText
           size="small"
         />
         <NumericInput

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -195,9 +195,17 @@ class Select extends PureComponent {
   };
 
   getOptionStyles = (base, { isDisabled, isFocused, isSelected }) => {
+    const { singleLineOptions } = this.props;
     const commonStyles = {
       ...base,
-      wordBreak: 'break-word',
+      ...(singleLineOptions
+        ? {
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }
+        : {
+            wordBreak: 'break-word',
+          }),
       padding: '8px 12px',
     };
 
@@ -373,6 +381,8 @@ Select.propTypes = {
   menuPortalTarget: PropTypes.instanceOf(Element),
   /** A custom width for the menu dropdown */
   menuWidth: PropTypes.string,
+  /** Boolean indicating whether the select option text should render on one single line. */
+  singleLineOptions: PropTypes.bool,
   /** Size of the input element. */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   /** The text string/element to use as success message below the input. */

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -195,10 +195,10 @@ class Select extends PureComponent {
   };
 
   getOptionStyles = (base, { isDisabled, isFocused, isSelected }) => {
-    const { singleLineOptions } = this.props;
+    const { truncateOptionText } = this.props;
     const commonStyles = {
       ...base,
-      ...(singleLineOptions
+      ...(truncateOptionText
         ? {
             overflow: 'hidden',
             textOverflow: 'ellipsis',
@@ -382,7 +382,7 @@ Select.propTypes = {
   /** A custom width for the menu dropdown */
   menuWidth: PropTypes.string,
   /** Boolean indicating whether the select option text should render on one single line. */
-  singleLineOptions: PropTypes.bool,
+  truncateOptionText: PropTypes.bool,
   /** Size of the input element. */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   /** The text string/element to use as success message below the input. */

--- a/src/components/select/select.stories.js
+++ b/src/components/select/select.stories.js
@@ -7,7 +7,7 @@ import { customOptions, groupedOptions, options } from '../../static/data/select
 const sizes = ['small', 'medium', 'large'];
 
 /* eslint react/prop-types: 0 */
-const CustomOption = ({ children, data, innerProps, isFocused, isSelected, isDisabled }) => {
+const CustomOption = ({ children, data, innerProps, isFocused, isSelected, isDisabled, selectProps }) => {
   const boxStyles = {
     backgroundColor: isFocused ? '#e4e4e6' : isSelected ? '#82828c' : '#fff',
     '&:active': {
@@ -22,7 +22,9 @@ const CustomOption = ({ children, data, innerProps, isFocused, isSelected, isDis
   return (
     <Box paddingVertical={2} paddingHorizontal={2} display="flex" alignItems="center" {...innerProps} style={boxStyles}>
       <Avatar imageUrl={data.avatar} size="tiny" marginRight={2} />
-      <TextBody style={textStyles}>{children}</TextBody>
+      <TextBody style={textStyles} maxLines={selectProps.singleLineOptions ? 1 : undefined}>
+        {children}
+      </TextBody>
     </Box>
   );
 };
@@ -50,6 +52,7 @@ export const basic = () => (
     options={options}
     placeholder="Select your favourite(s)"
     size={select('Size', sizes, 'medium')}
+    singleLineOptions={boolean('Single line options', false)}
     hideSelectedOptions={boolean('Hide selected options', false)}
     menuWidth={text('Menu width', undefined)}
     error={text('error', '')}
@@ -72,6 +75,7 @@ export const grouped = () => (
     options={groupedOptions}
     placeholder="Select your favourite(s)"
     size={select('Size', sizes, 'medium')}
+    singleLineOptions={boolean('Single line options', false)}
     hideSelectedOptions={boolean('Hide selected options', false)}
     error={text('error', '')}
     helpText={text('helpText', '')}
@@ -96,6 +100,7 @@ export const customOption = () => (
     options={customOptions}
     placeholder="Select your favourite(s)"
     size={select('Size', sizes, 'medium')}
+    singleLineOptions={boolean('Single line options', false)}
     hideSelectedOptions={boolean('Hide selected options', false)}
     error={text('error', '')}
     helpText={text('helpText', '')}
@@ -137,6 +142,7 @@ export const async = () => {
       options={options}
       placeholder="Select your favourite(s)"
       size={select('size', sizes, 'medium')}
+      singleLineOptions={boolean('Single line options', false)}
       hideSelectedOptions={boolean('hideSelectedOptions', false)}
       error={text('error', '')}
       helpText={text('helpText', '')}

--- a/src/components/select/select.stories.js
+++ b/src/components/select/select.stories.js
@@ -22,7 +22,7 @@ const CustomOption = ({ children, data, innerProps, isFocused, isSelected, isDis
   return (
     <Box paddingVertical={2} paddingHorizontal={2} display="flex" alignItems="center" {...innerProps} style={boxStyles}>
       <Avatar imageUrl={data.avatar} size="tiny" marginRight={2} />
-      <TextBody style={textStyles} maxLines={selectProps.singleLineOptions ? 1 : undefined}>
+      <TextBody style={textStyles} maxLines={selectProps.truncateOptionText ? 1 : undefined}>
         {children}
       </TextBody>
     </Box>
@@ -52,7 +52,7 @@ export const basic = () => (
     options={options}
     placeholder="Select your favourite(s)"
     size={select('Size', sizes, 'medium')}
-    singleLineOptions={boolean('Single line options', false)}
+    truncateOptionText={boolean('Truncate option text', false)}
     hideSelectedOptions={boolean('Hide selected options', false)}
     menuWidth={text('Menu width', undefined)}
     error={text('error', '')}
@@ -75,7 +75,7 @@ export const grouped = () => (
     options={groupedOptions}
     placeholder="Select your favourite(s)"
     size={select('Size', sizes, 'medium')}
-    singleLineOptions={boolean('Single line options', false)}
+    truncateOptionText={boolean('Truncate option text', false)}
     hideSelectedOptions={boolean('Hide selected options', false)}
     error={text('error', '')}
     helpText={text('helpText', '')}
@@ -100,7 +100,7 @@ export const customOption = () => (
     options={customOptions}
     placeholder="Select your favourite(s)"
     size={select('Size', sizes, 'medium')}
-    singleLineOptions={boolean('Single line options', false)}
+    truncateOptionText={boolean('Truncate option text', false)}
     hideSelectedOptions={boolean('Hide selected options', false)}
     error={text('error', '')}
     helpText={text('helpText', '')}
@@ -142,7 +142,7 @@ export const async = () => {
       options={options}
       placeholder="Select your favourite(s)"
       size={select('size', sizes, 'medium')}
-      singleLineOptions={boolean('Single line options', false)}
+      truncateOptionText={boolean('Truncate option text', false)}
       hideSelectedOptions={boolean('hideSelectedOptions', false)}
       error={text('error', '')}
       helpText={text('helpText', '')}


### PR DESCRIPTION
### Description

This PR introduces a `truncateOptionText` prop in our Select component. When `truncateOptionText` is true, it truncates long `Select` option text **words** with an ellipsis, but still makes multiline possible.

With the above in place, we enable better text-overflow handling in our `DatePicker`'s `MonthPicker`.

### Select
#### Screenshot before this PR
![Screenshot 2020-11-20 at 10 50 24](https://user-images.githubusercontent.com/5336831/99785992-3bf72d00-2b1e-11eb-9522-12e55c0bf117.png) ![Screenshot 2020-11-20 at 10 49 52](https://user-images.githubusercontent.com/5336831/99786001-3e598700-2b1e-11eb-9bbf-1610c117c881.png)

#### Screenshot after this PR
![Screenshot 2020-11-20 at 09 50 17](https://user-images.githubusercontent.com/5336831/99785390-64caf280-2b1d-11eb-8d56-c645594af9e4.png) ![Screenshot 2020-11-20 at 10 20 51](https://user-images.githubusercontent.com/5336831/99785412-6ac0d380-2b1d-11eb-8569-a8c4c119cab6.png)

### DatePicker - MonthPicker
#### Screenshot before this PR
![Screenshot 2020-11-20 at 10 56 07](https://user-images.githubusercontent.com/5336831/99786659-0e5eb380-2b1f-11eb-9870-1da655e7f1d9.png) ![Screenshot 2020-11-20 at 10 56 17](https://user-images.githubusercontent.com/5336831/99786680-11f23a80-2b1f-11eb-9f7c-1323a9dda4c7.png)

#### Screenshot after this PR
![Screenshot 2020-11-20 at 10 04 27](https://user-images.githubusercontent.com/5336831/99785490-80ce9400-2b1d-11eb-8746-5cf89ae788e7.png) ![Screenshot 2020-11-20 at 10 04 13](https://user-images.githubusercontent.com/5336831/99785501-8330ee00-2b1d-11eb-9980-15e109def05c.png)

### Breaking changes

None.
