### PR TITLE
Check every direction when rendering the popup for the best fit with a preference for the opposite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [6.5.2] - 2021-06-29
+
+### Fixed
+
+- `Popover`: Check each direction for the be one to render the popover ([@EOSullivanBerlin](https://github.com/EOSullivanBerlin) in [#1710](https://github.com/teamleadercrm/ui/pull/1710))
+
 ## [6.5.1] - 2021-06-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Popover`: Check each direction for the be one to render the popover ([@EOSullivanBerlin](https://github.com/EOSullivanBerlin) in [#1710](https://github.com/teamleadercrm/ui/pull/1710))
+
 ### Deprecated
 
 ### Removed
@@ -11,12 +13,6 @@
 ### Fixed
 
 ### Dependency updates
-
-## [6.5.2] - 2021-06-29
-
-### Fixed
-
-- `Popover`: Check each direction for the be one to render the popover ([@EOSullivanBerlin](https://github.com/EOSullivanBerlin) in [#1710](https://github.com/teamleadercrm/ui/pull/1710))
 
 ## [6.5.1] - 2021-06-29
 

--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -143,7 +143,7 @@ Popover.propTypes = {
   className: PropTypes.string,
   /** The background colour of the Popover. */
   color: PropTypes.oneOf(['aqua', 'gold', 'mint', 'neutral', 'ruby', 'teal', 'violet']),
-  /** The direction in which the Popover is rendered, is overridden with the opposite direction if the Popover cannot be entirely displayed in the current direction. */
+  /** The preferred direction in which the Popover is rendered, is overridden with the opposite or adjacent direction if the Popover cannot be entirely displayed in the current direction. */
   direction: PropTypes.oneOf(['north', 'south', 'east', 'west']),
   /** If true, the Popover stretches to fit its content vertically */
   fullHeight: PropTypes.bool,

--- a/src/components/popover/positionCalculation.js
+++ b/src/components/popover/positionCalculation.js
@@ -149,6 +149,32 @@ const getOppositeDirection = (direction) => {
   }
 };
 
+const getClockwise90DegreeDirection = (direction) => {
+  switch (direction) {
+    case DIRECTION_NORTH:
+      return DIRECTION_EAST;
+    case DIRECTION_EAST:
+      return DIRECTION_SOUTH;
+    case DIRECTION_SOUTH:
+      return DIRECTION_WEST;
+    case DIRECTION_WEST:
+      return DIRECTION_NORTH;
+  }
+};
+
+const getClockwise270DegreeDirection = (direction) => {
+  switch (direction) {
+    case DIRECTION_NORTH:
+      return DIRECTION_WEST;
+    case DIRECTION_EAST:
+      return DIRECTION_NORTH;
+    case DIRECTION_SOUTH:
+      return DIRECTION_EAST;
+    case DIRECTION_WEST:
+      return DIRECTION_SOUTH;
+  }
+};
+
 const getDirection = ({ direction, anchorPosition, popoverDimensions }) => {
   const inputDirectionRendersOnScreen = isInViewport({ direction, anchorPosition, popoverDimensions });
   const oppositeDirectionRendersOnScreen = isInViewport({
@@ -156,10 +182,31 @@ const getDirection = ({ direction, anchorPosition, popoverDimensions }) => {
     anchorPosition,
     popoverDimensions,
   });
+  const clockwise90DegreeDirectionRendersOnScreen = isInViewport({
+    direction: getClockwise90DegreeDirection(direction),
+    anchorPosition,
+    popoverDimensions,
+  });
 
-  return !inputDirectionRendersOnScreen && oppositeDirectionRendersOnScreen
-    ? getOppositeDirection(direction)
-    : direction;
+  const clockwise270DegreeDirectionRendersOnScreen = isInViewport({
+    direction: getClockwise270DegreeDirection(direction),
+    anchorPosition,
+    popoverDimensions,
+  });
+
+  if (!inputDirectionRendersOnScreen) {
+    if (oppositeDirectionRendersOnScreen) {
+      return getOppositeDirection(direction);
+    }
+    if (clockwise90DegreeDirectionRendersOnScreen) {
+      return getClockwise90DegreeDirection(direction);
+    }
+    if (clockwise270DegreeDirectionRendersOnScreen) {
+      return getClockwise270DegreeDirection(direction);
+    }
+  }
+
+  return direction;
 };
 
 const isPositionPossible = (direction, position, anchorPosition, popoverDimensions) =>


### PR DESCRIPTION
### Description
Check all directions when rendering a popup to ensure the best fix. 

#### Screenshot before this PR

<img width="845" alt="Screenshot 2021-06-29 at 16 27 10" src="https://user-images.githubusercontent.com/27338309/123815619-eb874f80-d8f6-11eb-92c8-8d49646b0af2.png">


#### Screenshot after this PR

<img width="837" alt="Screenshot 2021-06-29 at 16 23 16" src="https://user-images.githubusercontent.com/27338309/123815675-f5a94e00-d8f6-11eb-8a69-dcae585ca3c3.png">



