### PR TITLE
10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,23 @@
 
 ### Changed
 
-- [BREAKING] `Overlay`: `onClick`'s behavior has been replaced by `onOverlayClick`, which now passes a `mousedown` event instead of a `click` event ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1823](https://github.com/teamleadercrm/ui/pull/1823))
-
 ### Deprecated
 
 ### Removed
 
 ### Fixed
 
-- `Overlay, Dialog, Popover`: Fix dragging outside of the Overlay causing the Overlay to close ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1823](https://github.com/teamleadercrm/ui/pull/1823))
-
 ### Dependency updates
+
+## [10.0.0] - 2021-11-04
+
+### Changed
+
+- [BREAKING] `Overlay`: `onClick`'s behavior has been replaced by `onOverlayClick`, which now passes a `mousedown` event instead of a `click` event ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1823](https://github.com/teamleadercrm/ui/pull/1823))
+
+### Fixed
+
+- `Overlay, Dialog, Popover`: Fix dragging outside of the Overlay causing the Overlay to close ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1823](https://github.com/teamleadercrm/ui/pull/1823))
 
 ## [9.1.0] - 2021-10-13
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "9.1.0",
+  "version": "10.0.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [10.0.0] - 2021-11-04

### Changed

- [BREAKING] `Overlay`: `onClick`'s behavior has been replaced by `onOverlayClick`, which now passes a `mousedown` event instead of a `click` event ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1823](https://github.com/teamleadercrm/ui/pull/1823))

### Fixed

- `Overlay, Dialog, Popover`: Fix dragging outside of the Overlay causing the Overlay to close ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1823](https://github.com/teamleadercrm/ui/pull/1823))