### PR TITLE
Introduce `DurationInput` & improvements to the `NumericInput`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ### Added
 
+- `DurationInput`: Added DurationInput component to enter hours and minutes ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1646])
+
 ### Changed
 
 - :boom: `ProgressTracker`: replaced `alternating` prop with `labelPosition` (`top` / `bottom` / `alternating`). ([@lorgan3](https://github.com/lorgan3) in [#1641])
 - `ProgressTracker`: Update design to be more accessible. ([@lorgan3](https://github.com/lorgan3) in [#1641])
+- `NumericInput`: Allow clicking and holding on the stepper controls ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1646])
+- `NumericInput` [Internal]: Removed redundant internal state ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1646])
 
 ### Deprecated
 

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -4,11 +4,11 @@ import { Box, NumericInput } from '../../';
 const DurationInput = ({ value, onChange, onKeyDown }) => {
   return (
     <Box display="flex" alignItems="center">
-      <NumericInput placeholder="00" min={0} onKeyDown={onKeyDown} size="small" />
+      <NumericInput placeholder="00" min={0} onKeyDown={onKeyDown} size="small" flexGrow={1} />
       <Box element="span" marginHorizontal={2}>
         :
       </Box>
-      <NumericInput placeholder="00" min={0} onKeyDown={onKeyDown} size="small" />
+      <NumericInput placeholder="00" min={0} onKeyDown={onKeyDown} size="small" flexGrow={1} />
     </Box>
   );
 };

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -11,11 +11,30 @@ const DurationInput = ({ value, onChange, onKeyDown }) => {
   };
 
   const handleMinutesChange = (_, minutes) => {
-    onChange &&
+    if (!onChange) {
+      return;
+    }
+
+    if (minutes >= 60) {
       onChange({
-        ...value,
-        minutes,
+        hours: (value?.hours || 0) + 1,
+        minutes: 0,
       });
+      return;
+    }
+
+    if (minutes < 0) {
+      onChange({
+        hours: (value?.hours || 1) - 1,
+        minutes: 59,
+      });
+      return;
+    }
+
+    onChange({
+      ...value,
+      minutes,
+    });
   };
 
   return (
@@ -23,7 +42,7 @@ const DurationInput = ({ value, onChange, onKeyDown }) => {
       <NumericInput
         placeholder="00"
         min={0}
-        value={value?.hours || ''}
+        value={value?.hours ?? ''}
         onChange={handleHoursChanged}
         onKeyDown={onKeyDown}
         size="small"
@@ -34,8 +53,8 @@ const DurationInput = ({ value, onChange, onKeyDown }) => {
       </Box>
       <NumericInput
         placeholder="00"
-        min={0}
-        value={value?.minutes || ''}
+        {...(!value?.hours ? { min: 0 } : {})}
+        value={value?.minutes ?? ''}
         onChange={handleMinutesChange}
         onKeyDown={onKeyDown}
         size="small"

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Box, NumericInput } from '../../';
+
+const DurationInput = ({ value, onChange, onKeyDown }) => {
+  return (
+    <Box display="flex" alignItems="center">
+      <NumericInput placeholder="00" min={0} onKeyDown={onKeyDown} size="small" />
+      <Box element="span" marginHorizontal={2}>
+        :
+      </Box>
+      <NumericInput placeholder="00" min={0} onKeyDown={onKeyDown} size="small" />
+    </Box>
+  );
+};
+
+export default DurationInput;

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -9,6 +9,12 @@ const DurationInput = ({ value, onChange, onKeyDown }) => {
       return;
     }
 
+    if (hours === '') {
+      onChange({
+        minutes: value?.minutes,
+      });
+    }
+
     const parsedHours = parseInt(hours);
     if (!Number.isInteger(parsedHours)) {
       return;
@@ -22,6 +28,13 @@ const DurationInput = ({ value, onChange, onKeyDown }) => {
 
   const handleMinutesChange = (_, minutes) => {
     if (!onChange) {
+      return;
+    }
+
+    if (minutes === '') {
+      onChange({
+        hours: value?.hours,
+      });
       return;
     }
 

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -78,6 +78,8 @@ const DurationInput = ({ value, onChange, onKeyDown }) => {
         value={value?.hours ?? ''}
         onChange={handleHoursChanged}
         onKeyDown={onKeyDown}
+        type="text"
+        inputMode="numeric"
         size="small"
         flexGrow={1}
       />
@@ -90,6 +92,8 @@ const DurationInput = ({ value, onChange, onKeyDown }) => {
         value={minutes ?? ''}
         onChange={handleMinutesChange}
         onKeyDown={onKeyDown}
+        type="text"
+        inputMode="numeric"
         size="small"
         flexGrow={1}
       />

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -5,11 +5,19 @@ const transformToPaddedNumber = (number) => (number < 10 ? `0${number}` : number
 
 const DurationInput = ({ value, onChange, onKeyDown }) => {
   const handleHoursChanged = (_, hours) => {
-    onChange &&
-      onChange({
-        ...value,
-        hours,
-      });
+    if (!onChange) {
+      return;
+    }
+
+    const parsedHours = parseInt(hours);
+    if (!Number.isInteger(parsedHours)) {
+      return;
+    }
+
+    onChange({
+      ...value,
+      hours: parsedHours,
+    });
   };
 
   const handleMinutesChange = (_, minutes) => {
@@ -17,7 +25,12 @@ const DurationInput = ({ value, onChange, onKeyDown }) => {
       return;
     }
 
-    if (minutes >= 60) {
+    const parsedMinutes = parseInt(minutes);
+    if (!Number.isInteger(parsedMinutes)) {
+      return;
+    }
+
+    if (parsedMinutes >= 60) {
       onChange({
         hours: (value?.hours || 0) + 1,
         minutes: 0,
@@ -25,7 +38,7 @@ const DurationInput = ({ value, onChange, onKeyDown }) => {
       return;
     }
 
-    if (minutes < 0) {
+    if (parsedMinutes < 0) {
       onChange({
         hours: (value?.hours || 1) - 1,
         minutes: 59,
@@ -35,7 +48,7 @@ const DurationInput = ({ value, onChange, onKeyDown }) => {
 
     onChange({
       ...value,
-      minutes,
+      minutes: parsedMinutes,
     });
   };
 

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -2,13 +2,45 @@ import React from 'react';
 import { Box, NumericInput } from '../../';
 
 const DurationInput = ({ value, onChange, onKeyDown }) => {
+  const handleHoursChanged = (_, hours) => {
+    onChange &&
+      onChange({
+        ...value,
+        hours,
+      });
+  };
+
+  const handleMinutesChange = (_, minutes) => {
+    onChange &&
+      onChange({
+        ...value,
+        minutes,
+      });
+  };
+
   return (
     <Box display="flex" alignItems="center">
-      <NumericInput placeholder="00" min={0} onKeyDown={onKeyDown} size="small" flexGrow={1} />
+      <NumericInput
+        placeholder="00"
+        min={0}
+        value={value?.hours || ''}
+        onChange={handleHoursChanged}
+        onKeyDown={onKeyDown}
+        size="small"
+        flexGrow={1}
+      />
       <Box element="span" marginHorizontal={2}>
         :
       </Box>
-      <NumericInput placeholder="00" min={0} onKeyDown={onKeyDown} size="small" flexGrow={1} />
+      <NumericInput
+        placeholder="00"
+        min={0}
+        value={value?.minutes || ''}
+        onChange={handleMinutesChange}
+        onKeyDown={onKeyDown}
+        size="small"
+        flexGrow={1}
+      />
     </Box>
   );
 };

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Box, NumericInput } from '../../';
 
+const transformToPaddedNumber = (number) => (number < 10 ? `0${number}` : number.toString());
+
 const DurationInput = ({ value, onChange, onKeyDown }) => {
   const handleHoursChanged = (_, hours) => {
     onChange &&
@@ -37,6 +39,11 @@ const DurationInput = ({ value, onChange, onKeyDown }) => {
     });
   };
 
+  let minutes = value?.minutes;
+  if (Number.isInteger(minutes)) {
+    minutes = transformToPaddedNumber(minutes);
+  }
+
   return (
     <Box display="flex" alignItems="center">
       <NumericInput
@@ -54,7 +61,7 @@ const DurationInput = ({ value, onChange, onKeyDown }) => {
       <NumericInput
         placeholder="00"
         {...(!value?.hours ? { min: 0 } : {})}
-        value={value?.minutes ?? ''}
+        value={minutes ?? ''}
         onChange={handleMinutesChange}
         onKeyDown={onKeyDown}
         size="small"

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -73,7 +73,7 @@ const DurationInput = ({ value, onChange, onKeyDown }) => {
   return (
     <Box display="flex" alignItems="center">
       <NumericInput
-        placeholder="00"
+        placeholder="0"
         min={0}
         value={value?.hours ?? ''}
         onChange={handleHoursChanged}

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -38,6 +38,12 @@ class StepperControls extends PureComponent {
 }
 
 class NumericInput extends PureComponent {
+  constructor(props) {
+    super(props);
+    this.timer = React.createRef();
+    this.timeout = React.createRef();
+  }
+
   handleOnChange = (event) => {
     const { onChange } = this.props;
     onChange && onChange(event, event.currentTarget.value);
@@ -62,6 +68,27 @@ class NumericInput extends PureComponent {
     this.updateStep(-1);
   };
 
+  handleDecreaseMouseDown = () => {
+    this.handleDecreaseValue();
+    const parent = this;
+    this.timeout.current = setTimeout(() => {
+      parent.timer.current = setInterval(this.handleDecreaseValue, 75);
+    }, 300);
+  };
+
+  handleIncreaseMouseDown = () => {
+    this.handleIncreaseValue();
+    const parent = this;
+    this.timeout.current = setTimeout(() => {
+      parent.timer.current = setInterval(this.handleIncreaseValue, 75);
+    }, 300);
+  };
+
+  handleClearStepperTimer = () => {
+    clearTimeout(this.timeout.current);
+    clearInterval(this.timer.current);
+  };
+
   handleBlur = (...parameters) => {
     const { onBlur } = this.props;
 
@@ -80,8 +107,10 @@ class NumericInput extends PureComponent {
         <Button
           disabled={this.isMaxReached()}
           icon={<IconAddSmallOutline />}
-          onClick={this.handleIncreaseValue}
           onBlur={this.handleBlur}
+          onMouseDown={this.handleIncreaseMouseDown}
+          onMouseUp={this.handleClearStepperTimer}
+          onMouseLeave={this.handleClearStepperTimer}
           size={size}
         />
       );
@@ -98,7 +127,9 @@ class NumericInput extends PureComponent {
         <Button
           disabled={this.isMinReached()}
           icon={<IconMinusSmallOutline />}
-          onClick={this.handleDecreaseValue}
+          onMouseDown={this.handleDecreaseMouseDown}
+          onMouseUp={this.handleClearStepperTimer}
+          onMouseLeave={this.handleClearStepperTimer}
           onBlur={this.handleBlur}
           size={size}
         />
@@ -118,14 +149,18 @@ class NumericInput extends PureComponent {
         <StepperControls
           inverse={inverse}
           stepperUpProps={{
-            onClick: this.handleIncreaseValue,
             onBlur: this.handleBlur,
             disabled: this.isMaxReached(),
+            onMouseDown: this.handleIncreaseMouseDown,
+            onMouseUp: this.handleClearStepperTimer,
+            onMouseLeave: this.handleClearStepperTimer,
           }}
           stepperDownProps={{
-            onClick: this.handleDecreaseValue,
             onBlur: this.handleBlur,
             disabled: this.isMinReached(),
+            onMouseDown: this.handleDecreaseMouseDown,
+            onMouseUp: this.handleClearStepperTimer,
+            onMouseLeave: this.handleClearStepperTimer,
           }}
         />,
       ];

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -38,34 +38,18 @@ class StepperControls extends PureComponent {
 }
 
 class NumericInput extends PureComponent {
-  static getDerivedStateFromProps(nextProps, prevState) {
-    if (nextProps.value !== undefined) {
-      const newValue = nextProps.value || '';
-      if (newValue !== prevState.value) {
-        return {
-          value: newValue,
-        };
-      }
-    }
-    return null;
-  }
-
-  state = {
-    value: '',
-  };
-
   handleOnChange = (event) => {
-    this.setState({ value: event.currentTarget.value });
+    const { onChange } = this.props;
+    onChange && onChange(event, event.currentTarget.value);
   };
 
   updateStep = (n) => {
-    const { min, max, onChange, step } = this.props;
+    const { min, max, value, onChange, step } = this.props;
 
-    const currentValue = toNumber(this.state.value || 0);
+    const currentValue = toNumber(value || 0);
     const newValue = parseValue(currentValue + step * n, min, max);
 
     if (newValue !== currentValue) {
-      this.setState({ value: newValue });
       onChange && onChange(null, newValue);
     }
   };
@@ -84,9 +68,9 @@ class NumericInput extends PureComponent {
     onBlur && onBlur(...parameters);
   };
 
-  isMaxReached = () => this.state.value >= this.props.max;
+  isMaxReached = () => this.props.value >= this.props.max;
 
-  isMinReached = () => this.state.value <= this.props.min;
+  isMinReached = () => this.props.value <= this.props.min;
 
   getConnectedRight = () => {
     const { connectedRight, size, stepper } = this.props;
@@ -151,17 +135,14 @@ class NumericInput extends PureComponent {
   };
 
   render() {
-    const { onChange, ...others } = this.props;
-    const restProps = omit(others, ['suffix', 'value']);
+    const { value, ...rest } = this.props;
+    const restProps = omit(rest, ['suffix', 'onChange']);
 
     return (
       <SingleLineInputBase
         type="number"
-        value={this.state.value}
-        onChange={(event) => {
-          this.handleOnChange(event);
-          onChange && onChange(event, event.currentTarget.value);
-        }}
+        value={value}
+        onChange={this.handleOnChange}
         {...restProps}
         connectedLeft={this.getConnectedLeft()}
         connectedRight={this.getConnectedRight()}

--- a/src/components/input/index.js
+++ b/src/components/input/index.js
@@ -4,6 +4,7 @@ import SingleLineInputBase from './SingleLineInputBase';
 import NumericInput from './NumericInput';
 import Textarea from './Textarea';
 import TimeInput from './TimeInput';
+import DurationInput from './DurationInput';
 
-export { InputBase, NumericInput, SingleLineInputBase, Textarea, TimeInput };
+export { InputBase, NumericInput, SingleLineInputBase, Textarea, TimeInput, DurationInput };
 export default Input;

--- a/src/components/input/input.stories.js
+++ b/src/components/input/input.stories.js
@@ -15,6 +15,7 @@ import {
   TextBody,
   TextSmall,
   TimeInput,
+  DurationInput,
 } from '../../index';
 
 const sizes = ['small', 'medium', 'large'];
@@ -191,6 +192,16 @@ export const timeInput = () => {
 
 timeInput.story = {
   name: 'TimeInput',
+};
+
+export const durationInput = () => {
+  const [value, setValue] = useState();
+
+  return <DurationInput value={value} onChange={setValue} />;
+};
+
+durationInput.story = {
+  name: 'DurationInput',
 };
 
 export const textarea = () => (

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ import Dialog, { DialogBase } from './components/dialog';
 import EmptyState from './components/emptyState';
 import Icon from './components/icon';
 import IconButton from './components/iconButton';
-import Input, { InputBase, NumericInput, Textarea, TimeInput } from './components/input';
+import Input, { InputBase, NumericInput, Textarea, TimeInput, DurationInput } from './components/input';
 import Menu, { IconMenu, MenuItem, MenuDivider, MenuTitle } from './components/menu';
 import Link from './components/link';
 import MarketingButton from './components/marketingButton';
@@ -176,6 +176,7 @@ export {
   Tag,
   Textarea,
   TimeInput,
+  DurationInput,
   Timer,
   TimerPulser,
   TitleTab,


### PR DESCRIPTION
### Description

This PR introduces a new `DurationInput` component. It consists of an hour and minute NumericInput

<img width="564" alt="Screenshot 2021-05-18 at 11 23 38" src="https://user-images.githubusercontent.com/10011712/118626849-7f7bdc80-b7cb-11eb-901c-122ef9e9c665.png">

### Added

- `DurationInput` component

### Changed

- `NumericInput`: Add support for clicking and holding on the steppers to increment / decrement
- `NumericInput` [_Internal_]:  removed redundant internal state

### Breaking changes

- None

### Manual check

- The NumericInput allows clicking and holding the increment / decrement buttons
- Test out the DurationInput component
