### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,7 @@
 
 ### Added
 
-- `ProgressTracker`: Added support for `alternating` and `color` props. ([@lorgan3](https://github.com/lorgan3) in [#1368])
-- `ProgressStep`: Added a `meta` prop for displaying additional info below the label. ([@lorgan3](https://github.com/lorgan3) in [#1368])
-
 ### Changed
-
-- `Dependencies`: removed redundant postcss-mixins, cleaned up postcss configuration and dependency definition ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1366])
 
 ### Deprecated
 
@@ -16,6 +11,17 @@
 ### Fixed
 
 ### Dependency updates
+
+## [2.1.0] - 2020-12-15
+
+### Added
+
+- `ProgressTracker`: Added support for `alternating` and `color` props. ([@lorgan3](https://github.com/lorgan3) in [#1368])
+- `ProgressStep`: Added a `meta` prop for displaying additional info below the label. ([@lorgan3](https://github.com/lorgan3) in [#1368])
+
+### Changed
+
+- `Dependencies`: removed redundant postcss-mixins, cleaned up postcss configuration and dependency definition ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1366])
 
 ## [2.0.0] - 2020-12-10
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Added

- `ProgressTracker`: Added support for `alternating` and `color` props. ([@lorgan3](https://github.com/lorgan3) in [#1368])
- `ProgressStep`: Added a `meta` prop for displaying additional info below the label. ([@lorgan3](https://github.com/lorgan3) in [#1368])

### Changed

- `Dependencies`: removed redundant postcss-mixins, cleaned up postcss configuration and dependency definition ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1366])