### PR TITLE
[In-3666] more accessible progress tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- :boom: `ProgressTracker`: replaced `alternating` prop with `labelPosition` (`top` / `bottom` / `alternating`). ([@lorgan3](https://github.com/lorgan3) in [#1641])
+- `ProgressTracker`: Update design to be more accessible. ([@lorgan3](https://github.com/lorgan3) in [#1641])
+
 ### Deprecated
 
 ### Removed

--- a/src/components/progressTracker/ProgressStep.js
+++ b/src/components/progressTracker/ProgressStep.js
@@ -20,6 +20,7 @@ class ProgressStep extends PureComponent {
           <TextSmall className={theme['step-label']}>{label}</TextSmall>
           {meta && <TextSmall className={theme['step-meta']}>{meta}</TextSmall>}
         </div>
+        <span className={theme['status-bullet-halo']} onClick={onClick} />
         <span className={theme['status-bullet']} onClick={onClick} />
       </Box>
     );

--- a/src/components/progressTracker/ProgressTracker.js
+++ b/src/components/progressTracker/ProgressTracker.js
@@ -8,9 +8,9 @@ import ProgressStep from './ProgressStep';
 
 class ProgressTracker extends PureComponent {
   render() {
-    const { color, children, currentStep, done, alternating } = this.props;
+    const { color, children, currentStep, done, labelPosition } = this.props;
 
-    const classNames = cx(theme['tracker'], theme[color], { [theme['tracker-alternating']]: alternating });
+    const classNames = cx(theme['tracker'], theme[color], theme[`tracker-${labelPosition}`]);
 
     return (
       <Box className={classNames}>
@@ -39,13 +39,14 @@ ProgressTracker.propTypes = {
   children: PropTypes.node,
   /** Color theme of the progress tracker. */
   color: PropTypes.oneOf(['neutral', 'mint', 'aqua', 'violet', 'gold', 'ruby']),
-  /** Whether the position of the labels should alternate so they have more space  */
-  alternating: PropTypes.bool,
+  /** Where to position the labels. Alternating allows for wider labels. */
+  labelPosition: PropTypes.oneOf(['top', 'alternating', 'bottom']),
 };
 
 ProgressTracker.defaultProps = {
   currentStep: 0,
   color: 'mint',
+  labelPosition: 'top',
 };
 
 ProgressTracker.ProgressStep = ProgressStep;

--- a/src/components/progressTracker/progressTracker.stories.js
+++ b/src/components/progressTracker/progressTracker.stories.js
@@ -21,7 +21,6 @@ export default {
 export const DefaultStory = () => (
   <ProgressTracker
     done={boolean('Done', false)}
-    alternating={boolean('Alternating', false)}
     currentStep={number('Current step', 1, {
       range: true,
       min: 0,
@@ -29,6 +28,7 @@ export const DefaultStory = () => (
       step: 1,
     })}
     color={select('Color', COLORS, 'mint')}
+    labelPosition={select('Label position', ['top', 'alternating', 'bottom'], 'top')}
   >
     {steps.map((step, index) => (
       <ProgressTracker.ProgressStep

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -62,6 +62,10 @@
     .status-bullet-halo {
       margin-left: calc(var(--bullet-halo-size) * -0.25);
     }
+
+    &::after {
+      left: 0;
+    }
   }
 
   &:last-child {

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -36,6 +36,7 @@
 
   &:before {
     background-color: var(--color-neutral-dark);
+    width: 100%;
   }
 
   &:after {
@@ -44,10 +45,6 @@
       background-color 0.1s var(--animation-curve-default) calc(var(--animation-duration) - 0.1s);
     width: 0;
     z-index: 1;
-  }
-
-  &:before {
-    width: 100%;
   }
 
   &:first-child {

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -219,6 +219,24 @@
   }
 }
 
+.tracker-bottom {
+  .step {
+    flex-direction: column-reverse;
+
+    &:before {
+      bottom: 47px;
+    }
+
+    &:after {
+      bottom: 46px;
+    }
+
+    .status-bullet-halo {
+      bottom: 30px;
+    }
+  }
+}
+
 .neutral .step {
   &.is-completed,
   &.is-active {

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -225,8 +225,7 @@
     &:after {
       background-color: var(--color-neutral);
     }
-    .status-bullet,
-    .status-bullet-halo {
+    .status-bullet {
       background-color: var(--color-neutral);
     }
   }
@@ -236,6 +235,10 @@
       background-color: var(--color-neutral-dark);
     }
   }
+
+  .status-bullet-halo {
+    background-color: var(--color-neutral);
+  }
 }
 
 .mint .step {
@@ -244,8 +247,7 @@
     &:after {
       background-color: var(--color-mint);
     }
-    .status-bullet,
-    .status-bullet-halo {
+    .status-bullet {
       background-color: var(--color-mint);
     }
   }
@@ -255,6 +257,10 @@
       background-color: var(--color-mint-dark);
     }
   }
+
+  .status-bullet-halo {
+    background-color: var(--color-mint);
+  }
 }
 
 .aqua .step {
@@ -263,8 +269,7 @@
     &:after {
       background-color: var(--color-aqua);
     }
-    .status-bullet,
-    .status-bullet-halo {
+    .status-bullet {
       background-color: var(--color-aqua);
     }
   }
@@ -274,6 +279,10 @@
       background-color: var(--color-aqua-dark);
     }
   }
+
+  .status-bullet-halo {
+    background-color: var(--color-aqua);
+  }
 }
 
 .violet .step {
@@ -282,8 +291,7 @@
     &:after {
       background-color: var(--color-violet);
     }
-    .status-bullet,
-    .status-bullet-halo {
+    .status-bullet {
       background-color: var(--color-violet);
     }
   }
@@ -293,6 +301,10 @@
       background-color: var(--color-violet-dark);
     }
   }
+
+  .status-bullet-halo {
+    background-color: var(--color-violet);
+  }
 }
 
 .gold .step {
@@ -301,8 +313,7 @@
     &:after {
       background-color: var(--color-gold);
     }
-    .status-bullet,
-    .status-bullet-halo {
+    .status-bullet {
       background-color: var(--color-gold);
     }
   }
@@ -312,6 +323,10 @@
       background-color: var(--color-gold-dark);
     }
   }
+
+  .status-bullet-halo {
+    background-color: var(--color-gold);
+  }
 }
 
 .ruby .step {
@@ -320,8 +335,7 @@
     &:after {
       background-color: var(--color-ruby);
     }
-    .status-bullet,
-    .status-bullet-halo {
+    .status-bullet {
       background-color: var(--color-ruby);
     }
   }
@@ -330,6 +344,10 @@
     .status-bullet {
       background-color: var(--color-ruby-dark);
     }
+  }
+
+  .status-bullet-halo {
+    background-color: var(--color-ruby);
   }
 }
 

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -32,15 +32,17 @@
     content: '';
     height: 2px;
     position: absolute;
-    bottom: 11px;
   }
 
   &:before {
     background-color: var(--color-neutral-dark);
     width: 100%;
+    bottom: 11px;
   }
 
   &:after {
+    height: 4px;
+    bottom: 10px;
     left: 50%;
     transition: width var(--animation-duration) var(--animation-curve-default),
       background-color 0.1s var(--animation-curve-default) calc(var(--animation-duration) - 0.1s);
@@ -194,9 +196,12 @@
       flex-direction: column-reverse;
       margin-top: 36px;
 
-      &:before,
-      &:after {
+      &:before {
         bottom: 47px;
+      }
+
+      &:after {
+        bottom: 46px;
       }
 
       .status-bullet-halo {

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -126,7 +126,8 @@
   .status-bullet-halo {
     transform: scale(0);
     opacity: 0.5;
-    transition: transform 0.1s var(--animation-curve-default) calc(var(--animation-duration) - 0.1s);
+    transition: transform var(--animation-duration) var(--animation-curve-default)
+      calc(var(--animation-duration) - 0.1s);
     border-radius: 50%;
     display: block;
     margin: 6px 0;

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -6,6 +6,7 @@
 :root {
   --bullet-size: 12px;
   --bullet-center-size: calc(var(--bullet-size) / 2);
+  --bullet-halo-size: 24px;
 }
 
 .tracker {
@@ -55,6 +56,10 @@
       padding-left: 0;
       text-align: left;
     }
+
+    .status-bullet-halo {
+      margin-left: calc(var(--bullet-halo-size) * -0.25);
+    }
   }
 
   &:last-child {
@@ -64,6 +69,10 @@
     .step-label-holder {
       padding-right: 0;
       text-align: right;
+    }
+
+    .status-bullet-halo {
+      margin-right: calc(var(--bullet-halo-size) * -0.25);
     }
   }
 
@@ -106,6 +115,19 @@
       left: 50%;
       transform: translate(-50%, -50%);
     }
+  }
+
+  .status-bullet-halo {
+    transform: scale(0);
+    opacity: 0.5;
+    transition: transform 0.1s var(--animation-curve-default) calc(var(--animation-duration) - 0.1s);
+    border-radius: 50%;
+    display: block;
+    margin: 6px 0;
+    height: var(--bullet-halo-size);
+    width: var(--bullet-halo-size);
+    position: absolute;
+    bottom: calc(var(--bullet-halo-size) * -0.25);
   }
 
   .step-label-holder {
@@ -152,6 +174,10 @@
         animation: showBulletCenter 0.1s calc(var(--animation-duration) - 0.1s) forwards;
       }
     }
+
+    .status-bullet-halo {
+      transform: scale(1);
+    }
   }
 
   &.is-clickable {
@@ -172,6 +198,10 @@
       &:after {
         bottom: 47px;
       }
+
+      .status-bullet-halo {
+        bottom: 30px;
+      }
     }
 
     &-label-holder {
@@ -186,7 +216,8 @@
     &:after {
       background-color: var(--color-neutral);
     }
-    .status-bullet {
+    .status-bullet,
+    .status-bullet-halo {
       background-color: var(--color-neutral);
     }
   }
@@ -204,7 +235,8 @@
     &:after {
       background-color: var(--color-mint);
     }
-    .status-bullet {
+    .status-bullet,
+    .status-bullet-halo {
       background-color: var(--color-mint);
     }
   }
@@ -222,7 +254,8 @@
     &:after {
       background-color: var(--color-aqua);
     }
-    .status-bullet {
+    .status-bullet,
+    .status-bullet-halo {
       background-color: var(--color-aqua);
     }
   }
@@ -240,7 +273,8 @@
     &:after {
       background-color: var(--color-violet);
     }
-    .status-bullet {
+    .status-bullet,
+    .status-bullet-halo {
       background-color: var(--color-violet);
     }
   }
@@ -258,7 +292,8 @@
     &:after {
       background-color: var(--color-gold);
     }
-    .status-bullet {
+    .status-bullet,
+    .status-bullet-halo {
       background-color: var(--color-gold);
     }
   }
@@ -276,7 +311,8 @@
     &:after {
       background-color: var(--color-ruby);
     }
-    .status-bullet {
+    .status-bullet,
+    .status-bullet-halo {
       background-color: var(--color-ruby);
     }
   }

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -190,6 +190,12 @@
       background-color: var(--color-neutral);
     }
   }
