### PR TITLE
`DurationInput`: Follow up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `ProgressTracker`: Update design to be more accessible. ([@lorgan3](https://github.com/lorgan3) in [#1641])
 - `NumericInput`: Allow clicking and holding on the stepper controls ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1646])
 - `NumericInput` [Internal]: Removed redundant internal state ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1646])
+- `DurationInput`: Follow up changes to the newly added duration input ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1647])
 
 ### Deprecated
 

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -110,7 +110,6 @@ const DurationInput = ({ value, onChange, onBlur, onFocus, onKeyDown, autoFocus,
         onKeyDown={onKeyDown}
         type="text"
         inputMode="numeric"
-        size="small"
         flexGrow={1}
         className={theme['duration-input-numeric-input']}
         autoFocus={autoFocus}
@@ -128,7 +127,6 @@ const DurationInput = ({ value, onChange, onBlur, onFocus, onKeyDown, autoFocus,
         onKeyDown={onKeyDown}
         type="text"
         inputMode="numeric"
-        size="small"
         flexGrow={1}
         className={theme['duration-input-numeric-input']}
       />

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -111,6 +111,7 @@ const DurationInput = ({ value, onChange, onBlur, onKeyDown }) => {
         inputMode="numeric"
         size="small"
         flexGrow={1}
+        className={theme['duration-input-numeric-input']}
       />
       <Box element="span" className={theme['duration-input-colon']}>
         :
@@ -126,6 +127,7 @@ const DurationInput = ({ value, onChange, onBlur, onKeyDown }) => {
         inputMode="numeric"
         size="small"
         flexGrow={1}
+        className={theme['duration-input-numeric-input']}
       />
     </Box>
   );

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -4,7 +4,7 @@ import theme from './theme.css';
 
 const transformToPaddedNumber = (number) => (number < 10 ? `0${number}` : number.toString());
 
-const DurationInput = ({ value, onChange, onBlur, onKeyDown }) => {
+const DurationInput = ({ value, onChange, onBlur, onFocus, onKeyDown, autoFocus, className }) => {
   const ref = useRef();
 
   const handleHoursChanged = (_, hours) => {
@@ -99,19 +99,21 @@ const DurationInput = ({ value, onChange, onBlur, onKeyDown }) => {
   }
 
   return (
-    <Box display="flex" alignItems="center" ref={ref}>
+    <Box display="flex" alignItems="center" ref={ref} className={className}>
       <NumericInput
         placeholder="0"
         min={0}
         value={value?.hours ?? ''}
         onChange={handleHoursChanged}
         onBlur={handleBlur}
+        onFocus={onFocus}
         onKeyDown={onKeyDown}
         type="text"
         inputMode="numeric"
         size="small"
         flexGrow={1}
         className={theme['duration-input-numeric-input']}
+        autoFocus={autoFocus}
       />
       <Box element="span" className={theme['duration-input-colon']}>
         :
@@ -122,6 +124,7 @@ const DurationInput = ({ value, onChange, onBlur, onKeyDown }) => {
         value={minutes ?? ''}
         onChange={handleMinutesChange}
         onBlur={handleBlur}
+        onFocus={onFocus}
         onKeyDown={onKeyDown}
         type="text"
         inputMode="numeric"

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import { Box, NumericInput } from '../../';
+import theme from './theme.css';
 
 const transformToPaddedNumber = (number) => (number < 10 ? `0${number}` : number.toString());
 
@@ -111,7 +112,7 @@ const DurationInput = ({ value, onChange, onBlur, onKeyDown }) => {
         size="small"
         flexGrow={1}
       />
-      <Box element="span" marginHorizontal={2}>
+      <Box element="span" className={theme['duration-input-colon']}>
         :
       </Box>
       <NumericInput

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { Box, NumericInput } from '../../';
+import { Box, NumericInput, TextBodyCompact } from '../../';
 import theme from './theme.css';
 
 const transformToPaddedNumber = (number) => (number < 10 ? `0${number}` : number.toString());
@@ -114,9 +114,9 @@ const DurationInput = ({ value, onChange, onBlur, onFocus, onKeyDown, autoFocus,
         className={theme['duration-input-numeric-input']}
         autoFocus={autoFocus}
       />
-      <Box element="span" className={theme['duration-input-colon']}>
+      <TextBodyCompact color="neutral" tint="darkest" className={theme['duration-input-colon']}>
         :
-      </Box>
+      </TextBodyCompact>
       <NumericInput
         placeholder="00"
         {...(!value?.hours ? { min: 0 } : {})}

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -46,7 +46,11 @@ const DurationInput = ({ value, onChange, onBlur, onFocus, onKeyDown, autoFocus,
       return;
     }
 
-    if (parsedMinutes >= 60) {
+    if (parsedMinutes > 60) {
+      return;
+    }
+
+    if (parsedMinutes === 60) {
       onChange({
         hours: (value?.hours || 0) + 1,
         minutes: 0,

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -466,3 +466,7 @@
     cursor: default;
   }
 }
+
+.duration-input-colon {
+  margin: 0 4px;
+}

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -470,3 +470,15 @@
 .duration-input-colon {
   margin: 0 4px;
 }
+
+.duration-input-numeric-input {
+  .input {
+    padding-right: 0;
+  }
+
+  .suffix-wrapper {
+    > * {
+      margin-left: 0;
+    }
+  }
+}


### PR DESCRIPTION
### Changed

- Less spacing between both inputs
- Lowered internal padding inside of the input
- Use default normal sized numeric inputs
- Lightened color of the colon
- Don't allow entering a number more than 60 inside of the minute input

### Added

- onFocus, autoFocus and className props
