### PR TITLE
Select: set menuShouldBlockScroll as the default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Select`: changed `menuShouldBlockScroll` to be the default value. ([@driesd](https://github.com/driesd) in [#1482])
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- `Select`: changed `menuShouldBlockScroll` to be the default value. ([@driesd](https://github.com/driesd) in [#1482])
+- [Breaking] `Select`: changed `menuShouldBlockScroll` to be the default value. ([@driesd](https://github.com/driesd) in [#1482])
 
 ### Deprecated
 

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -357,6 +357,7 @@ class Select extends PureComponent {
           }}
           hideSelectedOptions={false}
           menuPortalTarget={portalTarget}
+          menuShouldBlockScroll
           styles={this.getStyles()}
           size={size}
           {...restProps}


### PR DESCRIPTION
This PR sets `menuShouldBlockScroll` as the default value in our Select component. This is an easy fix for our scrolling position problem when the select dropdown is open.

### Breaking changes

`menuShouldBlockScroll` is now the default value.
