### PR TITLE
DurationInput: updated design and interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ### Added
 
+- `NumericInput` Holding the keyboard up/down arrows increases/decreases the value ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1687])
+
 ### Changed
+
+- `DurationInput`: The step size for minutes has been increased to 15 ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1687])
+- `DurationInput`: The hours input now has a padded "0" similar to the minutes input ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1687])
 
 ### Deprecated
 

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { Box, NumericInput, TextBodyCompact } from '../../';
+import { Box, NumericInput } from '../../';
 import theme from './theme.css';
 
 const transformToPaddedNumber = (number) => (number < 10 ? `0${number}` : number.toString());
@@ -130,9 +130,6 @@ const DurationInput = ({ value, onChange, onBlur, onFocus, onKeyDown, autoFocus,
         autoFocus={autoFocus}
         textAlignRight={textAlignRight}
       />
-      <TextBodyCompact color="neutral" tint="darkest" className={theme['duration-input-colon']}>
-        :
-      </TextBodyCompact>
       <NumericInput
         placeholder="00"
         {...(!value?.hours ? { min: 0 } : {})}

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -113,12 +113,17 @@ const DurationInput = ({ value, onChange, onBlur, onFocus, onKeyDown, autoFocus,
     minutes = transformToPaddedNumber(minutes);
   }
 
+  let hours = value?.hours;
+  if (Number.isInteger(hours)) {
+    hours = transformToPaddedNumber(hours);
+  }
+
   return (
     <Box display="flex" alignItems="center" ref={ref} className={className}>
       <NumericInput
-        placeholder="0"
+        placeholder="00"
         min={0}
-        value={value?.hours ?? ''}
+        value={hours ?? ''}
         onChange={handleHoursChanged}
         onBlur={handleBlur}
         onFocus={onFocus}

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -125,7 +125,6 @@ const DurationInput = ({ value, onChange, onBlur, onFocus, onKeyDown, autoFocus,
         onKeyDown={onKeyDown}
         type="text"
         inputMode="numeric"
-        flexGrow={1}
         className={theme['duration-input-numeric-input']}
         autoFocus={autoFocus}
         textAlignRight={textAlignRight}
@@ -140,7 +139,6 @@ const DurationInput = ({ value, onChange, onBlur, onFocus, onKeyDown, autoFocus,
         onKeyDown={onKeyDown}
         type="text"
         inputMode="numeric"
-        flexGrow={1}
         className={theme['duration-input-numeric-input']}
         textAlignRight={textAlignRight}
       />

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -4,6 +4,8 @@ import theme from './theme.css';
 
 const transformToPaddedNumber = (number) => (number < 10 ? `0${number}` : number.toString());
 
+const MINUTES_STEP = 15;
+
 const DurationInput = ({ value, onChange, onBlur, onFocus, onKeyDown, autoFocus, textAlignRight, className }) => {
   const ref = useRef();
 
@@ -72,7 +74,7 @@ const DurationInput = ({ value, onChange, onBlur, onFocus, onKeyDown, autoFocus,
     if (parsedMinutes < 0) {
       onChange({
         hours: (value?.hours || 1) - 1,
-        minutes: 59,
+        minutes: 60 - MINUTES_STEP,
       });
       return;
     }
@@ -136,6 +138,7 @@ const DurationInput = ({ value, onChange, onBlur, onFocus, onKeyDown, autoFocus,
       />
       <NumericInput
         placeholder="00"
+        step={MINUTES_STEP}
         {...(!value?.hours ? { min: 0 } : {})}
         value={minutes ?? ''}
         onChange={handleMinutesChange}

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -100,8 +100,10 @@ class NumericInput extends PureComponent {
   // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#auto-repeat_handling
   handleKeyDown = (event) => {
     if (event.key === 'ArrowUp') {
+      event.preventDefault();
       this.handleIncreaseValue();
     } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
       this.handleDecreaseValue();
     }
 

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -95,6 +95,16 @@ class NumericInput extends PureComponent {
     clearInterval(this.timer.current);
   };
 
+  handleKeyDown = (event) => {
+    if (event.key === 'ArrowUp') {
+      this.handleIncreaseValue();
+    } else if (event.key === 'ArrowDown') {
+      this.handleDecreaseValue();
+    }
+
+    this.props.onKeyDown && this.props.onKeyDown(event);
+  };
+
   handleBlur = (...parameters) => {
     const { onBlur } = this.props;
 
@@ -177,7 +187,7 @@ class NumericInput extends PureComponent {
 
   render() {
     const { value, ...rest } = this.props;
-    const restProps = omit(rest, ['suffix', 'onChange']);
+    const restProps = omit(rest, ['suffix', 'onChange', 'onKeyDown']);
 
     return (
       <SingleLineInputBase
@@ -185,6 +195,7 @@ class NumericInput extends PureComponent {
         type="number"
         value={value}
         onChange={this.handleOnChange}
+        onKeyDown={this.handleKeyDown}
         {...restProps}
         connectedLeft={this.getConnectedLeft()}
         connectedRight={this.getConnectedRight()}

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -12,6 +12,7 @@ import SingleLineInputBase from './SingleLineInputBase';
 import omit from 'lodash.omit';
 import theme from './theme.css';
 import { parseValue, toNumber } from './utils';
+import { KEY } from '../../constants';
 
 class StepperControls extends PureComponent {
   render() {
@@ -99,10 +100,10 @@ class NumericInput extends PureComponent {
   // This means we don't need to use an interval and can directly rely on the handler
   // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#auto-repeat_handling
   handleKeyDown = (event) => {
-    if (event.key === 'ArrowUp') {
+    if (event.key === KEY.ArrowUp) {
       event.preventDefault();
       this.handleIncreaseValue();
-    } else if (event.key === 'ArrowDown') {
+    } else if (event.key === KEY.ArrowDown) {
       event.preventDefault();
       this.handleDecreaseValue();
     }

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -95,6 +95,9 @@ class NumericInput extends PureComponent {
     clearInterval(this.timer.current);
   };
 
+  // Unlike mouse down events, key down events are "auto-repeated" while holding down the key
+  // This means we don't need to use an interval and can directly rely on the handler
+  // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#auto-repeat_handling
   handleKeyDown = (event) => {
     if (event.key === 'ArrowUp') {
       this.handleIncreaseValue();

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -468,6 +468,8 @@
 }
 
 .duration-input-numeric-input {
+  width: 100%;
+
   .input {
     padding-right: 0;
   }

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -467,10 +467,6 @@
   }
 }
 
-.duration-input-colon {
-  margin: 0 4px;
-}
-
 .duration-input-numeric-input {
   .input {
     padding-right: 0;

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -478,3 +478,18 @@
     }
   }
 }
+
+.duration-input-numeric-input:first-child .input-inner-wrapper {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.duration-input-numeric-input:last-child .input-inner-wrapper {
+  margin-left: -1px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.duration-input-numeric-input:hover {
+  z-index: 1;
+}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,5 +1,6 @@
 import { COLOR, COLORS, TINTS, colorsWithout, tintsWithout } from './colors';
 import { SIZES, sizesWithout, TINY, SMALL, MEDIUM, LARGE, FULLSCREEN } from './sizes';
+import KEY from './keys';
 
 export {
   COLOR,
@@ -14,4 +15,5 @@ export {
   MEDIUM,
   LARGE,
   FULLSCREEN,
+  KEY,
 };

--- a/src/constants/keys.js
+++ b/src/constants/keys.js
@@ -1,0 +1,6 @@
+const KEY = {
+  ArrowUp: 'ArrowUp',
+  ArrowDown: 'ArrowDown',
+};
+
+export default KEY;


### PR DESCRIPTION
### Added

- `NumericInput` Holding the keyboard up/down arrows increases/decreases the value

### Changed

- `DurationInput`: The step size for minutes has been increased to 15
- `DurationInput`: The hours input now has a padded "0" similar to the minutes input

#### Screenshot before this PR

<img width="1051" alt="Screenshot 2021-06-14 at 13 40 29" src="https://user-images.githubusercontent.com/10011712/121886903-5725c600-cd16-11eb-85c0-5caba1fc26c3.png">


#### Screenshot after this PR

<img width="1042" alt="Screenshot 2021-06-14 at 13 40 37" src="https://user-images.githubusercontent.com/10011712/121886918-5ab94d00-cd16-11eb-80fa-df588dd28df3.png">
