### PR TITLE
Input: remove width 100% from the `.wrapper`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - :boom: `CompactMessage`: removed component. ([@driesd](https://github.com/driesd) in [#1612])
 - :boom: `Message`: removed component. ([@driesd](https://github.com/driesd) in [#1612])
+- `Input`: removed `width: 100%` from the component's wrapper. ([@driesd](https://github.com/driesd) in [#1617])
 
 ### Fixed
 

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -40,7 +40,6 @@
 
 .wrapper,
 .input {
-  width: 100%;
   border-radius: var(--input-border-radius);
 }
 


### PR DESCRIPTION
This PR removes the `width: 100%` from the component's wrapper because this is causing troubles with flexbox layout.

### Screenshot before this PR
![Screenshot 2021-04-21 at 13 07 59](https://user-images.githubusercontent.com/5336831/115544365-c8ab4000-a2a2-11eb-9767-fa214f74505a.png)

### Screenshot after this PR
![Screenshot 2021-04-21 at 13 08 19](https://user-images.githubusercontent.com/5336831/115544376-cc3ec700-a2a2-11eb-8c9f-3e05e87da8eb.png)

### Breaking changes

Should not break anything 🤞 
