### PR TITLE
Select: set menuPlacement 'auto' as the default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Select`: changed `menuPlacement` prop to have `auto` as default value. ([@driesd](https://github.com/driesd) in [#1485])
+
 ### Deprecated
 
 ### Removed

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -356,6 +356,7 @@ class Select extends PureComponent {
             ...components,
           }}
           hideSelectedOptions={false}
+          menuPlacement="auto"
           menuPortalTarget={portalTarget}
           menuShouldBlockScroll
           styles={this.getStyles()}


### PR DESCRIPTION
This PR sets the default `menuPlacement` prop value to `auto` in our `Select` component.

### Breaking changes

None.
