### PR TITLE
Align ref forwarding for remaining components

### DIFF
--- a/.storybook/stories/playground/forms.stories.js
+++ b/.storybook/stories/playground/forms.stories.js
@@ -40,16 +40,16 @@ export const forms = () => {
       <Box display="flex" marginTop={4}>
         <Label flex={1} marginRight={2}>
           Input
-          <Input innerRef={inputRef} />
+          <Input ref={inputRef} />
         </Label>
         <Label flex={1} marginLeft={2}>
           NumericInput
-          <NumericInput innerRef={numericInputRef} />
+          <NumericInput ref={numericInputRef} />
         </Label>
       </Box>
       <Label marginTop={4}>
         Textarea
-        <Textarea innerRef={textareaRef} />
+        <Textarea ref={textareaRef} />
       </Label>
     </Box>
   );

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 - `NumericInput`: now correctly forwards its `ref` prop ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1727](https://github.com/teamleadercrm/ui/pull/1727))
 - `TextArea`: now correctly forwards its `ref` prop ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1727](https://github.com/teamleadercrm/ui/pull/1727))
 - `TimeInput`: now correctly forwards its `ref` prop ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1727](https://github.com/teamleadercrm/ui/pull/1727))
+- [BREAKING] `IconButton`: now correctly forwards its `ref` prop ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1736](https://github.com/teamleadercrm/ui/pull/1736))
+- [BREAKING] `Link`: now correctly forwards its `ref` prop ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1736](https://github.com/teamleadercrm/ui/pull/1736))
+- [BREAKING] `TitleTab`: now correctly forwards its `ref` prop ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1736](https://github.com/teamleadercrm/ui/pull/1736))
+- [BREAKING] `MarketingButton`: now correctly forwards its `ref` prop ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1736](https://github.com/teamleadercrm/ui/pull/1736))
+- [BREAKING] `MarketingTab`: now correctly forwards its `ref` prop ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1736](https://github.com/teamleadercrm/ui/pull/1736))
+- [BREAKING] `MarketingLink`: now correctly forwards its `ref` prop ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1736](https://github.com/teamleadercrm/ui/pull/1736))
 
 ### Changed
 

--- a/src/components/iconButton/IconButton.js
+++ b/src/components/iconButton/IconButton.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import Box from '../box';
 import Icon from '../icon';
@@ -6,65 +6,76 @@ import cx from 'classnames';
 import buttonTheme from '../button/theme.css';
 import theme from './theme.css';
 
-class IconButton extends Component {
-  handleMouseUp = (event) => {
-    this.blur();
-    if (this.props.onMouseUp) {
-      this.props.onMouseUp(event);
+const IconButton = ({
+  children,
+  className,
+  disabled,
+  element,
+  icon,
+  size,
+  color,
+  tint,
+  selected,
+  type,
+  onMouseUp,
+  onMouseLeave,
+  ...others
+}) => {
+  const buttonRef = useRef();
+
+  const handleMouseUp = (event) => {
+    blur();
+    if (onMouseUp) {
+      onMouseUp(event);
     }
   };
 
-  handleMouseLeave = (event) => {
-    this.blur();
-    if (this.props.onMouseLeave) {
-      this.props.onMouseLeave(event);
+  const handleMouseLeave = (event) => {
+    blur();
+    if (onMouseLeave) {
+      onMouseLeave(event);
     }
   };
 
-  blur() {
-    if (this.buttonNode.blur) {
-      this.buttonNode.blur();
+  const blur = () => {
+    const currentButtonRef = buttonRef.current;
+    if (currentButtonRef.blur) {
+      currentButtonRef.blur();
     }
-  }
+  };
 
-  render() {
-    const { children, className, disabled, element, icon, size, color, tint, selected, type, ...others } = this.props;
+  const classNames = cx(
+    buttonTheme['button-base'],
+    theme['icon-button'],
+    theme[`is-${size}`],
+    {
+      [theme['is-disabled']]: disabled,
+      [theme['is-selected']]: selected,
+    },
+    className,
+  );
 
-    const classNames = cx(
-      buttonTheme['button-base'],
-      theme['icon-button'],
-      theme[`is-${size}`],
-      {
-        [theme['is-disabled']]: disabled,
-        [theme['is-selected']]: selected,
-      },
-      className,
-    );
+  const props = {
+    ...others,
+    ref: buttonRef,
+    className: classNames,
+    disabled: element === 'button' ? disabled : null,
+    element: element,
+    onMouseUp: handleMouseUp,
+    onMouseLeave: handleMouseLeave,
+    type: element === 'button' ? type : null,
+    'data-teamleader-ui': 'icon-button',
+  };
 
-    const props = {
-      ...others,
-      ref: (node) => {
-        this.buttonNode = node;
-      },
-      className: classNames,
-      disabled: element === 'button' ? disabled : null,
-      element: element,
-      onMouseUp: this.handleMouseUp,
-      onMouseLeave: this.handleMouseLeave,
-      type: element === 'button' ? type : null,
-      'data-teamleader-ui': 'icon-button',
-    };
-
-    return (
-      <Box {...props}>
-        <Icon color={color === 'white' ? 'neutral' : color} tint={color === 'white' ? 'lightest' : tint}>
-          {icon}
-        </Icon>
-        {children}
-      </Box>
-    );
-  }
-}
+  return (
+    <Box {...props}>
+      <Icon color={color === 'white' ? 'neutral' : color} tint={color === 'white' ? 'lightest' : tint}>
+        {icon}
+      </Icon>
+      {children}
+    </Box>
+  );
+};
 
 IconButton.propTypes = {
   /** The content to display inside the button. */

--- a/src/components/iconButton/IconButton.js
+++ b/src/components/iconButton/IconButton.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useImperativeHandle, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import Box from '../box';
 import Icon from '../icon';
@@ -6,76 +6,82 @@ import cx from 'classnames';
 import buttonTheme from '../button/theme.css';
 import theme from './theme.css';
 
-const IconButton = ({
-  children,
-  className,
-  disabled,
-  element,
-  icon,
-  size,
-  color,
-  tint,
-  selected,
-  type,
-  onMouseUp,
-  onMouseLeave,
-  ...others
-}) => {
-  const buttonRef = useRef();
-
-  const handleMouseUp = (event) => {
-    blur();
-    if (onMouseUp) {
-      onMouseUp(event);
-    }
-  };
-
-  const handleMouseLeave = (event) => {
-    blur();
-    if (onMouseLeave) {
-      onMouseLeave(event);
-    }
-  };
-
-  const blur = () => {
-    const currentButtonRef = buttonRef.current;
-    if (currentButtonRef.blur) {
-      currentButtonRef.blur();
-    }
-  };
-
-  const classNames = cx(
-    buttonTheme['button-base'],
-    theme['icon-button'],
-    theme[`is-${size}`],
+const IconButton = forwardRef(
+  (
     {
-      [theme['is-disabled']]: disabled,
-      [theme['is-selected']]: selected,
+      children,
+      className,
+      disabled,
+      element,
+      icon,
+      size,
+      color,
+      tint,
+      selected,
+      type,
+      onMouseUp,
+      onMouseLeave,
+      ...others
     },
-    className,
-  );
+    ref,
+  ) => {
+    const buttonRef = useRef();
+    useImperativeHandle(ref, () => buttonRef.current);
 
-  const props = {
-    ...others,
-    ref: buttonRef,
-    className: classNames,
-    disabled: element === 'button' ? disabled : null,
-    element: element,
-    onMouseUp: handleMouseUp,
-    onMouseLeave: handleMouseLeave,
-    type: element === 'button' ? type : null,
-    'data-teamleader-ui': 'icon-button',
-  };
+    const handleMouseUp = (event) => {
+      blur();
+      if (onMouseUp) {
+        onMouseUp(event);
+      }
+    };
 
-  return (
-    <Box {...props}>
-      <Icon color={color === 'white' ? 'neutral' : color} tint={color === 'white' ? 'lightest' : tint}>
-        {icon}
-      </Icon>
-      {children}
-    </Box>
-  );
-};
+    const handleMouseLeave = (event) => {
+      blur();
+      if (onMouseLeave) {
+        onMouseLeave(event);
+      }
+    };
+
+    const blur = () => {
+      const currentButtonRef = buttonRef.current;
+      if (currentButtonRef.blur) {
+        currentButtonRef.blur();
+      }
+    };
+
+    const classNames = cx(
+      buttonTheme['button-base'],
+      theme['icon-button'],
+      theme[`is-${size}`],
+      {
+        [theme['is-disabled']]: disabled,
+        [theme['is-selected']]: selected,
+      },
+      className,
+    );
+
+    const props = {
+      ...others,
+      ref: buttonRef,
+      className: classNames,
+      disabled: element === 'button' ? disabled : null,
+      element: element,
+      onMouseUp: handleMouseUp,
+      onMouseLeave: handleMouseLeave,
+      type: element === 'button' ? type : null,
+      'data-teamleader-ui': 'icon-button',
+    };
+
+    return (
+      <Box {...props}>
+        <Icon color={color === 'white' ? 'neutral' : color} tint={color === 'white' ? 'lightest' : tint}>
+          {icon}
+        </Icon>
+        {children}
+      </Box>
+    );
+  },
+);
 
 IconButton.propTypes = {
   /** The content to display inside the button. */
@@ -112,5 +118,7 @@ IconButton.defaultProps = {
   tint: 'darkest',
   type: 'button',
 };
+
+IconButton.displayName = 'IconButton';
 
 export default IconButton;

--- a/src/components/iconButton/iconButton.stories.js
+++ b/src/components/iconButton/iconButton.stories.js
@@ -19,7 +19,7 @@ export const basic = ({ size, ...args }) => (
   <IconButton {...args} icon={size === 'small' ? <IconAddSmallOutline /> : <IconAddMediumOutline />} />
 );
 
-export const withCustomElement = () => <IconButton icon={<IconAddMediumOutline />} element="a" href="#" />;
+export const withCustomElement = () => <IconButton icon={<IconAddMediumOutline />} element="a" />;
 
 withCustomElement.story = {
   name: 'With custom element',

--- a/src/components/link/Link.js
+++ b/src/components/link/Link.js
@@ -1,76 +1,82 @@
-import React, { Fragment, useRef } from 'react';
+import React, { forwardRef, Fragment, useRef, useImperativeHandle } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Box from '../box';
 import theme from './theme.css';
 import uiUtilities from '@teamleader/ui-utilities';
 
-const Link = ({
-  badged,
-  children,
-  className,
-  disabled,
-  icon,
-  iconPlacement,
-  element,
-  inherit,
-  inverse,
-  selected,
-  onMouseUp,
-  onMouseLeave,
-  ...others
-}) => {
-  const linkRef = useRef();
-
-  const blur = () => {
-    const currentLinkRef = linkRef.current;
-    if (currentLinkRef.blur) {
-      currentLinkRef.blur();
-    }
-  };
-
-  const handleMouseUp = (event) => {
-    blur();
-    onMouseUp && onMouseUp(event);
-  };
-
-  const handleMouseLeave = (event) => {
-    blur();
-    onMouseLeave && onMouseLeave(event);
-  };
-
-  const classNames = cx(
-    uiUtilities['reset-font-smoothing'],
-    theme['link'],
+const Link = forwardRef(
+  (
     {
-      [theme['is-badged']]: badged,
-      [theme['is-disabled']]: disabled,
-      [theme['is-inherit']]: inherit,
-      [theme['is-inverse']]: inverse,
-      [theme['is-selected']]: selected,
-      [theme['has-icon']]: icon,
+      badged,
+      children,
+      className,
+      disabled,
+      icon,
+      iconPlacement,
+      element,
+      inherit,
+      inverse,
+      selected,
+      onMouseUp,
+      onMouseLeave,
+      ...others
     },
-    className,
-  );
+    ref,
+  ) => {
+    const linkRef = useRef();
+    useImperativeHandle(ref, () => linkRef.current);
 
-  const ChildrenWrapper = icon ? 'span' : Fragment;
+    const blur = () => {
+      const currentLinkRef = linkRef.current;
+      if (currentLinkRef.blur) {
+        currentLinkRef.blur();
+      }
+    };
 
-  return (
-    <Box
-      element={element}
-      ref={linkRef}
-      className={classNames}
-      data-teamleader-ui="link"
-      onMouseUp={handleMouseUp}
-      onMouseLeave={handleMouseLeave}
-      {...others}
-    >
-      {icon && iconPlacement === 'left' && icon}
-      <ChildrenWrapper>{children}</ChildrenWrapper>
-      {icon && iconPlacement === 'right' && icon}
-    </Box>
-  );
-};
+    const handleMouseUp = (event) => {
+      blur();
+      onMouseUp && onMouseUp(event);
+    };
+
+    const handleMouseLeave = (event) => {
+      blur();
+      onMouseLeave && onMouseLeave(event);
+    };
+
+    const classNames = cx(
+      uiUtilities['reset-font-smoothing'],
+      theme['link'],
+      {
+        [theme['is-badged']]: badged,
+        [theme['is-disabled']]: disabled,
+        [theme['is-inherit']]: inherit,
+        [theme['is-inverse']]: inverse,
+        [theme['is-selected']]: selected,
+        [theme['has-icon']]: icon,
+      },
+      className,
+    );
+
+    const ChildrenWrapper = icon ? 'span' : Fragment;
+
+    return (
+      <Box
+        element={element}
+        ref={linkRef}
+        className={classNames}
+        data-teamleader-ui="link"
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseLeave}
+        {...others}
+      >
+        {icon && iconPlacement === 'left' && icon}
+        <ChildrenWrapper>{children}</ChildrenWrapper>
+        {icon && iconPlacement === 'right' && icon}
+      </Box>
+    );
+  },
+);
 
 Link.propTypes = {
   /** If true, component will be rendered with badged hover effect. */
@@ -108,5 +114,7 @@ Link.defaultProps = {
   inherit: true,
   inverse: false,
 };
+
+Link.displayName = 'Link';
 
 export default Link;

--- a/src/components/link/Link.js
+++ b/src/components/link/Link.js
@@ -1,81 +1,76 @@
-import React, { createRef, Fragment, PureComponent } from 'react';
+import React, { Fragment, useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Box from '../box';
 import theme from './theme.css';
 import uiUtilities from '@teamleader/ui-utilities';
 
-class Link extends PureComponent {
-  linkNode = createRef();
+const Link = ({
+  badged,
+  children,
+  className,
+  disabled,
+  icon,
+  iconPlacement,
+  element,
+  inherit,
+  inverse,
+  selected,
+  onMouseUp,
+  onMouseLeave,
+  ...others
+}) => {
+  const linkRef = useRef();
 
-  blur() {
-    if (this.linkNode.current.blur) {
-      this.linkNode.current.blur();
+  const blur = () => {
+    const currentLinkRef = linkRef.current;
+    if (currentLinkRef.blur) {
+      currentLinkRef.blur();
     }
-  }
+  };
 
-  handleMouseUp = (event) => {
-    const { onMouseUp } = this.props;
-
-    this.blur();
+  const handleMouseUp = (event) => {
+    blur();
     onMouseUp && onMouseUp(event);
   };
 
-  handleMouseLeave = (event) => {
-    const { onMouseLeave } = this.props;
-
-    this.blur();
+  const handleMouseLeave = (event) => {
+    blur();
     onMouseLeave && onMouseLeave(event);
   };
 
-  render() {
-    const {
-      badged,
-      children,
-      className,
-      disabled,
-      icon,
-      iconPlacement,
-      element,
-      inherit,
-      inverse,
-      selected,
-      ...others
-    } = this.props;
+  const classNames = cx(
+    uiUtilities['reset-font-smoothing'],
+    theme['link'],
+    {
+      [theme['is-badged']]: badged,
+      [theme['is-disabled']]: disabled,
+      [theme['is-inherit']]: inherit,
+      [theme['is-inverse']]: inverse,
+      [theme['is-selected']]: selected,
+      [theme['has-icon']]: icon,
+    },
+    className,
+  );
 
-    const classNames = cx(
-      uiUtilities['reset-font-smoothing'],
-      theme['link'],
-      {
-        [theme['is-badged']]: badged,
-        [theme['is-disabled']]: disabled,
-        [theme['is-inherit']]: inherit,
-        [theme['is-inverse']]: inverse,
-        [theme['is-selected']]: selected,
-        [theme['has-icon']]: icon,
-      },
-      className,
-    );
+  const ChildrenWrapper = icon ? 'span' : Fragment;
 
-    const ChildrenWrapper = icon ? 'span' : Fragment;
-
-    return (
-      <Box
-        element={element}
-        ref={this.linkNode}
-        className={classNames}
-        data-teamleader-ui="link"
-        onMouseUp={this.handleMouseUp}
-        onMouseLeave={this.handleMouseLeave}
-        {...others}
-      >
-        {icon && iconPlacement === 'left' && icon}
-        <ChildrenWrapper>{children}</ChildrenWrapper>
-        {icon && iconPlacement === 'right' && icon}
-      </Box>
-    );
-  }
-}
+  return (
+    <Box
+      element={element}
+      ref={linkRef}
+      className={classNames}
+      data-teamleader-ui="link"
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseLeave}
+      {...others}
+    >
+      {icon && iconPlacement === 'left' && icon}
+      <ChildrenWrapper>{children}</ChildrenWrapper>
+      {icon && iconPlacement === 'right' && icon}
+    </Box>
+  );
+};
 
 Link.propTypes = {
   /** If true, component will be rendered with badged hover effect. */

--- a/src/components/marketingButton/MarketingButton.js
+++ b/src/components/marketingButton/MarketingButton.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import Box from '../box';
 import LoadingSpinner from '../loadingSpinner';
@@ -13,101 +13,100 @@ const textComponentMap = {
   large: UITextDisplay,
 };
 
-class Button extends PureComponent {
-  handleMouseUp = (event) => {
-    this.blur();
-    if (this.props.onMouseUp) {
-      this.props.onMouseUp(event);
+const Button = ({
+  children,
+  className,
+  level,
+  disabled,
+  element,
+  fullWidth,
+  icon,
+  iconPlacement,
+  size,
+  type,
+  processing,
+  onMouseUp,
+  onMouseLeave,
+  ...others
+}) => {
+  const buttonRef = useRef();
+
+  const handleMouseUp = (event) => {
+    blur();
+    if (onMouseUp) {
+      onMouseUp(event);
     }
   };
 
-  handleMouseLeave = (event) => {
-    this.blur();
-    if (this.props.onMouseLeave) {
-      this.props.onMouseLeave(event);
+  const handleMouseLeave = (event) => {
+    blur();
+    if (onMouseLeave) {
+      onMouseLeave(event);
     }
   };
 
-  blur() {
-    if (this.buttonNode.blur) {
-      this.buttonNode.blur();
+  const blur = () => {
+    const currentButtonRef = buttonRef.current;
+    if (currentButtonRef.blur) {
+      currentButtonRef.blur();
     }
-  }
+  };
 
-  render() {
-    const {
-      children,
-      className,
-      level,
-      disabled,
-      element,
-      fullWidth,
-      icon,
-      iconPlacement,
-      size,
-      type,
-      processing,
-      ...others
-    } = this.props;
+  const classNames = cx(
+    theme['reset-box-sizing'],
+    theme['reset-font-smoothing'],
+    theme['button-base'],
+    theme['button'],
+    theme[level],
+    theme[size],
+    {
+      [theme['has-icon-only']]: !children || (Array.isArray(children) && !children[0]),
+      [theme['is-disabled']]: disabled,
+      [theme['is-full-width']]: fullWidth,
+      [theme['is-processing']]: processing,
+    },
+    className,
+  );
 
-    const classNames = cx(
-      theme['reset-box-sizing'],
-      theme['reset-font-smoothing'],
-      theme['button-base'],
-      theme['button'],
-      theme[level],
-      theme[size],
-      {
-        [theme['has-icon-only']]: !children || (Array.isArray(children) && !children[0]),
-        [theme['is-disabled']]: disabled,
-        [theme['is-full-width']]: fullWidth,
-        [theme['is-processing']]: processing,
-      },
-      className,
-    );
+  const props = {
+    ...others,
+    ref: buttonRef,
+    className: classNames,
+    disabled: element === 'button' ? disabled : null,
+    element: element,
+    onMouseUp: handleMouseUp,
+    onMouseLeave: handleMouseLeave,
+    type: element === 'button' ? type : null,
+    'data-teamleader-ui': 'button',
+  };
 
-    const props = {
-      ...others,
-      ref: (node) => {
-        this.buttonNode = node;
-      },
-      className: classNames,
-      disabled: element === 'button' ? disabled : null,
-      element: element,
-      onMouseUp: this.handleMouseUp,
-      onMouseLeave: this.handleMouseLeave,
-      type: element === 'button' ? type : null,
-      'data-teamleader-ui': 'button',
-    };
+  const Text = textComponentMap[size];
 
-    const Text = textComponentMap[size];
-
-    return (
-      <Box {...props}>
-        {icon && iconPlacement === 'left' && icon}
-        {children && (
-          <Text
-            element="span"
-            maxLines={1}
-            marginLeft={icon && iconPlacement === 'left' ? 2 : 0}
-            marginRight={icon && iconPlacement === 'right' ? 2 : 0}
-          >
-            {children}
-          </Text>
-        )}
-        {icon && iconPlacement === 'right' && icon}
-        {processing && (
-          <LoadingSpinner
-            className={theme['spinner']}
-            color={level === 'primary' ? 'neutral' : 'violet'}
-            size={size === 'tiny' || size === 'small' ? 'small' : 'medium'}
-            tint={level === 'primary' ? 'lightest' : 'darkest'}
-          />
-        )}
-      </Box>
-    );
-  }
-}
+  return (
+    <Box {...props}>
+      {icon && iconPlacement === 'left' && icon}
+      {children && (
+        <Text
+          element="span"
+          maxLines={1}
+          marginLeft={icon && iconPlacement === 'left' ? 2 : 0}
+          marginRight={icon && iconPlacement === 'right' ? 2 : 0}
+        >
+          {children}
+        </Text>
+      )}
+      {icon && iconPlacement === 'right' && icon}
+      {processing && (
+        <LoadingSpinner
+          className={theme['spinner']}
+          color={level === 'primary' ? 'neutral' : 'violet'}
+          size={size === 'tiny' || size === 'small' ? 'small' : 'medium'}
+          tint={level === 'primary' ? 'lightest' : 'darkest'}
+        />
+      )}
+    </Box>
+  );
+};
 
 Button.propTypes = {
   /** The content to display inside the button. */

--- a/src/components/marketingButton/MarketingButton.js
+++ b/src/components/marketingButton/MarketingButton.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, forwardRef, useImperativeHandle } from 'react';
 import PropTypes from 'prop-types';
 import Box from '../box';
 import LoadingSpinner from '../loadingSpinner';
@@ -13,100 +13,106 @@ const textComponentMap = {
   large: UITextDisplay,
 };
 
-const Button = ({
-  children,
-  className,
-  level,
-  disabled,
-  element,
-  fullWidth,
-  icon,
-  iconPlacement,
-  size,
-  type,
-  processing,
-  onMouseUp,
-  onMouseLeave,
-  ...others
-}) => {
-  const buttonRef = useRef();
-
-  const handleMouseUp = (event) => {
-    blur();
-    if (onMouseUp) {
-      onMouseUp(event);
-    }
-  };
-
-  const handleMouseLeave = (event) => {
-    blur();
-    if (onMouseLeave) {
-      onMouseLeave(event);
-    }
-  };
-
-  const blur = () => {
-    const currentButtonRef = buttonRef.current;
-    if (currentButtonRef.blur) {
-      currentButtonRef.blur();
-    }
-  };
-
-  const classNames = cx(
-    theme['reset-box-sizing'],
-    theme['reset-font-smoothing'],
-    theme['button-base'],
-    theme['button'],
-    theme[level],
-    theme[size],
+const Button = forwardRef(
+  (
     {
-      [theme['has-icon-only']]: !children || (Array.isArray(children) && !children[0]),
-      [theme['is-disabled']]: disabled,
-      [theme['is-full-width']]: fullWidth,
-      [theme['is-processing']]: processing,
+      children,
+      className,
+      level,
+      disabled,
+      element,
+      fullWidth,
+      icon,
+      iconPlacement,
+      size,
+      type,
+      processing,
+      onMouseUp,
+      onMouseLeave,
+      ...others
     },
-    className,
-  );
+    ref,
+  ) => {
+    const buttonRef = useRef();
+    useImperativeHandle(ref, () => buttonRef.current);
 
-  const props = {
-    ...others,
-    ref: buttonRef,
-    className: classNames,
-    disabled: element === 'button' ? disabled : null,
-    element: element,
-    onMouseUp: handleMouseUp,
-    onMouseLeave: handleMouseLeave,
-    type: element === 'button' ? type : null,
-    'data-teamleader-ui': 'button',
-  };
+    const handleMouseUp = (event) => {
+      blur();
+      if (onMouseUp) {
+        onMouseUp(event);
+      }
+    };
 
-  const Text = textComponentMap[size];
+    const handleMouseLeave = (event) => {
+      blur();
+      if (onMouseLeave) {
+        onMouseLeave(event);
+      }
+    };
 
-  return (
-    <Box {...props}>
-      {icon && iconPlacement === 'left' && icon}
-      {children && (
-        <Text
-          element="span"
-          maxLines={1}
-          marginLeft={icon && iconPlacement === 'left' ? 2 : 0}
-          marginRight={icon && iconPlacement === 'right' ? 2 : 0}
-        >
-          {children}
-        </Text>
-      )}
-      {icon && iconPlacement === 'right' && icon}
-      {processing && (
-        <LoadingSpinner
-          className={theme['spinner']}
-          color={level === 'primary' ? 'neutral' : 'violet'}
-          size={size === 'tiny' || size === 'small' ? 'small' : 'medium'}
-          tint={level === 'primary' ? 'lightest' : 'darkest'}
-        />
-      )}
-    </Box>
-  );
-};
+    const blur = () => {
+      const currentButtonRef = buttonRef.current;
+      if (currentButtonRef.blur) {
+        currentButtonRef.blur();
+      }
+    };
+
+    const classNames = cx(
+      theme['reset-box-sizing'],
+      theme['reset-font-smoothing'],
+      theme['button-base'],
+      theme['button'],
+      theme[level],
+      theme[size],
+      {
+        [theme['has-icon-only']]: !children || (Array.isArray(children) && !children[0]),
+        [theme['is-disabled']]: disabled,
+        [theme['is-full-width']]: fullWidth,
+        [theme['is-processing']]: processing,
+      },
+      className,
+    );
+
+    const props = {
+      ...others,
+      ref: buttonRef,
+      className: classNames,
+      disabled: element === 'button' ? disabled : null,
+      element: element,
+      onMouseUp: handleMouseUp,
+      onMouseLeave: handleMouseLeave,
+      type: element === 'button' ? type : null,
+      'data-teamleader-ui': 'button',
+    };
+
+    const Text = textComponentMap[size];
+
+    return (
+      <Box {...props}>
+        {icon && iconPlacement === 'left' && icon}
+        {children && (
+          <Text
+            element="span"
+            maxLines={1}
+            marginLeft={icon && iconPlacement === 'left' ? 2 : 0}
+            marginRight={icon && iconPlacement === 'right' ? 2 : 0}
+          >
+            {children}
+          </Text>
+        )}
+        {icon && iconPlacement === 'right' && icon}
+        {processing && (
+          <LoadingSpinner
+            className={theme['spinner']}
+            color={level === 'primary' ? 'neutral' : 'violet'}
+            size={size === 'tiny' || size === 'small' ? 'small' : 'medium'}
+            tint={level === 'primary' ? 'lightest' : 'darkest'}
+          />
+        )}
+      </Box>
+    );
+  },
+);
 
 Button.propTypes = {
   /** The content to display inside the button. */
@@ -149,5 +155,7 @@ Button.defaultProps = {
   size: 'medium',
   type: 'button',
 };
+
+Button.displayName = 'MarketingButton';
 
 export default Button;

--- a/src/components/marketingButton/MarketingButton.js
+++ b/src/components/marketingButton/MarketingButton.js
@@ -13,7 +13,7 @@ const textComponentMap = {
   large: UITextDisplay,
 };
 
-const Button = forwardRef(
+const MarketingButton = forwardRef(
   (
     {
       children,
@@ -114,7 +114,7 @@ const Button = forwardRef(
   },
 );
 
-Button.propTypes = {
+MarketingButton.propTypes = {
   /** The content to display inside the button. */
   children: PropTypes.any,
   /** A class name for the button to give custom styles. */
@@ -145,7 +145,7 @@ Button.propTypes = {
   type: PropTypes.string,
 };
 
-Button.defaultProps = {
+MarketingButton.defaultProps = {
   className: '',
   element: 'button',
   fullWidth: false,
@@ -156,6 +156,6 @@ Button.defaultProps = {
   type: 'button',
 };
 
-Button.displayName = 'MarketingButton';
+MarketingButton.displayName = 'MarketingButton';
 
-export default Button;
+export default MarketingButton;

--- a/src/components/marketingLink/MarketingLink.js
+++ b/src/components/marketingLink/MarketingLink.js
@@ -5,7 +5,7 @@ import Box from '../box';
 import theme from './theme.css';
 import uiUtilities from '@teamleader/ui-utilities';
 
-const Link = forwardRef(({ children, className, element, onMouseUp, onMouseLeave, ...others }, ref) => {
+const MarketingLink = forwardRef(({ children, className, element, onMouseUp, onMouseLeave, ...others }, ref) => {
   const linkRef = useRef();
   useImperativeHandle(ref, () => linkRef.current);
 
@@ -43,7 +43,7 @@ const Link = forwardRef(({ children, className, element, onMouseUp, onMouseLeave
   );
 });
 
-Link.propTypes = {
+MarketingLink.propTypes = {
   /** The content to display inside the link. */
   children: PropTypes.any.isRequired,
   /** A class name for the link to give custom styles. */
@@ -56,11 +56,11 @@ Link.propTypes = {
   onMouseUp: PropTypes.func,
 };
 
-Link.defaultProps = {
+MarketingLink.defaultProps = {
   className: '',
   element: 'a',
 };
 
-Link.displayName = 'MarketingLink';
+MarketingLink.displayName = 'MarketingLink';
 
-export default Link;
+export default MarketingLink;

--- a/src/components/marketingLink/MarketingLink.js
+++ b/src/components/marketingLink/MarketingLink.js
@@ -1,53 +1,46 @@
-import React, { createRef, PureComponent } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Box from '../box';
 import theme from './theme.css';
 import uiUtilities from '@teamleader/ui-utilities';
 
-class Link extends PureComponent {
-  linkNode = createRef();
+const Link = ({ children, className, element, onMouseUp, onMouseLeave, ...others }) => {
+  const linkRef = useRef();
 
-  blur() {
-    if (this.linkNode.current.blur) {
-      this.linkNode.current.blur();
+  const blur = () => {
+    const currentLinkRef = linkRef.current;
+    if (currentLinkRef.blur) {
+      currentLinkRef.blur();
     }
-  }
+  };
 
-  handleMouseUp = (event) => {
-    const { onMouseUp } = this.props;
-
-    this.blur();
+  const handleMouseUp = (event) => {
+    blur();
     onMouseUp && onMouseUp(event);
   };
 
-  handleMouseLeave = (event) => {
-    const { onMouseLeave } = this.props;
-
-    this.blur();
+  const handleMouseLeave = (event) => {
+    blur();
     onMouseLeave && onMouseLeave(event);
   };
 
-  render() {
-    const { children, className, element, ...others } = this.props;
+  const classNames = cx(uiUtilities['reset-font-smoothing'], theme['link'], className);
 
-    const classNames = cx(uiUtilities['reset-font-smoothing'], theme['link'], className);
-
-    return (
-      <Box
-        element={element}
-        ref={this.linkNode}
-        className={classNames}
-        data-teamleader-ui="marketing-link"
-        onMouseUp={this.handleMouseUp}
-        onMouseLeave={this.handleMouseLeave}
-        {...others}
-      >
-        {children}
-      </Box>
-    );
-  }
-}
+  return (
+    <Box
+      element={element}
+      ref={linkRef}
+      className={classNames}
+      data-teamleader-ui="marketing-link"
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseLeave}
+      {...others}
+    >
+      {children}
+    </Box>
+  );
+};
 
 Link.propTypes = {
   /** The content to display inside the link. */

--- a/src/components/marketingLink/MarketingLink.js
+++ b/src/components/marketingLink/MarketingLink.js
@@ -1,12 +1,13 @@
-import React, { useRef } from 'react';
+import React, { forwardRef, useRef, useImperativeHandle } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Box from '../box';
 import theme from './theme.css';
 import uiUtilities from '@teamleader/ui-utilities';
 
-const Link = ({ children, className, element, onMouseUp, onMouseLeave, ...others }) => {
+const Link = forwardRef(({ children, className, element, onMouseUp, onMouseLeave, ...others }, ref) => {
   const linkRef = useRef();
+  useImperativeHandle(ref, () => linkRef.current);
 
   const blur = () => {
     const currentLinkRef = linkRef.current;
@@ -40,7 +41,7 @@ const Link = ({ children, className, element, onMouseUp, onMouseLeave, ...others
       {children}
     </Box>
   );
-};
+});
 
 Link.propTypes = {
   /** The content to display inside the link. */
@@ -59,5 +60,7 @@ Link.defaultProps = {
   className: '',
   element: 'a',
 };
+
+Link.displayName = 'MarketingLink';
 
 export default Link;

--- a/src/components/marketingTab/MarketingTab.js
+++ b/src/components/marketingTab/MarketingTab.js
@@ -1,58 +1,49 @@
-import React, { createRef, forwardRef, PureComponent } from 'react';
+import React, { forwardRef, useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import theme from './theme.css';
-import omit from 'lodash.omit';
 import Box from '../box';
 import MarketingLockBadge from '../marketingLockBadge';
 import { Heading4, Heading5 } from '../typography';
 
-class MarketingTab extends PureComponent {
-  tabNode = createRef();
+const MarketingTab = ({ active, children, className, forwardedRef, size, onClick, ...others }) => {
+  const tabRef = useRef();
 
-  handleClick = (event) => {
-    if (this.props.onClick) {
-      this.props.onClick(event);
+  const handleClick = (event) => {
+    if (onClick) {
+      onClick(event);
     }
     if (event.pageX !== 0 && event.pageY !== 0) {
-      this.blur();
+      blur();
     }
   };
 
-  blur = () => {
-    const { forwardedRef } = this.props;
-    if (this.tabNode.current) {
-      this.tabNode.current.blur();
-    }
-    if (forwardedRef && forwardedRef.current) {
-      forwardedRef.current.blur();
+  const blur = () => {
+    const currentTabRef = tabRef.current;
+    if (currentTabRef.blur) {
+      currentTabRef.blur();
     }
   };
 
-  render() {
-    const { active, children, className, forwardedRef, size, ...others } = this.props;
-    const classNames = cx(theme['wrapper'], { [theme['is-active']]: active }, className);
+  const classNames = cx(theme['wrapper'], { [theme['is-active']]: active }, className);
 
-    const rest = omit(others, ['onClick']);
+  const TextElement = size === 'small' ? Heading5 : Heading4;
 
-    const TextElement = size === 'small' ? Heading5 : Heading4;
-
-    return (
-      <Box
-        data-teamleader-ui="marketing-tab"
-        className={classNames}
-        marginHorizontal={size === 'small' ? 1 : 2}
-        paddingHorizontal={size === 'small' ? 2 : 3}
-        ref={forwardedRef || this.tabNode}
-        onClick={this.handleClick}
-        {...rest}
-      >
-        <TextElement element="span">{children}</TextElement>
-        <MarketingLockBadge marginLeft={3} size={size} />
-      </Box>
-    );
-  }
-}
+  return (
+    <Box
+      data-teamleader-ui="marketing-tab"
+      className={classNames}
+      marginHorizontal={size === 'small' ? 1 : 2}
+      paddingHorizontal={size === 'small' ? 2 : 3}
+      ref={tabRef}
+      onClick={handleClick}
+      {...others}
+    >
+      <TextElement element="span">{children}</TextElement>
+      <MarketingLockBadge marginLeft={3} size={size} />
+    </Box>
+  );
+};
 
 MarketingTab.propTypes = {
   active: PropTypes.bool,

--- a/src/components/marketingTab/MarketingTab.js
+++ b/src/components/marketingTab/MarketingTab.js
@@ -1,4 +1,4 @@
-import React, { forwardRef, useRef } from 'react';
+import React, { forwardRef, useRef, useImperativeHandle } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import theme from './theme.css';
@@ -6,8 +6,9 @@ import Box from '../box';
 import MarketingLockBadge from '../marketingLockBadge';
 import { Heading4, Heading5 } from '../typography';
 
-const MarketingTab = ({ active, children, className, forwardedRef, size, onClick, ...others }) => {
+const MarketingTab = forwardRef(({ active, children, className, size, onClick, ...others }, ref) => {
   const tabRef = useRef();
+  useImperativeHandle(ref, () => tabRef.current);
 
   const handleClick = (event) => {
     if (onClick) {
@@ -43,7 +44,7 @@ const MarketingTab = ({ active, children, className, forwardedRef, size, onClick
       <MarketingLockBadge marginLeft={3} size={size} />
     </Box>
   );
-};
+});
 
 MarketingTab.propTypes = {
   active: PropTypes.bool,
@@ -60,8 +61,6 @@ MarketingTab.defaultProps = {
   size: 'medium',
 };
 
-const ForwardedMarketingTab = forwardRef((props, ref) => <MarketingTab {...props} forwardedRef={ref} />);
+MarketingTab.displayName = 'MarketingTab';
 
-ForwardedMarketingTab.displayName = 'MarketingTab';
-
-export default ForwardedMarketingTab;
+export default MarketingTab;

--- a/src/components/tab/TitleTab.js
+++ b/src/components/tab/TitleTab.js
@@ -1,4 +1,4 @@
-import React, { forwardRef, useRef } from 'react';
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
 import PropTypes from 'prop-types';
 import Box from '../box';
 import cx from 'classnames';
@@ -6,54 +6,57 @@ import theme from './theme.css';
 
 import { Heading4, Heading5 } from '../typography';
 
-const TitleTab = ({ active, children, className, counter = null, forwardedRef, size, onClick, ...others }) => {
-  const tabRef = useRef();
+const TitleTab = forwardRef(
+  ({ active, children, className, counter = null, forwardedRef, size, onClick, ...others }, ref) => {
+    const tabRef = useRef();
+    useImperativeHandle(ref, () => tabRef.current);
 
-  const handleClick = (event) => {
-    if (onClick) {
-      onClick(event);
-    }
-    if (event.pageX !== 0 && event.pageY !== 0) {
-      blur();
-    }
-  };
+    const handleClick = (event) => {
+      if (onClick) {
+        onClick(event);
+      }
+      if (event.pageX !== 0 && event.pageY !== 0) {
+        blur();
+      }
+    };
 
-  const blur = () => {
-    const currentTabRef = tabRef.current;
-    if (currentTabRef.blur) {
-      currentTabRef.blur();
-    }
-  };
+    const blur = () => {
+      const currentTabRef = tabRef.current;
+      if (currentTabRef.blur) {
+        currentTabRef.blur();
+      }
+    };
 
-  const getPaddingHorizontal = () => {
-    switch (size) {
-      case 'small':
-        return 2;
-      case 'medium':
-      default:
-        return 3;
-    }
-  };
+    const getPaddingHorizontal = () => {
+      switch (size) {
+        case 'small':
+          return 2;
+        case 'medium':
+        default:
+          return 3;
+      }
+    };
 
-  const classNames = cx(theme['title-tab'], { [theme['is-active']]: active }, className);
+    const classNames = cx(theme['title-tab'], { [theme['is-active']]: active }, className);
 
-  const TextElement = size === 'small' ? Heading5 : Heading4;
+    const TextElement = size === 'small' ? Heading5 : Heading4;
 
-  return (
-    <Box
-      data-teamleader-ui="title-tab"
-      className={classNames}
-      marginHorizontal={size === 'small' ? 1 : 2}
-      paddingHorizontal={getPaddingHorizontal()}
-      ref={tabRef}
-      onClick={handleClick}
-      {...others}
-    >
-      <TextElement element="span">{children}</TextElement>
-      {counter}
-    </Box>
-  );
-};
+    return (
+      <Box
+        data-teamleader-ui="title-tab"
+        className={classNames}
+        marginHorizontal={size === 'small' ? 1 : 2}
+        paddingHorizontal={getPaddingHorizontal()}
+        ref={tabRef}
+        onClick={handleClick}
+        {...others}
+      >
+        <TextElement element="span">{children}</TextElement>
+        {counter}
+      </Box>
+    );
+  },
+);
 
 TitleTab.propTypes = {
   active: PropTypes.bool,
@@ -71,8 +74,6 @@ TitleTab.defaultProps = {
   size: 'medium',
 };
 
-const ForwardedTitleTab = forwardRef((props, ref) => <TitleTab {...props} forwardedRef={ref} />);
+TitleTab.displayName = 'TitleTab';
 
-ForwardedTitleTab.displayName = 'TitleTab';
-
-export default ForwardedTitleTab;
+export default TitleTab;

--- a/src/components/tab/TitleTab.js
+++ b/src/components/tab/TitleTab.js
@@ -1,36 +1,31 @@
-import React, { createRef, forwardRef, PureComponent } from 'react';
+import React, { forwardRef, useRef } from 'react';
 import PropTypes from 'prop-types';
 import Box from '../box';
 import cx from 'classnames';
 import theme from './theme.css';
-import omit from 'lodash.omit';
 
 import { Heading4, Heading5 } from '../typography';
 
-class TitleTab extends PureComponent {
-  tabNode = createRef();
+const TitleTab = ({ active, children, className, counter = null, forwardedRef, size, onClick, ...others }) => {
+  const tabRef = useRef();
 
-  handleClick = (event) => {
-    if (this.props.onClick) {
-      this.props.onClick(event);
+  const handleClick = (event) => {
+    if (onClick) {
+      onClick(event);
     }
     if (event.pageX !== 0 && event.pageY !== 0) {
-      this.blur();
+      blur();
     }
   };
 
-  blur = () => {
-    const { forwardedRef } = this.props;
-    if (this.tabNode.current) {
-      this.tabNode.current.blur();
-    }
-    if (forwardedRef && forwardedRef.current) {
-      forwardedRef.current.blur();
+  const blur = () => {
+    const currentTabRef = tabRef.current;
+    if (currentTabRef.blur) {
+      currentTabRef.blur();
     }
   };
 
-  getPaddingHorizontal = () => {
-    const { size } = this.props;
+  const getPaddingHorizontal = () => {
     switch (size) {
       case 'small':
         return 2;
@@ -40,30 +35,25 @@ class TitleTab extends PureComponent {
     }
   };
 
-  render() {
-    const { active, children, className, counter = null, forwardedRef, size, ...others } = this.props;
-    const classNames = cx(theme['title-tab'], { [theme['is-active']]: active }, className);
+  const classNames = cx(theme['title-tab'], { [theme['is-active']]: active }, className);
 
-    const rest = omit(others, ['onClick']);
+  const TextElement = size === 'small' ? Heading5 : Heading4;
 
-    const TextElement = size === 'small' ? Heading5 : Heading4;
-
-    return (
-      <Box
-        data-teamleader-ui="title-tab"
-        className={classNames}
-        marginHorizontal={size === 'small' ? 1 : 2}
-        paddingHorizontal={this.getPaddingHorizontal()}
-        ref={forwardedRef || this.tabNode}
-        onClick={this.handleClick}
-        {...rest}
-      >
-        <TextElement element="span">{children}</TextElement>
-        {counter}
-      </Box>
-    );
-  }
-}
+  return (
+    <Box
+      data-teamleader-ui="title-tab"
+      className={classNames}
+      marginHorizontal={size === 'small' ? 1 : 2}
+      paddingHorizontal={getPaddingHorizontal()}
+      ref={tabRef}
+      onClick={handleClick}
+      {...others}
+    >
+      <TextElement element="span">{children}</TextElement>
+      {counter}
+    </Box>
+  );
+};
 
 TitleTab.propTypes = {
   active: PropTypes.bool,


### PR DESCRIPTION
Let's align this across the board.

### Added

- [BREAKING] `IconButton`: now correctly forwards its `ref` prop
- [BREAKING] `Link`: now correctly forwards its `ref` prop
- [BREAKING] `TitleTab`: now correctly forwards its `ref` prop
- [BREAKING] `MarketingButton`: now correctly forwards its `ref` prop
- [BREAKING] `MarketingTab`: now correctly forwards its `ref` prop
- [BREAKING] `MarketingLink`: now correctly forwards its `ref` prop