### PR TITLE
[10.1.1] - 2021-11-08

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@
 
 ### Fixed
 
-- `Overlay`: Prevent click events in the `Overlay` from propagating to the parent ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1836](https://github.com/teamleadercrm/ui/pull/1836))
-
 ### Dependency updates
+
+## [10.1.1] - 2021-11-08
+
+### Fixed
+
+- `Overlay`: Prevent click events in the `Overlay` from propagating to the parent ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1836](https://github.com/teamleadercrm/ui/pull/1836))
 
 ## [10.1.0] - 2021-11-05
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "10.1.0",
+  "version": "10.1.1",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Fixed

- `Overlay`: Prevent click events in the `Overlay` from propagating to the parent ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1836](https://github.com/teamleadercrm/ui/pull/1836))