+
+  &.is-active {
+    .status-bullet {
+      background-color: var(--color-neutral-dark);
+    }
+  }
 }
 
 .mint .step {
@@ -200,6 +206,12 @@
     }
     .status-bullet {
       background-color: var(--color-mint);
+    }
+  }
+
+  &.is-active {
+    .status-bullet {
+      background-color: var(--color-mint-dark);
     }
   }
 }
@@ -214,6 +226,12 @@
       background-color: var(--color-aqua);
     }
   }
+
+  &.is-active {
+    .status-bullet {
+      background-color: var(--color-aqua-dark);
+    }
+  }
 }
 
 .violet .step {
@@ -224,6 +242,12 @@
     }
     .status-bullet {
       background-color: var(--color-violet);
+    }
+  }
+
+  &.is-active {
+    .status-bullet {
+      background-color: var(--color-violet-dark);
     }
   }
 }
@@ -238,6 +262,12 @@
       background-color: var(--color-gold);
     }
   }
+
+  &.is-active {
+    .status-bullet {
+      background-color: var(--color-gold-dark);
+    }
+  }
 }
 
 .ruby .step {
@@ -248,6 +278,12 @@
     }
     .status-bullet {
       background-color: var(--color-ruby);
+    }
+  }
+
+  &.is-active {
+    .status-bullet {
+      background-color: var(--color-ruby-dark);
     }
   }
 }

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -370,6 +370,28 @@
   }
 }
 
