### PR TITLE
Fix Dialog horizontal positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- `Dialog`: fixed the horizontal positioning. ([@driesd](https://github.com/driesd) in [#1416])
 - `ProgressTracker`: Make sure bars are not misaligned on different zoomlevels. ([@lorgan3](https://github.com/lorgan3) in [#1378])
 
 ### Dependency updates

--- a/src/components/dialog/theme.css
+++ b/src/components/dialog/theme.css
@@ -13,6 +13,7 @@
   display: flex;
   height: 100vh;
   justify-content: center;
+  left: 0;
   position: fixed;
   top: 0;
   width: 100vw;


### PR DESCRIPTION
This PR fixes the horizontal positioning of our `Dialog` component.

#### Screenshot before this PR
![Screenshot 2021-01-14 at 10 18 05](https://user-images.githubusercontent.com/5336831/104570156-dcb32600-5651-11eb-8a66-b6036e15be61.png)

#### Screenshot after this PR
![Screenshot 2021-01-14 at 10 17 53](https://user-images.githubusercontent.com/5336831/104570176-e3419d80-5651-11eb-8b31-cd7b5bfd1854.png)

### Breaking changes

None.
