### PR TITLE
Release/8.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,21 @@
 
 ### Fixed
 
+### Dependency updates
+
+## [8.1.2] - 2021-08-23
+
+### Fixed
+
 - `PoweredByButton`: Inline svgs ([@lorgan3](https://github.com/lorgan3) in [#1770](https://github.com/teamleadercrm/ui/pull/1770))
 
 ### Dependency updates
+
+- `postcss-nested` from `5.0.5` to `5.0.6 `
+- `cssnano` from `5.0.6` to `5.0.7`
+- `@teamleader/ui-illustrations` from `1.2.0` to `1.3.0`
+- `@storybook/addon-backgrounds` from `6.3.4` to `6.3.7`
+- `@storybook/addon-doc`s from `6.3.6` to `6.3.7`
 
 ## [8.1.1] - 2021-08-16
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [8.1.2] - 2021-08-23

### Fixed

- `PoweredByButton`: Inline svgs ([@lorgan3](https://github.com/lorgan3) in [#1770](https://github.com/teamleadercrm/ui/pull/1770))

### Dependency updates

- `postcss-nested` from `5.0.5` to `5.0.6 `
- `cssnano` from `5.0.6` to `5.0.7`
- `@teamleader/ui-illustrations` from `1.2.0` to `1.3.0`
- `@storybook/addon-backgrounds` from `6.3.4` to `6.3.7`
- `@storybook/addon-doc`s from `6.3.6` to `6.3.7`