+.teal .step {
+  &.is-completed,
+  &.is-active {
+    &:after {
+      background-color: var(--color-teal);
+    }
+    .status-bullet {
+      background-color: var(--color-teal);
+    }
+  }
+
+  &.is-active {
+    .status-bullet {
+      background-color: var(--color-teal-dark);
+    }
+  }
+
+  .status-bullet-halo {
+    background-color: var(--color-teal);
+  }
+}
+
 @keyframes showBulletCenter {
   0% {
     background-color: transparent;


### PR DESCRIPTION
### Description
- Updated the progress tracker to be more accessible to color blind people.
- replaced the `alternating` prop with `labelPosition` because it should also be possible to place all the labels below the progress bar.

figma: https://www.figma.com/file/LHH25GN90ljQaBEUNMsdJn/Desktop-components?node-id=865%3A0

#### Screenshot before this PR

![image](https://user-images.githubusercontent.com/1833617/117970287-c760b680-b328-11eb-8dd0-7aa48abeb1f2.png)

#### Screenshot after this PR

![Screen Recording 2021-05-12 at 10 44 43](https://user-images.githubusercontent.com/1833617/117970663-33431f00-b329-11eb-9fc0-3291a77d7163.gif)

### Breaking changes

- Removed the `alternating` prop. Use `labelPosition="alternating"` to get the old behaviour