### PR TITLE
Badge: set a height of 18px for small variants

### DIFF
--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -64,7 +64,10 @@
   }
 }
 
-.is-small,
+.is-small {
+  height: 18px;
+}
+
 .is-medium {
   height: 24px;
 }


### PR DESCRIPTION
### Description

This PR changes the height of our `small` sized `Badge` component from 24px to 18px.

#### Screenshot before this PR

[add screenshot here]

#### Screenshot after this PR

![Screenshot 2021-03-10 at 11 32 19](https://user-images.githubusercontent.com/5336831/110616438-d2fef800-8194-11eb-95e8-4141f5dcbaea.png)


### Breaking changes

Should not be a breaking change.
