### PR TITLE
`Datepicker`: change the background for today's button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `DatePicker`: Change the background for today's button ([@lowiebenoot](https://github.com/lowiebenoot) in [#1803](https://github.com/teamleadercrm/ui/pull/1803))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/datepicker/theme.css
+++ b/src/components/datepicker/theme.css
@@ -194,6 +194,7 @@
 }
 
 .today {
+  background: var(--color-neutral);
   font-family: var(--font-family-inter);
   font-weight: 700;
 }


### PR DESCRIPTION
### Description

Add a neutral background to today's button in the datepicker, to make it easier to spot.

#### Screenshot before this PR
![Screenshot 2021-10-05 at 14 35 40](https://user-images.githubusercontent.com/330765/135972348-fc68d3f9-5beb-49b5-be7e-0858891cdabe.png)



#### Screenshot after this PR


![Screenshot 2021-10-05 at 14 35 22](https://user-images.githubusercontent.com/330765/135972375-324c2fed-7952-429f-b970-616d72a4efc7.png)
