### PR TITLE
Increase z-index on `Dialog` overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@
 
 ### Fixed
 
-- `Overlay`: fix faulty onOverlayClick trigger if the click origin isn't part of DOM tree ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1823](https://github.com/teamleadercrm/ui/pull/1828))
-- `Select`: prevent redundant complete re-renders of the DropdownIndicator and ClearIndicator component ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1823](https://github.com/teamleadercrm/ui/pull/1828))
+- `Overlay`: fix faulty onOverlayClick trigger if the click origin isn't part of DOM tree ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1828](https://github.com/teamleadercrm/ui/pull/1828))
+- `Select`: prevent redundant complete re-renders of the DropdownIndicator and ClearIndicator component ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1828](https://github.com/teamleadercrm/ui/pull/1828))
 
 ## [10.0.0] - 2021-11-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Increase z-index from 400 to 403 on Dialog overlays ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1834](https://github.com/teamleadercrm/ui/pull/1834))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/dialog/theme.css
+++ b/src/components/dialog/theme.css
@@ -12,7 +12,7 @@
   align-items: center;
   display: flex;
   justify-content: center;
-  z-index: 400;
+  z-index: 403;
 }
 
 .dialog-base {


### PR DESCRIPTION
### Description

I've increased the `z-index` on `Dialog` overlays to allow us to display new dialogs on top of existing legacy dialogs. (F.e. alert messages when saving a legacy dialog). This is what our current z-index system looks like in our own Teamleader Focus:

```js
#popupbg,
#tlconfirmbg {
  z-index: 401;
}

#popup-container,
#tl_innerconfirmbox,
.popupform .tooltip:hover,
#teamviewer_support_popup_bg {
  z-index: 401;
}

@media screen and (min-width: 1580px) {
  #TL_extra_overlays.visible_during_popups {
    z-index: 401;
  }
}

#dd,
#loaderspinner,
#bigclicker,
.ajax_cc_suggestions,
#teamviewer_support_popup {
  z-index: 402;
}

#dd_loading,
#filepreviewbar {
  z-index: 403;
}

#connectivity_info {
  z-index: 404;
}
```

Because our own legacy implementation of popups receives a `z-index` of 401, new `Dialogs` can't be displayed on top of them since the one defined previously was only 400. 403 seems to be the correct one in this case since 402 is already taken as well. I know this isn't an ideal solution, and we should avoid defining the `z-index` in our UI-library in the first place, but since it was already there this is a fix with the least impact.
