### PR TITLE
Dialog: remove redundant wrapper in dialog rendering implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `DialogBase`: Removed redundant wrapper in dialog rendering implementation ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1361])
+
 ### Deprecated
 
 ### Removed

--- a/src/components/dialog/DialogBase.js
+++ b/src/components/dialog/DialogBase.js
@@ -12,16 +12,6 @@ import theme from './theme.css';
 import uiUtilities from '@teamleader/ui-utilities';
 
 class DialogBase extends PureComponent {
-  dialogRoot = document.createElement('div');
-
-  componentDidMount() {
-    document.body.appendChild(this.dialogRoot);
-  }
-
-  componentWillUnmount() {
-    document.body.removeChild(this.dialogRoot);
-  }
-
   render() {
     const {
       active,
@@ -80,7 +70,7 @@ class DialogBase extends PureComponent {
       </Transition>
     );
 
-    return createPortal(dialog, this.dialogRoot);
+    return createPortal(dialog, document.body);
   }
 }
 


### PR DESCRIPTION
### Description

The `DialogBase` component creates a root div (which is empty) for some reason when rendering itself (trough a React portal). This causes issues since the actual overlay is then a child of that div, and the `position: fixed` set on it is relative to it's containing block (the root div).

### Manual check

- The dialog still mounts and unmounts
