### PR TITLE
Add forward references to Button and Input components, fix display name on existing forwardRefs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
     ],
     "curly": ["error", "all"],
     "react/prop-types": 0,
+    "react/display-name": 2,
     "dot-notation": 0
   },
   "settings": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ### Added
 
 - `FilterSelection` Add FilterSelectionComponent ([@JorenSaeyTL](https://github.com/JorenSaeyTL) in [#1717](https://github.com/teamleadercrm/ui/pull/1717))
+- `Button`: now correctly forwards its `ref` prop ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1727](https://github.com/teamleadercrm/ui/pull/1727))
+- `Input`: now correctly forwards its `ref` prop ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1727](https://github.com/teamleadercrm/ui/pull/1727))
+- `DurationInput`: now correctly forwards its `ref` prop ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1727](https://github.com/teamleadercrm/ui/pull/1727))
+- `NumericInput`: now correctly forwards its `ref` prop ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1727](https://github.com/teamleadercrm/ui/pull/1727))
+- `TextArea`: now correctly forwards its `ref` prop ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1727](https://github.com/teamleadercrm/ui/pull/1727))
+- `TimeInput`: now correctly forwards its `ref` prop ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1727](https://github.com/teamleadercrm/ui/pull/1727))
 
 ### Changed
 
@@ -14,6 +20,7 @@
 
 - `FilterSelection` Add Keyboard accessibility, remove unused style and fix clear handler ([@JorenSaeyTL](https://github.com/JorenSaeyTL) in [#1721](https://github.com/teamleadercrm/ui/pull/1721))
 - `FilterSelection` Fixed height and hover state ([@JorenSaeyTL](https://github.com/JorenSaeyTL) in [#1722](https://github.com/teamleadercrm/ui/pull/1722)
+- Display names on multiple components (for debugging) ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1727](https://github.com/teamleadercrm/ui/pull/1727))
 
 ### Dependency updates
 

--- a/src/components/box/Box.js
+++ b/src/components/box/Box.js
@@ -206,4 +206,8 @@ Box.defaultProps = {
   padding: 0,
 };
 
-export default forwardRef((props, ref) => <Box {...props} forwardedRef={ref} />);
+const ForwardedBox = forwardRef((props, ref) => <Box {...props} forwardedRef={ref} />);
+
+ForwardedBox.displayName = 'Box';
+
+export default ForwardedBox;

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { useRef, forwardRef, useImperativeHandle } from 'react';
 import PropTypes from 'prop-types';
 import Box from '../box';
 import LoadingSpinner from '../loadingSpinner';
@@ -13,76 +13,79 @@ const textComponentMap = {
   large: UITextDisplay,
 };
 
-class Button extends PureComponent {
-  getSpinnerColor() {
-    const { color, inverse, level } = this.props;
-
-    switch (level) {
-      case 'secondary':
-        return 'teal';
-      case 'outline':
-        return color === 'white' ? 'neutral' : color;
-      case 'link':
-        return inverse ? 'neutral' : 'aqua';
-      default:
-        return 'neutral';
-    }
-  }
-
-  getSpinnerTint() {
-    const { color, inverse, level } = this.props;
-
-    switch (level) {
-      case 'secondary':
-        return 'darkest';
-      case 'outline':
-        return color === 'white' ? 'lightest' : 'darkest';
-      case 'link':
-        return inverse ? 'lightest' : 'dark';
-      default:
-        return 'lightest';
-    }
-  }
-
-  handleMouseUp = (event) => {
-    this.blur();
-    if (this.props.onMouseUp) {
-      this.props.onMouseUp(event);
-    }
-  };
-
-  handleMouseLeave = (event) => {
-    this.blur();
-    if (this.props.onMouseLeave) {
-      this.props.onMouseLeave(event);
-    }
-  };
-
-  blur() {
-    if (this.buttonNode.blur) {
-      this.buttonNode.blur();
-    }
-  }
-
-  render() {
-    const {
+const Button = forwardRef(
+  (
+    {
+      color,
+      inverse,
+      level,
+      onMouseUp,
+      onMouseLeave,
       children,
       className,
-      color,
-      level,
       disabled,
       element,
       active,
       fullWidth,
       icon,
       iconPlacement,
-      inverse,
       label,
       size,
       type,
       processing,
       ...others
-    } = this.props;
+    },
+    ref,
+  ) => {
+    const buttonRef = useRef();
+    useImperativeHandle(ref, () => buttonRef.current);
+
+    const getSpinnerColor = () => {
+      switch (level) {
+        case 'secondary':
+          return 'teal';
+        case 'outline':
+          return color === 'white' ? 'neutral' : color;
+        case 'link':
+          return inverse ? 'neutral' : 'aqua';
+        default:
+          return 'neutral';
+      }
+    };
+
+    const getSpinnerTint = () => {
+      switch (level) {
+        case 'secondary':
+          return 'darkest';
+        case 'outline':
+          return color === 'white' ? 'lightest' : 'darkest';
+        case 'link':
+          return inverse ? 'lightest' : 'dark';
+        default:
+          return 'lightest';
+      }
+    };
+
+    const handleMouseUp = (event) => {
+      blur();
+      if (onMouseUp) {
+        onMouseUp(event);
+      }
+    };
+
+    const handleMouseLeave = (event) => {
+      blur();
+      if (onMouseLeave) {
+        onMouseLeave(event);
+      }
+    };
+
+    const blur = () => {
+      const currentButtonRef = buttonRef.current;
+      if (currentButtonRef) {
+        currentButtonRef.blur();
+      }
+    };
 
     const classNames = cx(
       theme['reset-box-sizing'],
@@ -105,14 +108,12 @@ class Button extends PureComponent {
 
     const props = {
       ...others,
-      ref: (node) => {
-        this.buttonNode = node;
-      },
+      ref: buttonRef,
       className: classNames,
       disabled: element === 'button' ? disabled : null,
       element: element,
-      onMouseUp: this.handleMouseUp,
-      onMouseLeave: this.handleMouseLeave,
+      onMouseUp: handleMouseUp,
+      onMouseLeave: handleMouseLeave,
       type: element === 'button' ? type : null,
       'data-teamleader-ui': 'button',
     };
@@ -137,15 +138,15 @@ class Button extends PureComponent {
         {processing && (
           <LoadingSpinner
             className={theme['spinner']}
-            color={this.getSpinnerColor()}
+            color={getSpinnerColor()}
             size={size === 'small' ? 'small' : 'medium'}
-            tint={this.getSpinnerTint()}
+            tint={getSpinnerTint()}
           />
         )}
       </Box>
     );
-  }
-}
+  },
+);
 
 Button.propTypes = {
   /** The content to display inside the button. */
@@ -196,5 +197,7 @@ Button.defaultProps = {
   size: 'medium',
   type: 'button',
 };
+
+Button.displayName = 'Button';
 
 export default Button;

--- a/src/components/datagrid/BodyRow.js
+++ b/src/components/datagrid/BodyRow.js
@@ -78,4 +78,8 @@ BodyRow.propTypes = {
   sliceTo: PropTypes.number,
 };
 
-export default forwardRef((props, ref) => <BodyRow {...props} forwardedRef={ref} />);
+const ForwardedBodyRow = forwardRef((props, ref) => <BodyRow {...props} forwardedRef={ref} />);
+
+ForwardedBodyRow.displayName = 'BodyRow';
+
+export default ForwardedBodyRow;

--- a/src/components/datagrid/FooterRow.js
+++ b/src/components/datagrid/FooterRow.js
@@ -30,4 +30,8 @@ FooterRow.propTypes = {
   sliceTo: PropTypes.number,
 };
 
-export default forwardRef((props, ref) => <FooterRow {...props} forwardedRef={ref} />);
+const ForwardedFooterRow = forwardRef((props, ref) => <FooterRow {...props} forwardedRef={ref} />);
+
+ForwardedFooterRow.displayName = 'FooterRow';
+
+export default ForwardedFooterRow;

--- a/src/components/datagrid/HeaderRow.js
+++ b/src/components/datagrid/HeaderRow.js
@@ -60,4 +60,8 @@ HeaderRow.propTypes = {
   sliceTo: PropTypes.number,
 };
 
-export default forwardRef((props, ref) => <HeaderRow {...props} forwardedRef={ref} />);
+const ForwardedHeaderRow = forwardRef((props, ref) => <HeaderRow {...props} forwardedRef={ref} />);
+
+ForwardedHeaderRow.displayName = 'HeaderRow';
+
+export default ForwardedHeaderRow;

--- a/src/components/datagrid/Row.js
+++ b/src/components/datagrid/Row.js
@@ -28,4 +28,8 @@ Row.defaultProps = {
   backgroundColor: 'white',
 };
 
-export default forwardRef((props, ref) => <Row {...props} forwardedRef={ref} />);
+const ForwardedRow = forwardRef((props, ref) => <Row {...props} forwardedRef={ref} />);
+
+ForwardedRow.displayName = 'Row';
+
+export default ForwardedRow;

--- a/src/components/dialog/Body.js
+++ b/src/components/dialog/Body.js
@@ -26,4 +26,8 @@ Body.propTypes = {
   scrollable: PropTypes.bool,
 };
 
-export default forwardRef((props, ref) => <Body {...props} forwardedRef={ref} />);
+const ForwardedBody = forwardRef((props, ref) => <Body {...props} forwardedRef={ref} />);
+
+ForwardedBody.displayName = 'Body';
+
+export default ForwardedBody;

--- a/src/components/filterSelection/FilterSelection.js
+++ b/src/components/filterSelection/FilterSelection.js
@@ -39,118 +39,120 @@ const BackgroundTintByStatus = {
   [Status.BROKEN]: 'lightest',
 };
 
-const FilterSelection = ({ label, modificationText, applied, status, amountApplied, onClick, onClearClick }, ref) => {
-  const showAmount = typeof amountApplied === 'number';
-  const modified = typeof modificationText === 'string';
+const FilterSelection = forwardRef(
+  ({ label, modificationText, applied, status, amountApplied, onClick, onClearClick }, ref) => {
+    const showAmount = typeof amountApplied === 'number';
+    const modified = typeof modificationText === 'string';
 
-  const Container = modified ? TooltippedBox : Box;
-  const tooltipProps = modified
-    ? {
-        tooltip: modificationText,
-        tooltipColor: 'white',
-        tooltipPosition: 'top',
-        tooltipSize: 'small',
+    const Container = modified ? TooltippedBox : Box;
+    const tooltipProps = modified
+      ? {
+          tooltip: modificationText,
+          tooltipColor: 'white',
+          tooltipPosition: 'top',
+          tooltipSize: 'small',
+        }
+      : {};
+
+    const handleKeyDown = (event) => {
+      if (event.key === KEY.Enter && status !== Status.DISABLED) {
+        onClick();
       }
-    : {};
+    };
 
-  const handleKeyDown = (event) => {
-    if (event.key === KEY.Enter && status !== Status.DISABLED) {
-      onClick();
-    }
-  };
+    const handleClearClick = (event) => {
+      event.stopPropagation();
+      if (status !== Status.DISABLED) {
+        onClearClick();
+      }
+    };
 
-  const handleClearClick = (event) => {
-    event.stopPropagation();
-    if (status !== Status.DISABLED) {
-      onClearClick();
-    }
-  };
-
-  return (
-    <Box
-      ref={ref}
-      className={cx(theme['select-control'], status === Status.DEFAULT && theme['select-control--hovered'])}
-      role="button"
-      tabIndex={0}
-      display="flex"
-      boxSizing="border-box"
-      paddingHorizontal={3}
-      backgroundColor={ColorByStatus[status] || 'neutral'}
-      backgroundTint={BackgroundTintByStatus[status] || undefined}
-      borderWidth={applied ? 2 : 0}
-      borderColor={ColorByStatus[status] || 'neutral'}
-      borderTint="dark"
-      borderRadius="rounded"
-      onClick={status !== Status.DISABLED && onClick}
-      onKeyDown={handleKeyDown}
-    >
-      <Container
+    return (
+      <Box
+        ref={ref}
+        className={cx(theme['select-control'], status === Status.DEFAULT && theme['select-control--hovered'])}
+        role="button"
+        tabIndex={0}
         display="flex"
-        flex={1}
-        alignItems="center"
-        justifyContent="space-between"
-        marginRight={2}
-        {...tooltipProps}
+        boxSizing="border-box"
+        paddingHorizontal={3}
+        backgroundColor={ColorByStatus[status] || 'neutral'}
+        backgroundTint={BackgroundTintByStatus[status] || undefined}
+        borderWidth={applied ? 2 : 0}
+        borderColor={ColorByStatus[status] || 'neutral'}
+        borderTint="dark"
+        borderRadius="rounded"
+        onClick={status !== Status.DISABLED && onClick}
+        onKeyDown={handleKeyDown}
       >
-        <TextBodyCompact
+        <Container
+          display="flex"
+          flex={1}
+          alignItems="center"
+          justifyContent="space-between"
+          marginRight={2}
+          {...tooltipProps}
+        >
+          <TextBodyCompact
+            color={status === Status.DEFAULT ? 'teal' : ColorByStatus[status] || 'neutral'}
+            tint={status === Status.DISABLED ? 'dark' : 'darkest'}
+            marginRight={applied ? 2 : 0}
+            className={theme['select-value-container']}
+          >{`${label}${modified ? ' •' : ''}`}</TextBodyCompact>
+          {applied && (
+            <Box
+              display="flex"
+              alignItems="center"
+              borderRadius="rounded"
+              className={cx(theme['select-clear'], theme[`select-clear--${status}`])}
+            >
+              {showAmount && (
+                <Heading4
+                  paddingLeft={2}
+                  paddingRight={1}
+                  color={ColorByStatus[status] || 'neutral'}
+                  tint="dark"
+                  borderTopLeftRadius="rounded"
+                  borderBottomLeftRadius="rounded"
+                  borderTopRightRadius={showAmount ? 'square' : 'rounded'}
+                  borderBottomRightRadius={showAmount ? 'square' : 'rounded'}
+                >
+                  <Monospaced>{amountApplied}</Monospaced>
+                </Heading4>
+              )}
+              <Box
+                alignItems="center"
+                display="flex"
+                onMouseDown={(event) => event.stopPropagation()}
+                onClick={handleClearClick}
+                paddingHorizontal={1}
+                borderTopLeftRadius={showAmount ? 'square' : 'rounded'}
+                borderBottomLeftRadius={showAmount ? 'square' : 'rounded'}
+                borderTopRightRadius="rounded"
+                borderBottomRightRadius="rounded"
+                className={theme['select-clear-icon']}
+              >
+                <Icon color={ColorByStatus[status] || 'neutral'} tint="dark" opacity={1}>
+                  <IconCloseSmallOutline />
+                </Icon>
+              </Box>
+            </Box>
+          )}
+        </Container>
+        <Icon
           color={status === Status.DEFAULT ? 'teal' : ColorByStatus[status] || 'neutral'}
           tint={status === Status.DISABLED ? 'dark' : 'darkest'}
-          marginRight={applied ? 2 : 0}
-          className={theme['select-value-container']}
-        >{`${label}${modified ? ' •' : ''}`}</TextBodyCompact>
-        {applied && (
-          <Box
-            display="flex"
-            alignItems="center"
-            borderRadius="rounded"
-            className={cx(theme['select-clear'], theme[`select-clear--${status}`])}
-          >
-            {showAmount && (
-              <Heading4
-                paddingLeft={2}
-                paddingRight={1}
-                color={ColorByStatus[status] || 'neutral'}
-                tint="dark"
-                borderTopLeftRadius="rounded"
-                borderBottomLeftRadius="rounded"
-                borderTopRightRadius={showAmount ? 'square' : 'rounded'}
-                borderBottomRightRadius={showAmount ? 'square' : 'rounded'}
-              >
-                <Monospaced>{amountApplied}</Monospaced>
-              </Heading4>
-            )}
-            <Box
-              alignItems="center"
-              display="flex"
-              onMouseDown={(event) => event.stopPropagation()}
-              onClick={handleClearClick}
-              paddingHorizontal={1}
-              borderTopLeftRadius={showAmount ? 'square' : 'rounded'}
-              borderBottomLeftRadius={showAmount ? 'square' : 'rounded'}
-              borderTopRightRadius="rounded"
-              borderBottomRightRadius="rounded"
-              className={theme['select-clear-icon']}
-            >
-              <Icon color={ColorByStatus[status] || 'neutral'} tint="dark" opacity={1}>
-                <IconCloseSmallOutline />
-              </Icon>
-            </Box>
-          </Box>
-        )}
-      </Container>
-      <Icon
-        color={status === Status.DEFAULT ? 'teal' : ColorByStatus[status] || 'neutral'}
-        tint={status === Status.DISABLED ? 'dark' : 'darkest'}
-        className={cx(
-          theme['select-dropdown-indicator'],
-          status === Status.FOCUSED && theme['select-dropdown-indicator--focused'],
-        )}
-      >
-        <IconChevronDownSmallOutline />
-      </Icon>
-    </Box>
-  );
-};
+          className={cx(
+            theme['select-dropdown-indicator'],
+            status === Status.FOCUSED && theme['select-dropdown-indicator--focused'],
+          )}
+        >
+          <IconChevronDownSmallOutline />
+        </Icon>
+      </Box>
+    );
+  },
+);
 
 FilterSelection.propTypes = {
   label: PropTypes.string,
@@ -172,4 +174,6 @@ FilterSelection.defaultProps = {
   onClearClick: null,
 };
 
-export default forwardRef(FilterSelection);
+FilterSelection.displayName = 'FilterSelection';
+
+export default FilterSelection;

--- a/src/components/hoc/DocumentObjectProvider/DocumentObjectProvider.js
+++ b/src/components/hoc/DocumentObjectProvider/DocumentObjectProvider.js
@@ -3,7 +3,7 @@ import React, { PureComponent, createContext } from 'react';
 export const Context = createContext();
 
 const DocumentObjectProvider = (WrappedComponent) => {
-  return class extends PureComponent {
+  const Provider = class extends PureComponent {
     componentDidMount() {
       this.forceUpdate(); // force a re-render because we have the document ref now
     }
@@ -31,6 +31,10 @@ const DocumentObjectProvider = (WrappedComponent) => {
       );
     }
   };
+
+  Provider.displayName = 'Provider';
+
+  return Provider;
 };
 
 export default DocumentObjectProvider;

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, forwardRef, useImperativeHandle } from 'react';
 import PropTypes from 'prop-types';
 import { Box, NumericInput } from '../../';
 import theme from './theme.css';
@@ -8,183 +8,174 @@ const transformToPaddedNumber = (number) => (number < 10 ? `0${number}` : number
 
 const MINUTES_STEP = 15;
 
-const DurationInput = ({
-  id,
-  value,
-  onChange,
-  onBlur,
-  onFocus,
-  onKeyDown,
-  autoFocus,
-  textAlignRight,
-  className,
-  error,
-  max,
-}) => {
-  const ref = useRef();
+const DurationInput = forwardRef(
+  ({ id, value, onChange, onBlur, onFocus, onKeyDown, autoFocus, textAlignRight, className, error, max }, ref) => {
+    const containerRef = useRef();
+    useImperativeHandle(ref, () => containerRef.current);
 
-  const handleHoursChanged = (_, hours) => {
-    if (!onChange) {
-      return;
-    }
+    const handleHoursChanged = (_, hours) => {
+      if (!onChange) {
+        return;
+      }
 
-    if (hours === '') {
-      if (typeof value?.minutes === 'undefined') {
-        onChange();
+      if (hours === '') {
+        if (typeof value?.minutes === 'undefined') {
+          onChange();
+          return;
+        }
+
+        onChange({
+          minutes: value?.minutes,
+        });
+        return;
+      }
+
+      const parsedHours = parseInt(hours);
+      if (!Number.isInteger(parsedHours)) {
         return;
       }
 
       onChange({
-        minutes: value?.minutes,
+        ...value,
+        hours: parsedHours,
       });
-      return;
-    }
+    };
 
-    const parsedHours = parseInt(hours);
-    if (!Number.isInteger(parsedHours)) {
-      return;
-    }
+    const handleMinutesChange = (_, minutes) => {
+      if (!onChange) {
+        return;
+      }
 
-    onChange({
-      ...value,
-      hours: parsedHours,
-    });
-  };
+      if (minutes === '') {
+        if (typeof value?.hours === 'undefined') {
+          onChange();
+          return;
+        }
 
-  const handleMinutesChange = (_, minutes) => {
-    if (!onChange) {
-      return;
-    }
+        onChange({
+          hours: value?.hours,
+        });
+        return;
+      }
 
-    if (minutes === '') {
-      if (typeof value?.hours === 'undefined') {
-        onChange();
+      const parsedMinutes = parseInt(minutes);
+      if (!Number.isInteger(parsedMinutes)) {
+        return;
+      }
+
+      if (parsedMinutes > 60) {
+        return;
+      }
+
+      if (parsedMinutes === 60) {
+        onChange({
+          hours: (value?.hours || 0) + 1,
+          minutes: 0,
+        });
+        return;
+      }
+
+      if (parsedMinutes < 0) {
+        onChange({
+          hours: (value?.hours || 1) - 1,
+          minutes: 60 - MINUTES_STEP,
+        });
         return;
       }
 
       onChange({
-        hours: value?.hours,
+        ...value,
+        minutes: parsedMinutes,
       });
-      return;
-    }
+    };
 
-    const parsedMinutes = parseInt(minutes);
-    if (!Number.isInteger(parsedMinutes)) {
-      return;
-    }
+    /**
+     * This blur handler is a special one, because this input consists of multiple focus points:
+     * the two inputs themselves, and the four increment/decrement buttons
+     * we filter out the blur events caused by changing focus between these, so the onBlur event only
+     * gets triggered when really blurring outside of the entire component
+     */
+    const handleBlur = (event) => {
+      if (!event.relatedTarget) {
+        onBlur && onBlur(event);
+        return;
+      }
 
-    if (parsedMinutes > 60) {
-      return;
-    }
+      const inputs = containerRef.current?.getElementsByTagName('input') || [];
+      if (Array.from(inputs).find((node) => node === event.relatedTarget)) {
+        return;
+      }
 
-    if (parsedMinutes === 60) {
-      onChange({
-        hours: (value?.hours || 0) + 1,
-        minutes: 0,
-      });
-      return;
-    }
+      const buttons = containerRef.current?.getElementsByTagName('button') || [];
+      if (Array.from(buttons).find((node) => node === event.relatedTarget)) {
+        return;
+      }
 
-    if (parsedMinutes < 0) {
-      onChange({
-        hours: (value?.hours || 1) - 1,
-        minutes: 60 - MINUTES_STEP,
-      });
-      return;
-    }
-
-    onChange({
-      ...value,
-      minutes: parsedMinutes,
-    });
-  };
-
-  /**
-   * This blur handler is a special one, because this input consists of multiple focus points:
-   * the two inputs themselves, and the four increment/decrement buttons
-   * we filter out the blur events caused by changing focus between these, so the onBlur event only
-   * gets triggered when really blurring outside of the entire component
-   */
-  const handleBlur = (event) => {
-    if (!event.relatedTarget) {
       onBlur && onBlur(event);
-      return;
+    };
+
+    let minutes = value?.minutes;
+    if (Number.isInteger(minutes)) {
+      minutes = transformToPaddedNumber(minutes);
     }
 
-    const inputs = ref.current?.getElementsByTagName('input') || [];
-    if (Array.from(inputs).find((node) => node === event.relatedTarget)) {
-      return;
+    let hours = value?.hours;
+    if (Number.isInteger(hours)) {
+      hours = transformToPaddedNumber(hours);
     }
 
-    const buttons = ref.current?.getElementsByTagName('button') || [];
-    if (Array.from(buttons).find((node) => node === event.relatedTarget)) {
-      return;
+    let maxHours;
+    let maxMinutes;
+    if (max) {
+      maxHours = Math.floor(max / 60);
+      maxMinutes = max % 60;
     }
 
-    onBlur && onBlur(event);
-  };
+    // Minutes are relative to the already filled in hours, so the max needs to be set on the fly
+    const isMaximumMinutesLimited = (max && value?.hours && value.hours >= maxHours) || maxHours === 0;
 
-  let minutes = value?.minutes;
-  if (Number.isInteger(minutes)) {
-    minutes = transformToPaddedNumber(minutes);
-  }
-
-  let hours = value?.hours;
-  if (Number.isInteger(hours)) {
-    hours = transformToPaddedNumber(hours);
-  }
-
-  let maxHours;
-  let maxMinutes;
-  if (max) {
-    maxHours = Math.floor(max / 60);
-    maxMinutes = max % 60;
-  }
-
-  // Minutes are relative to the already filled in hours, so the max needs to be set on the fly
-  const isMaximumMinutesLimited = (max && value?.hours && value.hours >= maxHours) || maxHours === 0;
-
-  return (
-    <Box
-      id={id}
-      display="flex"
-      alignItems="center"
-      ref={ref}
-      className={cx(className, theme['duration-input-numeric-container'], { [theme['has-error']]: error })}
-    >
-      <NumericInput
-        placeholder="00"
-        min={0}
-        {...(max ? { max: maxHours } : {})}
-        value={hours ?? ''}
-        onChange={handleHoursChanged}
-        onBlur={handleBlur}
-        onFocus={onFocus}
-        onKeyDown={onKeyDown}
-        type="text"
-        inputMode="numeric"
-        className={theme['duration-input-numeric-input']}
-        autoFocus={autoFocus}
-        textAlignRight={textAlignRight}
-      />
-      <NumericInput
-        placeholder="00"
-        step={MINUTES_STEP}
-        {...(!value?.hours ? { min: 0 } : {})}
-        {...(isMaximumMinutesLimited ? { max: maxMinutes } : {})}
-        value={minutes ?? ''}
-        onChange={handleMinutesChange}
-        onBlur={handleBlur}
-        onFocus={onFocus}
-        onKeyDown={onKeyDown}
-        type="text"
-        inputMode="numeric"
-        className={theme['duration-input-numeric-input']}
-        textAlignRight={textAlignRight}
-      />
-    </Box>
-  );
-};
+    return (
+      <Box
+        id={id}
+        display="flex"
+        alignItems="center"
+        ref={containerRef}
+        className={cx(className, theme['duration-input-numeric-container'], { [theme['has-error']]: error })}
+      >
+        <NumericInput
+          placeholder="00"
+          min={0}
+          {...(max ? { max: maxHours } : {})}
+          value={hours ?? ''}
+          onChange={handleHoursChanged}
+          onBlur={handleBlur}
+          onFocus={onFocus}
+          onKeyDown={onKeyDown}
+          type="text"
+          inputMode="numeric"
+          className={theme['duration-input-numeric-input']}
+          autoFocus={autoFocus}
+          textAlignRight={textAlignRight}
+        />
+        <NumericInput
+          placeholder="00"
+          step={MINUTES_STEP}
+          {...(!value?.hours ? { min: 0 } : {})}
+          {...(isMaximumMinutesLimited ? { max: maxMinutes } : {})}
+          value={minutes ?? ''}
+          onChange={handleMinutesChange}
+          onBlur={handleBlur}
+          onFocus={onFocus}
+          onKeyDown={onKeyDown}
+          type="text"
+          inputMode="numeric"
+          className={theme['duration-input-numeric-input']}
+          textAlignRight={textAlignRight}
+        />
+      </Box>
+    );
+  },
+);
 
 DurationInput.propTypes = {
   id: PropTypes.string,
@@ -200,5 +191,7 @@ DurationInput.propTypes = {
   /** In minutes **/
   max: PropTypes.number,
 };
+
+DurationInput.displayName = 'DurationInput';
 
 export default DurationInput;

--- a/src/components/input/Input.js
+++ b/src/components/input/Input.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { forwardRef, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import SingleLineInputBase from './SingleLineInputBase';
@@ -23,10 +23,11 @@ class Input extends PureComponent {
   };
 
   render() {
-    const { onChange, ...others } = this.props;
+    const { onChange, forwardedRef, ...others } = this.props;
 
     return (
       <SingleLineInputBase
+        ref={forwardedRef}
         value={this.state.value}
         onChange={(event) => {
           this.setState({ value: event.currentTarget.value });
@@ -69,4 +70,8 @@ Input.defaultProps = {
   type: 'text',
 };
 
-export default Input;
+const ForwardedInput = forwardRef((props, ref) => <Input {...props} forwardedRef={ref} />);
+
+ForwardedInput.displayName = 'Input';
+
+export default ForwardedInput;

--- a/src/components/input/InputBase.js
+++ b/src/components/input/InputBase.js
@@ -91,4 +91,8 @@ InputBase.defaultProps = {
   size: 'medium',
 };
 
-export default forwardRef((props, ref) => <InputBase {...props} forwardedRef={ref} />);
+const ForwardedInputBase = forwardRef((props, ref) => <InputBase {...props} forwardedRef={ref} />);
+
+ForwardedInputBase.displayName = 'InputBase';
+
+export default ForwardedInputBase;

--- a/src/components/input/NumericInput.js
+++ b/src/components/input/NumericInput.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import {
   IconAddSmallOutline,
@@ -198,13 +198,23 @@ class NumericInput extends PureComponent {
     return suffix;
   };
 
+  setRef = (ref) => {
+    this.inputElement = ref;
+    const { forwardedRef } = this.props;
+    if (typeof forwardedRef === 'function') {
+      forwardedRef(ref);
+    } else if (typeof forwardedRef === 'object' && forwardedRef !== null) {
+      forwardedRef.current = ref;
+    }
+  };
+
   render() {
     const { value, ...rest } = this.props;
     const restProps = omit(rest, ['suffix', 'onChange', 'onKeyDown']);
 
     return (
       <SingleLineInputBase
-        ref={this.inputElement}
+        ref={this.setRef}
         type="number"
         value={value}
         onChange={this.handleOnChange}
@@ -239,4 +249,8 @@ NumericInput.defaultProps = {
   stepper: 'suffix',
 };
 
-export default NumericInput;
+const ForwardedNumericInput = forwardRef((props, ref) => <NumericInput {...props} forwardedRef={ref} />);
+
+ForwardedNumericInput.displayName = 'NumericInput';
+
+export default ForwardedNumericInput;

--- a/src/components/input/SingleLineInputBase.js
+++ b/src/components/input/SingleLineInputBase.js
@@ -124,4 +124,8 @@ SingleLineInputBase.propTypes = {
   noInputStyling: PropTypes.bool,
 };
 
-export default forwardRef((props, ref) => <SingleLineInputBase {...props} forwardedRef={ref} />);
+const ForwardedSingleInputBase = forwardRef((props, ref) => <SingleLineInputBase {...props} forwardedRef={ref} />);
+
+ForwardedSingleInputBase.displayName = 'SingleLineInputBase';
+
+export default ForwardedSingleInputBase;

--- a/src/components/input/Textarea.js
+++ b/src/components/input/Textarea.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
@@ -9,7 +9,7 @@ import theme from './theme.css';
 
 class Textarea extends PureComponent {
   render() {
-    const { className, error, helpText, inverse, success, warning, ...others } = this.props;
+    const { className, error, helpText, inverse, success, warning, forwardedRef, ...others } = this.props;
 
     const classNames = cx(
       theme['wrapper'],
@@ -29,7 +29,7 @@ class Textarea extends PureComponent {
 
     return (
       <Box className={classNames} {...boxProps}>
-        <InputBase className={theme['textarea']} element="textarea" {...inputProps} />
+        <InputBase ref={forwardedRef} className={theme['textarea']} element="textarea" {...inputProps} />
         <ValidationText error={error} help={helpText} inverse={inverse} success={success} warning={warning} />
       </Box>
     );
@@ -55,4 +55,8 @@ Textarea.defaultProps = {
   inverse: false,
 };
 
-export default Textarea;
+const ForwardedTextArea = forwardRef((props, ref) => <Textarea {...props} forwardedRef={ref} />);
+
+ForwardedTextArea.displayName = 'Textarea';
+
+export default ForwardedTextArea;

--- a/src/components/input/TimeInput.js
+++ b/src/components/input/TimeInput.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { forwardRef, PureComponent } from 'react';
 import InputMask from 'react-input-mask';
 import Icon from '../icon';
 import SingleLineInputBase from './SingleLineInputBase';
@@ -14,12 +14,13 @@ class TimeInput extends PureComponent {
   };
 
   render() {
-    const { disabled, readOnly } = this.props;
+    const { disabled, readOnly, forwardedRef } = this.props;
     return (
       <InputMask {...this.props} mask="99:99" maskChar="0" beforeMaskedValueChange={this.beforeMaskedValueChange}>
         {(inputProps) => (
           <SingleLineInputBase
             {...inputProps}
+            ref={forwardedRef}
             autoComplete="off"
             readOnly={readOnly}
             disabled={disabled}
@@ -35,4 +36,8 @@ class TimeInput extends PureComponent {
   }
 }
 
-export default TimeInput;
+const ForwardedTimeInput = forwardRef((props, ref) => <TimeInput {...props} forwardedRef={ref} />);
+
+ForwardedTimeInput.displayName = 'TimeInput';
+
+export default ForwardedTimeInput;

--- a/src/components/marketingTab/MarketingTab.js
+++ b/src/components/marketingTab/MarketingTab.js
@@ -69,4 +69,8 @@ MarketingTab.defaultProps = {
   size: 'medium',
 };
 
-export default forwardRef((props, ref) => <MarketingTab {...props} forwardedRef={ref} />);
+const ForwardedMarketingTab = forwardRef((props, ref) => <MarketingTab {...props} forwardedRef={ref} />);
+
+ForwardedMarketingTab.displayName = 'MarketingTab';
+
+export default ForwardedMarketingTab;

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -423,4 +423,8 @@ Select.defaultProps = {
   width: '100%',
 };
 
-export default forwardRef((props, ref) => <Select {...props} forwardedRef={ref} />);
+const ForwardedSelect = forwardRef((props, ref) => <Select {...props} forwardedRef={ref} />);
+
+ForwardedSelect.displayName = 'Select';
+
+export default ForwardedSelect;

--- a/src/components/tab/TitleTab.js
+++ b/src/components/tab/TitleTab.js
@@ -81,4 +81,8 @@ TitleTab.defaultProps = {
   size: 'medium',
 };
 
-export default forwardRef((props, ref) => <TitleTab {...props} forwardedRef={ref} />);
+const ForwardedTitleTab = forwardRef((props, ref) => <TitleTab {...props} forwardedRef={ref} />);
+
+ForwardedTitleTab.displayName = 'TitleTab';
+
+export default ForwardedTitleTab;


### PR DESCRIPTION
I've also enabled a rule that enforces the display names to avoid the display names issue in the future.

### Added

- `Button`:  now correctly forwards its `ref` prop
- `Input`: now correctly forwards its `ref` prop
- `DurationInput`: now correctly forwards its `ref` prop
- `NumericInput`: now correctly forwards its `ref` prop
- `TextArea`: now correctly forwards its `ref` prop
- `TimeInput`: now correctly forwards its `ref` prop

### Fixed

- Display names on multiple components (for debugging)
