### PR TITLE
`DurationInput`: Consistent empty values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `DurationInput`: Consistent empty values ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1652])
+
 ### Dependency updates
 
 ## [6.1.0] - 2021-05-20

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -13,6 +13,11 @@ const DurationInput = ({ value, onChange, onBlur, onFocus, onKeyDown, autoFocus,
     }
 
     if (hours === '') {
+      if (typeof value?.minutes === 'undefined') {
+        onChange();
+        return;
+      }
+
       onChange({
         minutes: value?.minutes,
       });
@@ -35,6 +40,11 @@ const DurationInput = ({ value, onChange, onBlur, onFocus, onKeyDown, autoFocus,
     }
 
     if (minutes === '') {
+      if (typeof value?.hours === 'undefined') {
+        onChange();
+        return;
+      }
+
       onChange({
         hours: value?.hours,
       });

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -21,6 +21,7 @@ const DurationInput = ({ value, onChange, onBlur, onFocus, onKeyDown, autoFocus,
       onChange({
         minutes: value?.minutes,
       });
+      return;
     }
 
     const parsedHours = parseInt(hours);


### PR DESCRIPTION
### Fixed

- `DurationInput` would resort to a weird `{ hours: undefined }` or `{ minutes: undefined }` value when clearing either of the values