### PR TITLE
Progresstracker followup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `ProgressTracker`: Make sure bars are not misaligned on different zoomlevels. ([@lorgan3](https://github.com/lorgan3) in [#1378])
+
 ### Dependency updates
 
 ## [2.2.0] - 2020-12-17

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
     "Tarald Rotsaert <tarald.rotsaert@teamleader.eu>",
     "Bert Coppens <bert.coppens@teamleader.eu>",
     "Arnaud Weyts <arnaud.weyts@teamleader.eu>",
-    "Mike Verfaillie  <mike@teamleader.eu>",
-    "Sander Brugge sander.brugge@teamleader.eu"
+    "Mike Verfaillie <mike@teamleader.eu>",
+    "Sander Brugge <sander.brugge@teamleader.eu>",
+    "Lennert Claeys <lennert.claeys@teamleader.eu>"
   ],
   "files": [
     "cjs",

--- a/src/components/progressTracker/progressTracker.stories.js
+++ b/src/components/progressTracker/progressTracker.stories.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import { boolean, number, select } from '@storybook/addon-knobs';
 import { addStoryInGroup, MID_LEVEL_BLOCKS } from '../../../.storybook/utils';
 import ProgressTracker from './ProgressTracker';
+import { COLORS } from '../../index';
 
 const steps = ['Draft', 'Book', 'Send invoices', 'Get paid'];
 
@@ -16,8 +18,18 @@ export default {
   },
 };
 
-export const DefaultStory = (args) => (
-  <ProgressTracker {...args}>
+export const DefaultStory = () => (
+  <ProgressTracker
+    done={boolean('Done', false)}
+    alternating={boolean('Alternating', false)}
+    currentStep={number('Current step', 1, {
+      range: true,
+      min: 0,
+      max: steps.length - 1,
+      step: 1,
+    })}
+    color={select('Color', COLORS, 'mint')}
+  >
     {steps.map((step, index) => (
       <ProgressTracker.ProgressStep
         label={step}
@@ -28,7 +40,3 @@ export const DefaultStory = (args) => (
     ))}
   </ProgressTracker>
 );
-
-DefaultStory.args = {
-  currentStep: 1,
-};

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -40,7 +40,8 @@
 
   &:after {
     left: 50%;
-    transition: width var(--animation-duration) var(--animation-curve-default);
+    transition: width var(--animation-duration) var(--animation-curve-default),
+      background-color 0.1s var(--animation-curve-default) calc(var(--animation-duration) - 0.1s);
     width: 0;
     z-index: 1;
   }

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -171,7 +171,7 @@
 
       &:before,
       &:after {
-        top: 11px;
+        bottom: 47px;
       }
     }
 


### PR DESCRIPTION
### Description

There were 2 minor details I noticed when actually using the component
 - When not at 100% zoom the bars could be misaligned in alternating mode
 - Colors of the bars didn't change at the same time as the bullets

### Manual check
- Enable 'alternating'
- Zoom in our out (for me it happened at 80% and 110%)
- The progresstracker should not be misaligned