### PR TITLE
Prevent click events in the `Overlay` from propagating to the parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Overlay`: Prevent click events in the `Overlay` from propagating to the parent ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1836](https://github.com/teamleadercrm/ui/pull/1836))
+
 ### Dependency updates
 
 ## [10.1.0] - 2021-11-05

--- a/src/components/overlay/Overlay.js
+++ b/src/components/overlay/Overlay.js
@@ -51,6 +51,11 @@ class Overlay extends PureComponent {
     }
   };
 
+  handleClick = (event) => {
+    event.stopPropagation();
+    this.props.onClick?.(event);
+  };
+
   handleMouseDown = (event) => {
     event.stopPropagation();
     this.clickOriginRef.current = event.target;
@@ -85,6 +90,7 @@ class Overlay extends PureComponent {
               onKeyDown={this.handleEscKey}
               onMouseDown={this.handleMouseDown}
               onMouseUp={this.handleMouseUp}
+              onClick={this.handleClick}
               className={cx(
                 theme['overlay'],
                 theme[backdrop],


### PR DESCRIPTION
### Description

- Prevent click events in the `Overlay` from propagating to the parent

### Manual check

Let's do an over the shoulder check
