### PR TITLE
[AHOY-437] Pagination: remove previous & next button labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Removed
 
+- :boom: `Pagination`: removed props `prevPageText` and `nextPageText`. ([@driesd](https://github.com/driesd) in [#1643])
+
 ### Fixed
 
 ### Dependency updates

--- a/src/components/pagination/Pagination.js
+++ b/src/components/pagination/Pagination.js
@@ -8,16 +8,7 @@ import theme from './theme.css';
 
 class Pagination extends PureComponent {
   render() {
-    const {
-      className,
-      currentPage,
-      inverse,
-      maxNumPagesVisible,
-      numPages,
-      prevPageText,
-      children,
-      ...others
-    } = this.props;
+    const { className, currentPage, inverse, maxNumPagesVisible, numPages, children, ...others } = this.props;
 
     if (numPages < 2) {
       return null;
@@ -57,7 +48,6 @@ class Pagination extends PureComponent {
             <li className={theme['list-item']}>
               {children({
                 number: currentPage - 1,
-                text: prevPageText,
                 isActive: false,
                 icon: <IconChevronLeftMediumOutline />,
                 iconPlacement: 'left',
@@ -105,7 +95,6 @@ Pagination.propTypes = {
   numPages: PropTypes.number.isRequired,
   maxNumPagesVisible: PropTypes.number,
   currentPage: PropTypes.number.isRequired,
-  prevPageText: PropTypes.string,
   className: PropTypes.string,
   children: PropTypes.func.isRequired,
 };

--- a/src/components/pagination/Pagination.js
+++ b/src/components/pagination/Pagination.js
@@ -13,7 +13,6 @@ class Pagination extends PureComponent {
       currentPage,
       inverse,
       maxNumPagesVisible,
-      nextPageText,
       numPages,
       prevPageText,
       children,
@@ -89,7 +88,6 @@ class Pagination extends PureComponent {
             <li className={theme['list-item']}>
               {children({
                 number: currentPage + 1,
-                text: nextPageText,
                 isActive: false,
                 icon: <IconChevronRightMediumOutline />,
                 iconPlacement: 'right',
@@ -104,7 +102,6 @@ class Pagination extends PureComponent {
 
 Pagination.propTypes = {
   inverse: PropTypes.bool,
-  nextPageText: PropTypes.string,
   numPages: PropTypes.number.isRequired,
   maxNumPagesVisible: PropTypes.number,
   currentPage: PropTypes.number.isRequired,

--- a/src/components/pagination/pagination.stories.js
+++ b/src/components/pagination/pagination.stories.js
@@ -18,7 +18,6 @@ export const Full = ({ inverse, ...args }) => (
 Full.args = {
   currentPage: 3,
   numPages: 21,
-  prevPageText: 'previous',
 };
 
 export const Compact = (args) => (

--- a/src/components/pagination/pagination.stories.js
+++ b/src/components/pagination/pagination.stories.js
@@ -17,7 +17,6 @@ export const Full = ({ inverse, ...args }) => (
 
 Full.args = {
   currentPage: 3,
-  nextPageText: 'next',
   numPages: 21,
   prevPageText: 'previous',
 };


### PR DESCRIPTION
### Description

This PR removes the labels from our `Pagination`'s `previous` and `next` buttons. 

### Breaking changes

- 💥  Removed `prevPageText` and `nextPageText` props from the `Pagination` component.
