### PR TITLE
Fix story path config

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-  stories: ['./**/*.stories.(js|mdx)', '../**/*.stories.(js|mdx)'],
+  stories: ['./**/*.stories.@(js|mdx)', '../**/*.stories.@(js|mdx)'],
   addons: [
     '@storybook/addon-backgrounds',
     'storybook-addon-designs',


### PR DESCRIPTION
Fixes console warning:

```
WARN We found no files matching any of the following globs:
WARN 
WARN ./**/*.stories.(js|mdx)
WARN ../**/*.stories.(js|mdx)
WARN 
WARN Maybe your glob was invalid?
WARN see: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#correct-globs-in-mainjs
(node:75522) DeprecationWarning: You have specified an invalid glob, we've attempted to fix it, please ensure that the glob you specify is valid. See: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#correct-globs-in-mainjs
```