### PR TITLE
Release 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [2.2.2] - 2021-01-15
+
+### Dependency updates
+
+- `react-select`: revert from `3.0.11` to `3.0.4`
+
 ## [2.2.1] - 2021-01-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Dependency updates
 
-- `react-select`: revert from `3.0.11` to `3.0.4`
+- `react-select`: downgrade from `3.0.11` to `3.0.4`
 
 ## [2.2.1] - 2021-01-14
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Dependency updates

- `react-select`: downgrade from `3.0.11` to `3.0.4`
