### PR TITLE
Bump node version

### DIFF
--- a/ci/deploy-storybook.yml
+++ b/ci/deploy-storybook.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: node
-    tag: '13-slim'
+    tag: '14-slim'
 
 inputs:
   - name: git-design-ui


### PR DESCRIPTION
### Description

The storybook doesn't get deployed anymore because the node version is incompatible 
```
error @teamleader/ui@2.2.0: The engine "node" is incompatible with this module. Expected version "^10.13 || ^12 || >=14". Got "13.14.0"  
```

I just picked the next best node version from [docker hub](https://hub.docker.com/_/node)
