### PR TITLE
Release 4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Changed
 
-- `Timer`: updated according to latest design specs. ([@driesd](https://github.com/driesd) in [#1595])
-
 ### Deprecated
 
 ### Removed
@@ -13,6 +11,18 @@
 ### Fixed
 
 ### Dependency updates
+
+## [4.5.0] - 2021-04-15
+
+### Changed
+
+- `Timer`: updated according to latest design specs. ([@driesd](https://github.com/driesd) in [#1595])
+
+### Dependency updates
+
+- `ssri` from `8.0.0` to `8.0.1`
+- `css-loader` from `5.1.3` to `5.2.1`
+- `react-dev-utils` from `11.0.3` to `11.0.4`
 
 ## [4.4.0] - 2021-04-13
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Changed

- `Timer`: updated according to latest design specs. ([@driesd](https://github.com/driesd) in [#1595])

### Dependency updates

- `ssri` from `8.0.0` to `8.0.1`
- `css-loader` from `5.1.3` to `5.2.1`
- `react-dev-utils` from `11.0.3` to `11.0.4`
