### PR TITLE
Fix duration input overlapping other elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `DurationInput`: Fix duration input overlapping other elements ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1704](https://github.com/teamleadercrm/ui/pull/1704))
+
 ### Dependency updates
 
 ## [6.5.0] - 2021-06-18

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -497,6 +497,8 @@
 }
 
 .duration-input-numeric-container {
+  position: relative;
+  z-index: 0;
   border-radius: var(--input-border-radius);
   &.has-error {
     box-shadow: 0 0 0 1px var(--input-error-border);


### PR DESCRIPTION
I haven't applied this change to any of the other inputs yet since I'm unsure what the impact will be.

### Fixed

- DurationInput conflicting with existing stacking contexts

### Manual check

Let's zoom for this one.
