### PR TITLE
Marketing typography: MarketingHeading1

### DIFF
--- a/src/components/marketingTypography/MarketingHeading1.js
+++ b/src/components/marketingTypography/MarketingHeading1.js
@@ -1,0 +1,25 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Box from '../box';
+import cx from 'classnames';
+import theme from './theme.css';
+
+class MarketingHeading1 extends Component {
+  render() {
+    const { children, className, ...others } = this.props;
+
+    const classNames = cx(theme['heading-1'], className);
+
+    return (
+      <Box {...others} className={classNames} element="h1">
+        {children}
+      </Box>
+    );
+  }
+}
+
+MarketingHeading1.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+};
+
+export default MarketingHeading1;

--- a/src/components/marketingTypography/index.js
+++ b/src/components/marketingTypography/index.js
@@ -1,0 +1,3 @@
+import MarketingHeading1 from './MarketingHeading1';
+
+export { MarketingHeading1 };

--- a/src/components/marketingTypography/marketingTypography.stories.js
+++ b/src/components/marketingTypography/marketingTypography.stories.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { addStoryInGroup, MARKETING } from '../../../.storybook/utils';
+import MarketingHeading1 from './MarketingHeading1';
+
+export default {
+  component: MarketingHeading1,
+  title: addStoryInGroup(MARKETING, 'Typography'),
+
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/6nbw3mXc6VpIOYrbmUxn8C/Marketing-components?node-id=84%3A0',
+    },
+  },
+};
+
+export const heading1 = (args) => <MarketingHeading1 {...args} />;
+
+heading1.args = {
+  children: "I'm a heading 1 for marketing purposes only",
+};

--- a/src/components/marketingTypography/theme.css
+++ b/src/components/marketingTypography/theme.css
@@ -1,0 +1,10 @@
+@import '@teamleader/ui-colors';
+@import '@teamleader/ui-typography';
+
+.heading-1 {
+  color: var(--color-teal-darkest);
+  font-family: var(--font-family-black);
+  font-weight: normal;
+  font-size: 24px;
+  line-height: 30px;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ import Menu, { IconMenu, MenuItem, MenuDivider, MenuTitle } from './components/m
 import Link from './components/link';
 import MarketingButton from './components/marketingButton';
 import MarketingMarker from './components/marketingMarker';
+import { MarketingHeading1 } from './components/marketingTypography';
 import Message from './components/message';
 import Overlay from './components/overlay';
 import OverviewPage, { OverviewPageBody, OverviewPageHeader } from './components/overviewPage';
@@ -137,6 +138,7 @@ export {
   Marker,
   MarketingButton,
   MarketingMarker,
+  MarketingHeading1,
   Menu,
   MenuItem,
   MenuDivider,


### PR DESCRIPTION
### Description

This PR adds the new `MarketingHeading1` component according to [these specs](https://www.figma.com/file/6nbw3mXc6VpIOYrbmUxn8C/Marketing-components?node-id=84%3A0).

### Breaking changes

None.
