### PR TITLE
StatusLabel: add text overflow mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `StatusLabel`: added text-overflow mode. ([@driesd](https://github.com/driesd) in [#1498])
+
 ### Changed
 
 ### Deprecated

--- a/src/components/statusLabel/StatusLabel.js
+++ b/src/components/statusLabel/StatusLabel.js
@@ -29,7 +29,7 @@ class StatusLabel extends PureComponent {
         display="inline-flex"
         paddingHorizontal={2}
       >
-        {children}
+        <span className={theme['inner']}>{children}</span>
       </Element>
     );
   }

--- a/src/components/statusLabel/theme.css
+++ b/src/components/statusLabel/theme.css
@@ -1,4 +1,5 @@
 .label {
+  overflow: hidden;
   text-transform: none;
   vertical-align: middle;
 }
@@ -11,4 +12,10 @@
 .small {
   border-radius: 9px;
   height: 18px;
+}
+
+.inner {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }


### PR DESCRIPTION
This PR implements `text-overflow mode` in our `StatusLabel` component.

![Screenshot 2021-02-19 at 09 48 56](https://user-images.githubusercontent.com/5336831/108481212-34b7fa80-7298-11eb-86c0-77e13b034b2b.png)

![Screenshot 2021-02-19 at 09 51 06](https://user-images.githubusercontent.com/5336831/108481223-384b8180-7298-11eb-8597-c282671205a8.png)

![Screenshot 2021-02-19 at 09 50 01](https://user-images.githubusercontent.com/5336831/108481235-3bdf0880-7298-11eb-9f12-b80f02288d6c.png)

### Breaking changes

None.