### PR TITLE
Select: fix menu portal target logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Select`: fixed menu portal target logic. ([@driesd](https://github.com/driesd) in [#1474])
+
 ### Dependency updates
 
 ## [2.4.0] - 2021-02-03

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -343,7 +343,7 @@ class Select extends PureComponent {
     });
 
     const Element = creatable ? ReactCreatableSelect : ReactSelect;
-    const portalTarget = menuPortalTarget || typeof window !== 'undefined' ? window.document.body : undefined;
+    const portalTarget = menuPortalTarget || (typeof window !== 'undefined' ? window.document.body : undefined);
 
     return (
       <Box className={wrapperClassnames} {...boxProps}>


### PR DESCRIPTION
This PR fixes the `menu portal target` logic in our `Select` component. Before this PR the `portalTarget` variable could only be `window.document.body` or `undefined`. After this PR it can also be overridden from outside the component.

### Breaking changes

None.
