### PR TITLE
SplitButton: fix text overflow ellipsis

### DIFF
--- a/src/components/buttonGroup/theme.css
+++ b/src/components/buttonGroup/theme.css
@@ -8,6 +8,7 @@
 .group {
   display: flex;
   align-items: center;
+  min-width: 0;
 
   > * {
     margin-left: var(--button-margin);


### PR DESCRIPTION
### Description

This PR fixes text overflow behavior in `ButtonGroup`.

#### Screenshot before this PR
![Screenshot 2021-03-29 at 16 49 57](https://user-images.githubusercontent.com/5336831/112855279-f55aa600-90ae-11eb-8969-93300118ebd6.png)

#### Screenshot after this PR
![Screenshot 2021-03-29 at 16 45 04](https://user-images.githubusercontent.com/5336831/112855330-fd1a4a80-90ae-11eb-8b52-c368be6505e0.png)


### Breaking changes

None.
