### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,19 @@
 
 ### Changed
 
-- `DialogBase`: Removed redundant wrapper in dialog rendering implementation ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1361])
-
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+### Dependency updates
+
+## [2.0.0] - 2020-12-10
+
+### Changed
+
+- `DialogBase`: Removed redundant wrapper in dialog rendering implementation ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1361])
 
 ### Dependency updates
 
@@ -22,6 +28,15 @@
 - [Breaking] `postcss-mixins` from `6.2.1` to `7.0.1` ([@lowiebenoot](https://github.com/lowiebenoot) in [#1360]).
 - [Breaking] `postcss-nested` from `4.1.2` to `5.0.3` ([@lowiebenoot](https://github.com/lowiebenoot) in [#1360]).
 - [Breaking] `postcss-reporter` from `6.0.1` to `7.0.2` ([@lowiebenoot](https://github.com/lowiebenoot) in [#1360]).
+- `@storybook/addon-backgrounds` from `6.0.0-rc.15` to `6.1.5`
+- `@storybook/addon-controls` from `6.0.0-beta.15` to `6.1.5`
+- `@storybook/addon-docs` from `6.0.0-rc.15` to `6.1.5`
+- `@storybook/addon-knobs` from `6.0.0-rc.15` to `6.1.9`
+- `@storybook/addons` from `6.0.0-rc.15` to `6.1.9`
+- `@storybook/react` from `6.0.0-rc.15` to `6.1.9`
+- `@storybook/theming` from `6.0.0-rc.15` to `6.1.5`
+- `@storybook/ui` from `6.0.0-rc.15` to `6.1.9`
+- `prettier` from `2.1.0` to `2.2.0`
 
 ## [1.0.11] - 2020-11-23
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "1.0.11",
+  "version": "2.0.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## 2.0.0

### Changed

- `DialogBase`: Removed redundant wrapper in dialog rendering implementation ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1361])

### Dependency updates

- Removed `html-webpack-plugin` because it's not used anymore ([@lowiebenoot](https://github.com/lowiebenoot) in [#1346])
- [Breaking] `postcss` from `7.0.17` to `8.2.0` ([@lowiebenoot](https://github.com/lowiebenoot) in [#1360]). This removes support for Node 11 and 13.
- [Breaking] `postcss-cli` from `7.0.0` to `8.3.0` ([@lowiebenoot](https://github.com/lowiebenoot) in [#1360]).
- [Breaking] `postcss-loader` from `3.0.0` to `4.1.0` ([@lowiebenoot](https://github.com/lowiebenoot) in [#1360]).
- [Breaking] `postcss-import` from `12.0.1` to `13.0.0` ([@lowiebenoot](https://github.com/lowiebenoot) in [#1360]).
- [Breaking] `postcss-mixins` from `6.2.1` to `7.0.1` ([@lowiebenoot](https://github.com/lowiebenoot) in [#1360]).
- [Breaking] `postcss-nested` from `4.1.2` to `5.0.3` ([@lowiebenoot](https://github.com/lowiebenoot) in [#1360]).
- [Breaking] `postcss-reporter` from `6.0.1` to `7.0.2` ([@lowiebenoot](https://github.com/lowiebenoot) in [#1360]).
- `@storybook/addon-backgrounds` from `6.0.0-rc.15` to `6.1.5`
- `@storybook/addon-controls` from `6.0.0-beta.15` to `6.1.5`
- `@storybook/addon-docs` from `6.0.0-rc.15` to `6.1.5`
- `@storybook/addon-knobs` from `6.0.0-rc.15` to `6.1.9`
- `@storybook/addons` from `6.0.0-rc.15` to `6.1.9`
- `@storybook/react` from `6.0.0-rc.15` to `6.1.9`
- `@storybook/theming` from `6.0.0-rc.15` to `6.1.5`
- `@storybook/ui` from `6.0.0-rc.15` to `6.1.9`
- `prettier` from `2.1.0` to `2.2.0`