### PR TITLE
Fix date picker locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `DatePicker`: Pass localeUtils to support different locales out of the box ([@lorgan3](https://github.com/lorgan3) in [#1791](https://github.com/teamleadercrm/ui/pull/1791))
+
 ### Dependency updates
 
 ## [8.2.0] - 2021-09-06

--- a/src/components/datepicker/DatePicker.js
+++ b/src/components/datepicker/DatePicker.js
@@ -9,6 +9,7 @@ import { convertModifiersToClassnames } from './utils';
 import cx from 'classnames';
 import theme from './theme.css';
 import uiUtilities from '@teamleader/ui-utilities';
+import LocaleUtils from './localeUtils';
 
 class DatePicker extends PureComponent {
   state = {
@@ -72,6 +73,7 @@ class DatePicker extends PureComponent {
       <Box {...boxProps}>
         <DayPicker
           {...restProps}
+          localeUtils={LocaleUtils}
           initialMonth={selectedDate}
           month={selectedMonth}
           className={classNames}

--- a/src/components/datepicker/DatePickerInput.js
+++ b/src/components/datepicker/DatePickerInput.js
@@ -7,7 +7,7 @@ import Input from '../input';
 import Popover from '../popover';
 import cx from 'classnames';
 import theme from './theme.css';
-import LocaleUtils, { formatDate } from './localeUtils';
+import { formatDate } from './localeUtils';
 import { IconCalendarSmallOutline } from '@teamleader/ui-icons';
 
 class DatePickerInput extends PureComponent {
@@ -148,7 +148,6 @@ class DatePickerInput extends PureComponent {
             <DatePicker
               className={datePickerClassNames}
               locale={locale}
-              localeUtils={LocaleUtils}
               month={selectedDate}
               onChange={this.handleDatePickerDateChange}
               selectedDate={selectedDate}

--- a/src/components/datepicker/DatePickerRange.js
+++ b/src/components/datepicker/DatePickerRange.js
@@ -8,6 +8,7 @@ import { convertModifiersToClassnames, isSelectingFirstDay } from './utils';
 import cx from 'classnames';
 import theme from './theme.css';
 import uiUtilities from '@teamleader/ui-utilities';
+import LocaleUtils from './localeUtils';
 
 class DatePickerRange extends PureComponent {
   state = {
@@ -92,6 +93,7 @@ class DatePickerRange extends PureComponent {
       <Box {...boxProps}>
         <DayPicker
           {...restProps}
+          localeUtils={LocaleUtils}
           className={classNames}
           classNames={theme}
           modifiers={convertModifiersToClassnames(modifiers, theme)}

--- a/src/components/datepicker/datePicker.stories.js
+++ b/src/components/datepicker/datePicker.stories.js
@@ -3,7 +3,7 @@ import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
 import { boolean, number, select, text } from '@storybook/addon-knobs';
 import { DatePicker, DatePickerRange, DatePickerInput, DatePickerInputRange, Toggle } from '../../index';
 import { DateTime } from 'luxon';
-import CustomLocaleUtils, { formatDate, parseDate } from './localeUtils';
+import { formatDate, parseDate } from './localeUtils';
 
 const languages = [
   'da-DK',
@@ -63,7 +63,6 @@ export const singleDate = () => {
     <DatePicker
       bordered={boolean('bordered', true)}
       locale={select('Locale', languages, 'nl-BE')}
-      localeUtils={CustomLocaleUtils}
       numberOfMonths={number('Number of months', 1)}
       onChange={handleOnChange}
       selectedDate={preSelectedDate}
@@ -158,7 +157,6 @@ export const range = () => {
     <DatePickerRange
       bordered={boolean('bordered', true)}
       locale={select('Locale', languages, 'nl-BE')}
-      localeUtils={CustomLocaleUtils}
       numberOfMonths={number('Number of months', 2)}
       onChange={handleOnChange}
       selectedRange={preSelectedRange}
@@ -179,7 +177,6 @@ export const inputRange = () => {
       bold={boolean('Bold', false)}
       dayPickerProps={{
         locale: select('Locale', languages, 'nl-BE'),
-        localeUtils: CustomLocaleUtils,
         numberOfMonths: number('Number of months', 2),
         showOutsideDays: boolean('Show outside days', false),
         showWeekNumbers: boolean('Show week numbers', true),


### PR DESCRIPTION
### Description

The `DatePickerInput` passes `localeUtils` to the day-picker so it is translated but the basic `DatePicker` does not, which results in it always being english unless you implement them yourself.
This fixes that behaviour by passing the utils in the DatePicker instead of DatePickerInput

#### Screenshot before this PR

/

#### Screenshot after this PR

/

