### PR TITLE
Timer: change display inline-flex to flex

### DIFF
--- a/src/components/timer/Timer.js
+++ b/src/components/timer/Timer.js
@@ -29,7 +29,7 @@ class Timer extends PureComponent {
         data-teamleader-ui="timer"
         element="button"
         alignItems="center"
-        display="inline-flex"
+        display="flex"
         ref={timerRef}
         paddingHorizontal={2}
       >


### PR DESCRIPTION
### Description

This PR changes the `Timer`'s wrapper prop `display` from `inline-flex` to `flex`. Visually nothing changes, but it fixes an [alignment issue in core](https://github.com/teamleadercrm/core/pull/21311).

### Breaking changes

None.
