### PR TITLE
Select: pass size property to react-select Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Select`: Pass size property to the Select component, allowing custom components to access it. ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1375])
+
 ### Changed
 
 ### Deprecated

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -358,6 +358,7 @@ class Select extends PureComponent {
           hideSelectedOptions={false}
           menuPortalTarget={portalTarget}
           styles={this.getStyles()}
+          size={size}
           {...restProps}
         />
         <ValidationText error={error} help={helpText} inverse={inverse} success={success} warning={warning} />


### PR DESCRIPTION
### Added

- Pass the size property to the Select component, this way underlying custom components can access the size property in `selectProps`