### PR TITLE
Release 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### Added
 
-- `MenuItem`: added `children` prop. ([@driesd](https://github.com/driesd) in [#1465])
-
 ### Changed
 
 ### Deprecated
@@ -13,6 +11,23 @@
 ### Fixed
 
 ### Dependency updates
+
+## [2.4.0] - 2021-02-03
+
+### Added
+
+- `MenuItem`: added `children` prop. ([@driesd](https://github.com/driesd) in [#1465])
+
+### Dependency updates
+
+- `@storybook/addon-backgrounds` from `6.1.14` to `6.1.16`
+- `@storybook/addon-docs` from `6.1.14` to `6.1.16`
+- `@storybook/addon-knobs` from `6.1.14` to `6.1.16`
+- `@storybook/addon-controls` from `6.1.14` to `6.1.16`
+- `@storybook/addons` from `6.1.14` to `6.1.16`
+- `@storybook/react` from `6.1.14` to `6.1.16`
+- `@storybook/ui` from `6.1.14` to `6.1.16`
+- `eslint` from `7.18.0` to `7.19.0`
 
 ## [2.3.0] - 2021-01-22
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [2.4.0] - 2021-02-03

### Added

- `MenuItem`: added `children` prop. ([@driesd](https://github.com/driesd) in [#1465])

### Dependency updates

- `@storybook/addon-backgrounds` from `6.1.14` to `6.1.16`
- `@storybook/addon-docs` from `6.1.14` to `6.1.16`
- `@storybook/addon-knobs` from `6.1.14` to `6.1.16`
- `@storybook/addon-controls` from `6.1.14` to `6.1.16`
- `@storybook/addons` from `6.1.14` to `6.1.16`
- `@storybook/react` from `6.1.14` to `6.1.16`
- `@storybook/ui` from `6.1.14` to `6.1.16`
- `eslint` from `7.18.0` to `7.19.0`
