### PR TITLE
[ATL-460] Fix `Overlay` conflicting with `Select` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 
+- `Overlay`: fix faulty onOverlayClick trigger if the click origin isn't part of DOM tree ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1823](https://github.com/teamleadercrm/ui/pull/1828))
+- `Select`: prevent redundant complete re-renders of the DropdownIndicator and ClearIndicator component ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1823](https://github.com/teamleadercrm/ui/pull/1828))
+
 ### Dependency updates
 
 ## [10.0.0] - 2021-11-04

--- a/src/components/overlay/Overlay.js
+++ b/src/components/overlay/Overlay.js
@@ -61,6 +61,8 @@ class Overlay extends PureComponent {
     // Only register clicks outside of the children
     if (
       this.props.onOverlayClick &&
+      // if the clickOrigin is no longer part of the DOM tree, (f.e. due to internal React re-renders)
+      document.body.contains(this.clickOriginRef.current) &&
       !this.innerWrapperRef.current?.contains(this.clickOriginRef.current) &&
       // react-select has its own implementation of an overlay, conflicting with our custom implementation
       // so clicks on the select overlay shouldn't be registered either

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -18,6 +18,29 @@ const minHeightBySizeMap = {
   large: 48,
 };
 
+const DropdownIndicator = ({ selectProps: { inverse } }) => {
+  return (
+    <Icon
+      alignItems="center"
+      className={theme['dropdown-indicator']}
+      color={inverse ? 'teal' : 'neutral'}
+      display="flex"
+      justifyContent="center"
+      tint={inverse ? 'lightest' : 'darkest'}
+    >
+      <IconChevronDownSmallOutline />
+    </Icon>
+  );
+};
+
+const ClearIndicator = ({ innerProps, selectProps: { inverse } }) => {
+  return (
+    <Icon color={inverse ? 'teal' : 'neutral'} display="flex" tint={inverse ? 'lightest' : 'darkest'} {...innerProps}>
+      <IconCloseBadgedSmallFilled />
+    </Icon>
+  );
+};
+
 export const selectOverlayNode = document.createElement('div');
 selectOverlayNode.setAttribute('data-teamleader-ui', 'select-overlay');
 
@@ -323,40 +346,6 @@ class Select extends PureComponent {
     valueContainer: this.getValueContainerStyles,
   });
 
-  getClearIndicator =
-    () =>
-    ({ innerProps }) => {
-      const { inverse } = this.props;
-
-      return (
-        <Icon
-          color={inverse ? 'teal' : 'neutral'}
-          display="flex"
-          tint={inverse ? 'lightest' : 'darkest'}
-          {...innerProps}
-        >
-          <IconCloseBadgedSmallFilled />
-        </Icon>
-      );
-    };
-
-  getDropDownIndicator = () => () => {
-    const { inverse } = this.props;
-
-    return (
-      <Icon
-        alignItems="center"
-        className={theme['dropdown-indicator']}
-        color={inverse ? 'teal' : 'neutral'}
-        display="flex"
-        justifyContent="center"
-        tint={inverse ? 'lightest' : 'darkest'}
-      >
-        <IconChevronDownSmallOutline />
-      </Icon>
-    );
-  };
-
   render() {
     const { components, creatable, error, inverse, helpText, size, success, warning, forwardedRef, ...otherProps } =
       this.props;
@@ -377,8 +366,8 @@ class Select extends PureComponent {
           ref={forwardedRef}
           className={cx(uiUtilities['reset-font-smoothing'], theme['select'])}
           components={{
-            ClearIndicator: this.getClearIndicator(),
-            DropdownIndicator: this.getDropDownIndicator(),
+            ClearIndicator,
+            DropdownIndicator,
             IndicatorSeparator: null,
             ...components,
           }}


### PR DESCRIPTION
### Description

- The `Select` component was fresh rendering components when opening, causing the `clickOrigin.current` to no longer be present in the DOM and the `Overlay` component to detect the click as outside of the overlay content

### Manual check

- Let's do an over the shoulder check