### PR TITLE
release/8.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### Added
 
-- `DurationInput`: add `small`, `medium` (default) and `large` size property ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1789](https://github.com/teamleadercrm/ui/pull/1794))
-
 ### Changed
 
 ### Deprecated
@@ -12,9 +10,17 @@
 
 ### Fixed
 
-- `DatePicker`: Pass localeUtils to support different locales out of the box ([@lorgan3](https://github.com/lorgan3) in [#1791](https://github.com/teamleadercrm/ui/pull/1791))
-
 ### Dependency updates
+
+## [8.3.0] - 2021-09-13
+
+### Added
+
+- `DurationInput`: add `small`, `medium` (default) and `large` size property ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1789](https://github.com/teamleadercrm/ui/pull/1794))
+
+### Fixed
+
+- `DatePicker`: Pass localeUtils to support different locales out of the box ([@lorgan3](https://github.com/lorgan3) in [#1791](https://github.com/teamleadercrm/ui/pull/1791))
 
 ## [8.2.0] - 2021-09-06
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
##  [8.3.0] - 2021-09-13

### Added

- `DurationInput`: add `small`, `medium` (default) and `large` size property ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1789](https://github.com/teamleadercrm/ui/pull/1794))

### Fixed

- `DatePicker`: Pass localeUtils to support different locales out of the box ([@lorgan3](https://github.com/lorgan3) in [#1791](https://github.com/teamleadercrm/ui/pull/1791))