### PR TITLE
MarketingHeading2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- `MarketingHeading2`: added new component. ([@driesd](https://github.com/driesd) in [#1552])
 - `MarketingLockBadge`: added new component. ([@driesd](https://github.com/driesd) in [#1541])
 - `MarketingStatusLabel`: added new component. ([@driesd](https://github.com/driesd) in [#1550])
 - `MarketingTab`: added new component. ([@driesd](https://github.com/driesd) in [#1551])

--- a/src/components/marketingTypography/MarketingHeading2.js
+++ b/src/components/marketingTypography/MarketingHeading2.js
@@ -1,0 +1,25 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Box from '../box';
+import cx from 'classnames';
+import theme from './theme.css';
+
+class MarketingHeading2 extends Component {
+  render() {
+    const { children, className, ...others } = this.props;
+
+    const classNames = cx(theme['heading-2'], className);
+
+    return (
+      <Box {...others} className={classNames} element="h2">
+        {children}
+      </Box>
+    );
+  }
+}
+
+MarketingHeading2.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+};
+
+export default MarketingHeading2;

--- a/src/components/marketingTypography/index.js
+++ b/src/components/marketingTypography/index.js
@@ -1,3 +1,4 @@
 import MarketingHeading1 from './MarketingHeading1';
+import MarketingHeading2 from './MarketingHeading2';
 
-export { MarketingHeading1 };
+export { MarketingHeading1, MarketingHeading2 };

--- a/src/components/marketingTypography/marketingTypography.stories.js
+++ b/src/components/marketingTypography/marketingTypography.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { addStoryInGroup, MARKETING } from '../../../.storybook/utils';
 import MarketingHeading1 from './MarketingHeading1';
+import MarketingHeading2 from './MarketingHeading2';
 
 export default {
   component: MarketingHeading1,
@@ -18,4 +19,10 @@ export const heading1 = (args) => <MarketingHeading1 {...args} />;
 
 heading1.args = {
   children: "I'm a heading 1 for marketing purposes only",
+};
+
+export const heading2 = (args) => <MarketingHeading2 {...args} />;
+
+heading2.args = {
+  children: "I'm a heading 2 for marketing purposes only",
 };

--- a/src/components/marketingTypography/theme.css
+++ b/src/components/marketingTypography/theme.css
@@ -1,10 +1,20 @@
 @import '@teamleader/ui-colors';
 @import '@teamleader/ui-typography';
 
-.heading-1 {
+.heading-1,
+.heading-2 {
   color: var(--color-teal-darkest);
   font-family: var(--font-family-inter);
+}
+
+.heading-1 {
   font-weight: 800;
   font-size: 24px;
   line-height: 30px;
+}
+
+.heading-2 {
+  font-weight: 800;
+  font-size: 21px;
+  line-height: 24px;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ import MarketingLockBadge from './components/marketingLockBadge';
 import MarketingMarker from './components/marketingMarker';
 import MarketingStatusLabel from './components/marketingStatusLabel';
 import MarketingTab from './components/marketingTab';
-import { MarketingHeading1 } from './components/marketingTypography';
+import { MarketingHeading1, MarketingHeading2 } from './components/marketingTypography';
 import Message from './components/message';
 import Overlay from './components/overlay';
 import OverviewPage, { OverviewPageBody, OverviewPageHeader } from './components/overviewPage';
@@ -146,6 +146,7 @@ export {
   MarketingMarker,
   MarketingStatusLabel,
   MarketingHeading1,
+  MarketingHeading2,
   MarketingTab,
   Menu,
   MenuItem,


### PR DESCRIPTION
### Description

This PR adds the new `MarketingHeading2` component according to [these specs](https://www.figma.com/file/6nbw3mXc6VpIOYrbmUxn8C/Marketing-components?node-id=84%3A0).

### Breaking changes

None.
