### PR TITLE
Don't allow more characters than needed in duration input 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `DurationInput`: Don't allow more characters than needed ([@jnstr](https://github.com/jnstr) in [#1738](https://github.com/teamleadercrm/ui/pull/1738)) 
+
 ### Deprecated
 
 ### Removed

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -118,6 +118,8 @@ const DurationInput = forwardRef(
     if (Number.isInteger(minutes)) {
       minutes = transformToPaddedNumber(minutes);
     }
+    // if it starts with 0, allow one more so we don't block typing (because we autopad the minutes)
+    const maxMinuteLength = (minutes && minutes.length >= 2 && minutes[0] !== '0') ? 2 : 3
 
     let hours = value?.hours;
     if (Number.isInteger(hours)) {
@@ -129,6 +131,15 @@ const DurationInput = forwardRef(
     if (max) {
       maxHours = Math.floor(max / 60);
       maxMinutes = max % 60;
+    }
+    let maxHourLength;
+    if (hours && maxHours) {
+      maxHourLength = maxHours.toString().length;
+
+      // if it starts with 0, allow one more so we don't block typing (because we autopad the hours)
+      if (hours && hours.length >= maxHourLength && hours[0] === '0') {
+        maxHourLength += 1;
+      }
     }
 
     // Minutes are relative to the already filled in hours, so the max needs to be set on the fly
@@ -146,6 +157,7 @@ const DurationInput = forwardRef(
           placeholder="00"
           min={0}
           {...(max ? { max: maxHours } : {})}
+          maxLength={maxHourLength}
           value={hours ?? ''}
           onChange={handleHoursChanged}
           onBlur={handleBlur}
@@ -162,6 +174,7 @@ const DurationInput = forwardRef(
           step={MINUTES_STEP}
           {...(!value?.hours ? { min: 0 } : {})}
           {...(isMaximumMinutesLimited ? { max: maxMinutes } : {})}
+          maxLength={maxMinuteLength}
           value={minutes ?? ''}
           onChange={handleMinutesChange}
           onBlur={handleBlur}


### PR DESCRIPTION
We're limiting the length of the input when manually typing in the duration input instead of using the stepper.

Minutes should always be limited to maximum 2 characters.

We only limit the length of the hour input if there is a maximum duration.

--- 

**:rotating_light: Hold merge until #1737 is merged :rotating_light:** 
