### PR TITLE
release/6.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@
 
 ### Fixed
 
-- `DurationInput`: Fix duration input overlapping other elements ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1704](https://github.com/teamleadercrm/ui/pull/1704))
-
 ### Dependency updates
+
+## [6.5.1] - 2021-06-29
+
+### Fixed
+
+- `DurationInput`: Fix duration input overlapping other elements ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1704](https://github.com/teamleadercrm/ui/pull/1704))
 
 ## [6.5.0] - 2021-06-18
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [6.5.1] - 2021-06-29

### Fixed

- `DurationInput`: Fix duration input overlapping other elements ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1704](https://github.com/teamleadercrm/ui/pull/1704))