### PR TITLE
Counter: fix centering when zooming out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### Fixed
 
+- `Counter`: improve centering when zooming out in Chrome on windows. ([@lowiebenoot](https://github.com/lowiebenoot) in [#1436])
+
 ### Dependency updates
 
 - `eslint-config-standard-react` from `9.2.0` to `11.0.1`. ([@driesd](https://github.com/driesd) in [#1422])

--- a/src/components/counter/theme.css
+++ b/src/components/counter/theme.css
@@ -9,22 +9,24 @@
 .counter {
   border-radius: var(--border-radius);
   color: var(--color-white);
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   font-family: var(--font-family-bold);
   font-size: calc(1.2 * var(--unit));
   line-height: 1;
-  text-align: center;
-  vertical-align: middle;
 }
 
 .medium {
   min-width: calc(2.4 * var(--unit));
-  padding: var(--spacer-smaller);
+  height: calc(2.4 * var(--unit));
+  padding: 0 var(--spacer-smaller);
 }
 
 .small {
   min-width: calc(1.8 * var(--unit));
-  padding: var(--spacer-smallest);
+  height: calc(1.8 * var(--unit));
+  padding: 0 var(--spacer-smallest);
 }
 
 .neutral {


### PR DESCRIPTION


### Description

The current centering implementation wasn't centered when zooming out on chrome on windows. It still doesn't look 100% perfect, but it's better.


#### Screenshot before this PR

![Screenshot 2021-01-22 at 10 46 08](https://user-images.githubusercontent.com/330765/105440888-5e363400-5ca2-11eb-8df5-3f5c8ceb4242.png)


#### Screenshot after this PR

![Screenshot 2021-01-22 at 10 48 19](https://user-images.githubusercontent.com/330765/105440911-69895f80-5ca2-11eb-96ff-899aa98a87d5.png)
