### PR TITLE
`DurationInput`: add `small`, `medium` (default) and `large` size property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `DurationInput`: add `small`, `medium` (default) and `large` size property ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1789](https://github.com/teamleadercrm/ui/pull/1794))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -212,6 +212,7 @@ DurationInput.propTypes = {
 };
 
 DurationInput.defaultProps = {
+  textAlignRight: false,
   size: 'medium',
 };
 

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -208,7 +208,7 @@ DurationInput.propTypes = {
   error: PropTypes.bool,
   /** In minutes **/
   max: PropTypes.number,
-  size: 'small' | 'medium' | 'large',
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
 };
 
 DurationInput.defaultProps = {

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -122,7 +122,7 @@ const DurationInput = forwardRef(
       minutes = transformToPaddedNumber(minutes);
     }
     // if it starts with 0, allow one more so we don't block typing (because we autopad the minutes)
-    const maxMinuteLength = (minutes && minutes.length >= 2 && minutes[0] !== '0') ? 2 : 3
+    const maxMinuteLength = minutes && minutes.length >= 2 && minutes[0] !== '0' ? 2 : 3;
 
     let hours = value?.hours;
     if (Number.isInteger(hours)) {

--- a/src/components/input/DurationInput.js
+++ b/src/components/input/DurationInput.js
@@ -9,7 +9,10 @@ const transformToPaddedNumber = (number) => (number < 10 ? `0${number}` : number
 const MINUTES_STEP = 15;
 
 const DurationInput = forwardRef(
-  ({ id, value, onChange, onBlur, onFocus, onKeyDown, autoFocus, textAlignRight, className, error, max }, ref) => {
+  (
+    { id, value, onChange, onBlur, onFocus, onKeyDown, autoFocus, textAlignRight, className, error, max, size },
+    ref,
+  ) => {
     const containerRef = useRef();
     useImperativeHandle(ref, () => containerRef.current);
 
@@ -168,6 +171,7 @@ const DurationInput = forwardRef(
           className={theme['duration-input-numeric-input']}
           autoFocus={autoFocus}
           textAlignRight={textAlignRight}
+          size={size}
         />
         <NumericInput
           placeholder="00"
@@ -184,6 +188,7 @@ const DurationInput = forwardRef(
           inputMode="numeric"
           className={theme['duration-input-numeric-input']}
           textAlignRight={textAlignRight}
+          size={size}
         />
       </Box>
     );
@@ -203,6 +208,11 @@ DurationInput.propTypes = {
   error: PropTypes.bool,
   /** In minutes **/
   max: PropTypes.number,
+  size: 'small' | 'medium' | 'large',
+};
+
+DurationInput.defaultProps = {
+  size: 'medium',
 };
 
 DurationInput.displayName = 'DurationInput';


### PR DESCRIPTION
### Added

- `DurationInput`: add `small`, `medium` (default) and `large` size property

#### Screenshot after this PR

Example of the small input

<img width="314" alt="Screenshot 2021-09-12 at 12 27 13" src="https://user-images.githubusercontent.com/10011712/132984095-249c7859-3c49-4753-8397-0efa7698987e.png">

