### PR TITLE
Progress tracker spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `ProgressTracker`: Adjust vertical spacing ([@lorgan3](https://github.com/lorgan3) in [#1784](https://github.com/teamleadercrm/ui/pull/1784))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/progressTracker/ProgressStep.js
+++ b/src/components/progressTracker/ProgressStep.js
@@ -12,7 +12,8 @@ class ProgressStep extends PureComponent {
     const classNames = cx(theme['step'], {
       [theme['is-active']]: active,
       [theme['is-completed']]: completed,
-      [theme['is-clickable']]: onClick,
+      [theme['is-clickable']]: !!onClick,
+      [theme['has-meta']]: !!meta,
     });
     return (
       <Box className={classNames}>

--- a/src/components/progressTracker/progressTracker.stories.js
+++ b/src/components/progressTracker/progressTracker.stories.js
@@ -33,7 +33,7 @@ export const DefaultStory = () => (
     {steps.map((step, index) => (
       <ProgressTracker.ProgressStep
         label={step}
-        meta={`${10 + index * 3}/12/2020`}
+        meta={boolean('Meta labels', true) ? `${10 + index * 3}/12/2020` : undefined}
         key={index}
         onClick={() => console.log('step clicked')}
       />

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -195,45 +195,31 @@
   }
 }
 
+.tracker-alternating .step:nth-child(even),
+.tracker-bottom .step {
+  flex-direction: column-reverse;
+
+  &:before {
+    bottom: 53px;
+  }
+
+  &:after {
+    bottom: 52px;
+  }
+
+  .status-bullet-halo {
+    bottom: 30px;
+  }
+}
+
 .tracker-alternating {
   .step {
     &:nth-child(even) {
-      flex-direction: column-reverse;
       margin-top: 36px;
-
-      &:before {
-        bottom: 53px;
-      }
-
-      &:after {
-        bottom: 52px;
-      }
-
-      .status-bullet-halo {
-        bottom: 30px;
-      }
     }
 
     &-label-holder {
       width: 200%;
-    }
-  }
-}
-
-.tracker-bottom {
-  .step {
-    flex-direction: column-reverse;
-
-    &:before {
-      bottom: 53px;
-    }
-
-    &:after {
-      bottom: 52px;
-    }
-
-    .status-bullet-halo {
-      bottom: 30px;
     }
   }
 }

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -200,22 +200,40 @@
   flex-direction: column-reverse;
 
   &:before {
-    bottom: 53px;
+    bottom: 35px;
   }
 
   &:after {
-    bottom: 52px;
+    bottom: 34px;
   }
 
   .status-bullet-halo {
-    bottom: 30px;
+    bottom: 12px;
+  }
+
+  &.has-meta {
+    &:before {
+      bottom: 53px;
+    }
+
+    &:after {
+      bottom: 52px;
+    }
+
+    .status-bullet-halo {
+      bottom: 30px;
+    }
   }
 }
 
 .tracker-alternating {
   .step {
     &:nth-child(even) {
-      margin-top: 36px;
+      margin-top: 18px;
+
+      &.has-meta {
+        margin-top: 36px;
+      }
     }
 
     &-label-holder {

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -37,12 +37,12 @@
   &:before {
     background-color: var(--color-neutral-dark);
     width: 100%;
-    bottom: 11px;
+    bottom: 17px;
   }
 
   &:after {
     height: 4px;
-    bottom: 10px;
+    bottom: 16px;
     left: 50%;
     transition: width var(--animation-duration) var(--animation-curve-default),
       background-color 0.1s var(--animation-curve-default) calc(var(--animation-duration) - 0.1s);
@@ -104,7 +104,7 @@
     border-radius: 50%;
     display: block;
     height: var(--bullet-size);
-    margin: 6px 0;
+    margin: 12px 0;
     width: var(--bullet-size);
     z-index: 2;
     position: relative;
@@ -130,7 +130,7 @@
       calc(var(--animation-duration) - 0.1s);
     border-radius: 50%;
     display: block;
-    margin: 6px 0;
+    margin: 12px 0;
     height: var(--bullet-halo-size);
     width: var(--bullet-halo-size);
     position: absolute;
@@ -202,11 +202,11 @@
       margin-top: 36px;
 
       &:before {
-        bottom: 47px;
+        bottom: 53px;
       }
 
       &:after {
-        bottom: 46px;
+        bottom: 52px;
       }
 
       .status-bullet-halo {
@@ -225,11 +225,11 @@
     flex-direction: column-reverse;
 
     &:before {
-      bottom: 47px;
+      bottom: 53px;
     }
 
     &:after {
-      bottom: 46px;
+      bottom: 52px;
     }
 
     .status-bullet-halo {


### PR DESCRIPTION
### Description

This is a tweak and a fix for the progress tracker:
- The spacing between the bullets and the labels should be 12px instead of 6px
- If you had no meta labels and the progress tracker was in `alternating` mode the bullets were not correctly aligned with the horizontal line.

#### Screenshot before this PR

![image](https://user-images.githubusercontent.com/1833617/131498785-c5072c54-148d-4087-9a69-a2dce1359d16.png)
![image](https://user-images.githubusercontent.com/1833617/131498873-cff35af5-39ac-47ef-9e7b-ed7da4fdad5a.png)


#### Screenshot after this PR

![image](https://user-images.githubusercontent.com/1833617/131498710-26090732-98b1-4a16-adbf-9c1b439d690f.png)
![image](https://user-images.githubusercontent.com/1833617/131498573-3d529d50-8c8e-4944-9ce9-e852e3d00090.png)

