### PR TITLE
Copy extra files while building

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,8 +154,8 @@
   "scripts": {
     "build:css": "postcss ./src/**/*.css --base src --dir ./es && cp -R ./es ./cjs",
     "build:js": "yarn build:es; yarn build:cjs",
-    "build:cjs": "NODE_ENV=cjs babel src --out-dir cjs --copy-files --no-copy-ignored",
-    "build:es": "NODE_ENV=es babel src --out-dir es --copy-files --no-copy-ignored",
+    "build:cjs": "NODE_ENV=cjs babel src --out-dir cjs --copy-files --no-copy-ignored --extensions .js,.png",
+    "build:es": "NODE_ENV=es babel src --out-dir es --copy-files --no-copy-ignored --extensions .js,.png",
     "build": "rimraf es && rimraf cjs && yarn build:css && yarn build:js",
     "compile": "build-storybook -o dist",
     "lint:clean": "yarn lint && rimraf dist",

--- a/package.json
+++ b/package.json
@@ -154,8 +154,8 @@
   "scripts": {
     "build:css": "postcss ./src/**/*.css --base src --dir ./es && cp -R ./es ./cjs",
     "build:js": "yarn build:es; yarn build:cjs",
-    "build:cjs": "NODE_ENV=cjs babel src --out-dir cjs",
-    "build:es": "NODE_ENV=es babel src --out-dir es",
+    "build:cjs": "NODE_ENV=cjs babel src --out-dir cjs --copy-files --no-copy-ignored",
+    "build:es": "NODE_ENV=es babel src --out-dir es --copy-files --no-copy-ignored",
     "build": "rimraf es && rimraf cjs && yarn build:css && yarn build:js",
     "compile": "build-storybook -o dist",
     "lint:clean": "yarn lint && rimraf dist",


### PR DESCRIPTION
### Description

The babel build only includes files that were built by it so I've added `--copy-files` to include the required svgs
Then I've also added `--no-copy-ignored` so the stories are excluded.
And finally `--extensions` was added to get around [an issue](https://github.com/babel/babel/issues/11394) with the `no-copy-ignored` parameter