### PR TITLE
Update wysiwyg link popup z-index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `WysiwygEditor`: Render LinkOptions on top of editor when rendered in a dialog ([@lorgan3](https://github.com/lorgan3) in [#1876](https://github.com/teamleadercrm/ui/pull/1876))
+
 ### Dependency updates
 
 ## [10.1.1] - 2021-11-08

--- a/src/components/wysiwygEditor/LinkOptions.js
+++ b/src/components/wysiwygEditor/LinkOptions.js
@@ -82,7 +82,7 @@ const LinkOptions = ({
         onOverlayClick={handleClosePopoverClick}
         minWidth={276}
         maxWidth="100%"
-        zIndex={401}
+        zIndex={404}
       >
         <Box display="flex" flexDirection="column" padding={4}>
           <Label htmlFor="linkText" helpText="">


### PR DESCRIPTION
### Description

When rendering a wysiwyg editor in a dialog, the link option does not work anymore because the popup appears below the editor.
Related to https://github.com/teamleadercrm/ui/pull/1834

#### Screenshot before this PR

![image](https://user-images.githubusercontent.com/1833617/146337913-dc85906c-89d4-4caf-8a7f-78da325a1988.png)


#### Screenshot after this PR

![image](https://user-images.githubusercontent.com/1833617/146337643-26b0db54-002c-47df-a44b-7d7d5a164190.png)
