### PR TITLE
MarketingLockBadge component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `MarketingLockBadge`: added new component. ([@driesd](https://github.com/driesd) in [#1541])
+
 ### Changed
 
 ### Deprecated

--- a/src/components/marketingLockBadge/MarketingLockBadge.js
+++ b/src/components/marketingLockBadge/MarketingLockBadge.js
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Box from '../box';
+import Icon from '../icon';
+import cx from 'classnames';
+import theme from './theme.css';
+import { IconLockSmallFilled } from '@teamleader/ui-icons';
+
+class MarketingLockBadge extends Component {
+  render() {
+    const { className, size, ...others } = this.props;
+
+    const classNames = cx(theme['wrapper'], theme[`is-${size}`], className);
+
+    return (
+      <Box
+        {...others}
+        alignItems="center"
+        borderRadius="rounded"
+        display="flex"
+        justifyContent="center"
+        className={classNames}
+      >
+        <Icon className={theme['icon']}>
+          <IconLockSmallFilled />
+        </Icon>
+      </Box>
+    );
+  }
+}
+
+MarketingLockBadge.propTypes = {
+  size: PropTypes.oneOf(['small', 'medium']),
+};
+
+MarketingLockBadge.defaultProps = {
+  size: 'medium',
+};
+
+export default MarketingLockBadge;

--- a/src/components/marketingLockBadge/index.js
+++ b/src/components/marketingLockBadge/index.js
@@ -1,0 +1,2 @@
+import MarketingLockBadge from './MarketingLockBadge';
+export default MarketingLockBadge;

--- a/src/components/marketingLockBadge/marketingLockBadge.stories.js
+++ b/src/components/marketingLockBadge/marketingLockBadge.stories.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { addStoryInGroup, MARKETING } from '../../../.storybook/utils';
+import MarketingLockBadge from './MarketingLockBadge';
+
+export default {
+  component: MarketingLockBadge,
+  title: addStoryInGroup(MARKETING, 'MarketingLockBadge'),
+
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/6nbw3mXc6VpIOYrbmUxn8C/Marketing-components?node-id=165%3A3907',
+    },
+  },
+};
+
+export const Basic = (args) => <MarketingLockBadge {...args} />;

--- a/src/components/marketingLockBadge/theme.css
+++ b/src/components/marketingLockBadge/theme.css
@@ -1,0 +1,25 @@
+@import '@teamleader/ui-colors';
+@import '@teamleader/ui-utilities';
+
+:root {
+  --color-marketing-violet-light: #d3d1fe;
+  --color-marketing-violet: #4f1fff;
+}
+
+.wrapper {
+  background-color: var(--color-marketing-violet-light);
+}
+
+.icon {
+  color: var(--color-marketing-violet) !important;
+}
+
+.is-small {
+  height: 18px;
+  width: 18px;
+}
+
+.is-medium {
+  height: 24px;
+  width: 24px;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ import Menu, { IconMenu, MenuItem, MenuDivider, MenuTitle } from './components/m
 import Link from './components/link';
 import MarketingButton from './components/marketingButton';
 import MarketingLink from './components/marketingLink';
+import MarketingLockBadge from './components/marketingLockBadge';
 import MarketingMarker from './components/marketingMarker';
 import { MarketingHeading1 } from './components/marketingTypography';
 import Message from './components/message';
@@ -139,6 +140,7 @@ export {
   Marker,
   MarketingButton,
   MarketingLink,
+  MarketingLockBadge,
   MarketingMarker,
   MarketingHeading1,
   Menu,


### PR DESCRIPTION
### Description

This PR adds the new `MarketingLockBadge` component according to [these specs](https://www.figma.com/file/6nbw3mXc6VpIOYrbmUxn8C/Marketing-components?node-id=152%3A7532).

### Breaking changes

None.
