### PR TITLE
Release 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Changed
 
-- `Select`: changed `menuPlacement` prop to have `auto` as default value. ([@driesd](https://github.com/driesd) in [#1485])
-
 ### Deprecated
 
 ### Removed
@@ -13,6 +11,17 @@
 ### Fixed
 
 ### Dependency updates
+
+## [3.1.0] - 2021-02-09
+
+### Changed
+
+- `Select`: changed `menuPlacement` prop to have `auto` as default value. ([@driesd](https://github.com/driesd) in [#1485])
+
+### Dependency updates
+
+- `@storybook/addon-knobs` from `6.1.16` to `6.1.17`
+- `@babel/runtime` from `7.12.5` to `7.12.13`
 
 ## [3.0.0] - 2021-02-09
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Changed

- `Select`: changed `menuPlacement` prop to have `auto` as default value. ([@driesd](https://github.com/driesd) in [#1485])

### Dependency updates

- `@storybook/addon-knobs` from `6.1.16` to `6.1.17`
- `@babel/runtime` from `7.12.5` to `7.12.13`
