### PR TITLE
10.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@
 
 ### Fixed
 
+### Dependency updates
+
+## [10.0.1] - 2021-11-04
+
+### Fixed
+
 - `Overlay`: fix faulty onOverlayClick trigger if the click origin isn't part of DOM tree ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1823](https://github.com/teamleadercrm/ui/pull/1828))
 - `Select`: prevent redundant complete re-renders of the DropdownIndicator and ClearIndicator component ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1823](https://github.com/teamleadercrm/ui/pull/1828))
-
-### Dependency updates
 
 ## [10.0.0] - 2021-11-04
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [10.0.1] - 2021-11-04

### Fixed

- `Overlay`: fix faulty onOverlayClick trigger if the click origin isn't part of DOM tree ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1823](https://github.com/teamleadercrm/ui/pull/1828))
- `Select`: prevent redundant complete re-renders of the DropdownIndicator and ClearIndicator component ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1823](https://github.com/teamleadercrm/ui/pull/1828))