### PR TITLE
Fix Toggle layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Toggle`: Fix layout ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1672])
+
 ### Dependency updates
 
 ## [6.2.0]
@@ -28,7 +30,7 @@
 - `@teamleader/ui-typography` from `2.0.1` to `2.0.2`
 - `css-loader` from `5.2.4` to `5.2.6`
 - `eslint-config-standard` from `16.0.2` to `16.0.3`
-- `eslint` from `7.26.0` to `7.27.0` 
+- `eslint` from `7.26.0` to `7.27.0`
 - `husky` from `4.3.8` to `6.0.0`
 - `postcss ` from `8.2.14` to `8.3.0`
 - `react-resize-detector` from `6.7.1` to `6.7.2`

--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -57,6 +57,7 @@ class Toggle extends PureComponent {
         <input
           className={theme['input']}
           type="checkbox"
+          hidden
           checked={checked}
           disabled={disabled}
           onChange={this.handleToggle}

--- a/src/components/toggle/theme.css
+++ b/src/components/toggle/theme.css
@@ -125,6 +125,7 @@
   &.is-small {
     .track {
       flex: 0 0 var(--toggle-track-width-small);
+      width: var(--toggle-track-width-small);
       height: var(--toggle-track-height-small);
       border-radius: var(--toggle-track-height-small);
     }
@@ -154,6 +155,7 @@
 
     .track {
       flex: 0 0 var(--toggle-track-width-medium);
+      width: var(--toggle-track-width-medium);
       height: var(--toggle-track-height-medium);
       border-radius: var(--toggle-track-height-medium);
     }
@@ -183,6 +185,7 @@
 
     .track {
       flex: 0 0 var(--toggle-track-width-large);
+      width: var(--toggle-track-width-large);
       height: var(--toggle-track-height-large);
       border-radius: var(--toggle-track-height-large);
     }

--- a/src/components/toggle/toggle.stories.js
+++ b/src/components/toggle/toggle.stories.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Toggle from './Toggle';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
 
@@ -14,7 +14,15 @@ export default {
   },
 };
 
-export const DefaultStory = (args) => <Toggle {...args} />;
+export const DefaultStory = (args) => {
+  const [checked, setChecked] = useState(args.checked);
+
+  const handleChange = (event) => {
+    setChecked(event.currentTarget.checked);
+  };
+
+  return <Toggle {...args} checked={checked} onChange={handleChange} />;
+};
 
 DefaultStory.args = {
   checked: true,


### PR DESCRIPTION
### Description

When using the Toggle component inside of a flex container, the track (slider control) wasn't taking up the space it should take up (30px for small), it looks like the `flex-basis` property doesn't suffice, so I just added explicit width for all sizes as well. I've also set the input to hidden to prevent the extra 4 pixels before the slider seen in the screenshot

### Fixed

- Toggle takes up the correct amount of space in a flex container
- Toggle input that's used under the hood is hidden

#### Screenshot before this PR

<img width="205" alt="Screenshot 2021-06-07 at 15 40 03" src="https://user-images.githubusercontent.com/10011712/121026700-a6b04300-c7a6-11eb-8bc2-81c1631f573a.png">


#### Screenshot after this PR

<img width="215" alt="Screenshot 2021-06-07 at 15 42 40" src="https://user-images.githubusercontent.com/10011712/121027135-03136280-c7a7-11eb-89ea-02b716db497c.png">

