### PR TITLE
FIX: Make stepper events trigger the onChange event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - `DurationInput`: Consistent empty values ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1652])
+- `NumericInput`: Make stepper dispatch native onChange events ([@JorenSaeyTL](https://github.com/JorenSaeyTL) in [#1659])
 
 ### Dependency updates
 

--- a/src/components/input/InputBase.js
+++ b/src/components/input/InputBase.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { omitBoxProps } from '../box';
@@ -6,7 +6,7 @@ import theme from './theme.css';
 
 class InputBase extends PureComponent {
   render() {
-    const { bold, className, element, innerRef, inverse, size, textAlignRight, ...otherProps } = this.props;
+    const { bold, className, element, forwardedRef, inverse, size, textAlignRight, ...otherProps } = this.props;
 
     const classNames = cx(
       theme['input'],
@@ -23,7 +23,7 @@ class InputBase extends PureComponent {
 
     const props = {
       className: classNames,
-      ref: innerRef,
+      ref: forwardedRef,
       ...restProps,
     };
 
@@ -41,7 +41,7 @@ InputBase.propTypes = {
   /** The element to render. */
   element: PropTypes.oneOf(['input', 'textarea']),
   /** The reference to the inner html element */
-  innerRef: PropTypes.object,
+  forwaredRef: PropTypes.object,
   /** Boolean indicating whether the input should render as inverse. */
   inverse: PropTypes.bool,
   /** Callback function that is fired when blurring the input field. */
@@ -91,4 +91,4 @@ InputBase.defaultProps = {
   size: 'medium',
 };
 
-export default InputBase;
+export default forwardRef((props, ref) => <InputBase {...props} forwardedRef={ref} />);

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -181,7 +181,7 @@ class NumericInput extends PureComponent {
 
     return (
       <SingleLineInputBase
-        innerRef={this.inputElement}
+        ref={this.inputElement}
         type="number"
         value={value}
         onChange={this.handleOnChange}

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -40,9 +40,22 @@ class StepperControls extends PureComponent {
 class NumericInput extends PureComponent {
   constructor(props) {
     super(props);
+    this.inputElement = React.createRef();
     this.timer = React.createRef();
     this.timeout = React.createRef();
   }
+
+  setNativeValue = (element, value) => {
+    const valueSetter = Object.getOwnPropertyDescriptor(element, 'value').set;
+    const prototype = Object.getPrototypeOf(element);
+    const prototypeValueSetter = Object.getOwnPropertyDescriptor(prototype, 'value').set;
+
+    if (valueSetter && valueSetter !== prototypeValueSetter) {
+      prototypeValueSetter.call(element, value);
+    } else {
+      valueSetter.call(element, value);
+    }
+  };
 
   handleOnChange = (event) => {
     const { onChange } = this.props;
@@ -50,13 +63,15 @@ class NumericInput extends PureComponent {
   };
 
   updateStep = (n) => {
-    const { min, max, value, onChange, step } = this.props;
+    const { min, max, value, step } = this.props;
 
     const currentValue = toNumber(value || 0);
     const newValue = parseValue(currentValue + step * n, min, max);
 
-    if (newValue !== currentValue) {
-      onChange && onChange(null, newValue);
+    const inputElement = this.inputElement.current;
+    if (inputElement && newValue !== currentValue) {
+      this.setNativeValue(inputElement, newValue);
+      inputElement.dispatchEvent(new Event('input', { bubbles: true }));
     }
   };
 
@@ -175,6 +190,7 @@ class NumericInput extends PureComponent {
 
     return (
       <SingleLineInputBase
+        innerRef={this.inputElement}
         type="number"
         value={value}
         onChange={this.handleOnChange}

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -45,18 +45,6 @@ class NumericInput extends PureComponent {
     this.timeout = React.createRef();
   }
 
-  setNativeValue = (element, value) => {
-    const valueSetter = Object.getOwnPropertyDescriptor(element, 'value').set;
-    const prototype = Object.getPrototypeOf(element);
-    const prototypeValueSetter = Object.getOwnPropertyDescriptor(prototype, 'value').set;
-
-    if (valueSetter && valueSetter !== prototypeValueSetter) {
-      prototypeValueSetter.call(element, value);
-    } else {
-      valueSetter.call(element, value);
-    }
-  };
-
   handleOnChange = (event) => {
     const { onChange } = this.props;
     onChange && onChange(event, event.currentTarget.value);
@@ -69,9 +57,12 @@ class NumericInput extends PureComponent {
     const newValue = parseValue(currentValue + step * n, min, max);
 
     const inputElement = this.inputElement.current;
-    if (inputElement && newValue !== currentValue) {
-      this.setNativeValue(inputElement, newValue);
-      inputElement.dispatchEvent(new Event('input', { bubbles: true }));
+    if (inputElement) {
+      const prototype = Object.getPrototypeOf(inputElement);
+      const prototypeValueSetter = Object.getOwnPropertyDescriptor(prototype, 'value').set;
+
+      prototypeValueSetter.call(inputElement, newValue);
+      inputElement.dispatchEvent(new Event('change', { bubbles: true }));
     }
   };
 

--- a/src/components/input/SingleLineInputBase.js
+++ b/src/components/input/SingleLineInputBase.js
@@ -46,6 +46,7 @@ class SingleLineInputBase extends PureComponent {
       onFocus,
       onBlur,
       prefix,
+      innerRef,
       inverse,
       readOnly,
       success,
@@ -79,6 +80,7 @@ class SingleLineInputBase extends PureComponent {
       onBlur: this.handleBlur,
       onFocus: this.handleFocus,
       readOnly,
+      innerRef,
       ...omitBoxProps(others),
     };
 

--- a/src/components/input/SingleLineInputBase.js
+++ b/src/components/input/SingleLineInputBase.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
@@ -42,11 +42,11 @@ class SingleLineInputBase extends PureComponent {
       connectedRight,
       disabled,
       error,
+      forwardedRef,
       helpText,
       onFocus,
       onBlur,
       prefix,
-      innerRef,
       inverse,
       readOnly,
       success,
@@ -75,12 +75,12 @@ class SingleLineInputBase extends PureComponent {
 
     const boxProps = pickBoxProps(others);
     const inputProps = {
+      ref: forwardedRef,
       disabled,
       inverse,
       onBlur: this.handleBlur,
       onFocus: this.handleFocus,
       readOnly,
-      innerRef,
       ...omitBoxProps(others),
     };
 
@@ -124,4 +124,4 @@ SingleLineInputBase.propTypes = {
   noInputStyling: PropTypes.bool,
 };
 
-export default SingleLineInputBase;
+export default forwardRef((props, ref) => <SingleLineInputBase {...props} forwardedRef={ref} />);


### PR DESCRIPTION
### Description

I did this so that the stepper can be used when
passing native value and onChange props to
the NumericInput

For example a form library that passes value and onChange
to this component will now be able to work with the
stepper out of the box.

Current behavior is still supported (onChange(event, value)).

#### Screenshot before this PR

- Same styling though so N/A

#### Screenshot after this PR

- Same styling though so N/A

### Breaking changes

- Current behavior should still be supported onChange(event, value) instead of onChange(event)

Based on this https://stackoverflow.com/questions/42550341/react-trigger-onchange-if-input-value-is-changing-by-state =>
**Solution Working in the Year 2020 and 2021:**

Also in this post top answer: https://stackoverflow.com/questions/23892547/what-is-the-best-way-to-trigger-onchange-event-in-react-js

### Manual check
 
- NumericInput => typing in the input field still works with (onChange(event, value)) (both event and value are present)
- NumericInput =>  Clicking the stepper now works with onChange(event, value) (both event and value are present, instead of event being null)