### PR TITLE
`Widget`, `IslandGroup`: ref forwarding, `boxProps`: style property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### Added
 
+- `Widget`: added ref forwarding ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1877](https://github.com/teamleadercrm/ui/pull/1877))
+
 ### Changed
+
+- [BREAKING] `Checkbox`, `Input`, `TimeInput`, `NumericInput`, `SingleLineInputBase`, `Textarea`, `RadioButton`, `Select`, `Toggle`: due to the `style` prop now being part of `boxProps`, the property will no longer get passed to the internal elements, but rather the wrapping `Box`, same as `classname` ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1877](https://github.com/teamleadercrm/ui/pull/1877))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- `Widget`: added ref forwarding ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1877](https://github.com/teamleadercrm/ui/pull/1877))
+- `Widget`, `IslandGroup`: added ref forwarding ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#1877](https://github.com/teamleadercrm/ui/pull/1877))
 
 ### Changed
 

--- a/src/components/box/boxProps.js
+++ b/src/components/box/boxProps.js
@@ -19,6 +19,7 @@ const boxProps = [
   'borderBottomRightRadius',
   'boxSizing',
   'className',
+  'style',
   'display',
   'element',
   'flex',

--- a/src/components/datepicker/DatePicker.js
+++ b/src/components/datepicker/DatePicker.js
@@ -55,7 +55,7 @@ class DatePicker extends PureComponent {
   };
 
   render() {
-    const { bordered, className, modifiers, size, withMonthPicker, showWeekNumbers, ...others } = this.props;
+    const { bordered, className, style, modifiers, size, withMonthPicker, showWeekNumbers, ...others } = this.props;
     const { selectedDate, selectedMonth } = this.state;
     const boxProps = pickBoxProps(others);
     const restProps = omitBoxProps(others);
@@ -77,6 +77,7 @@ class DatePicker extends PureComponent {
           initialMonth={selectedDate}
           month={selectedMonth}
           className={classNames}
+          style={style}
           classNames={theme}
           modifiers={convertModifiersToClassnames(modifiers, theme)}
           navbarElement={<NavigationBar size={size} withMonthPicker={withMonthPicker} />}

--- a/src/components/datepicker/DatePickerRange.js
+++ b/src/components/datepicker/DatePickerRange.js
@@ -71,7 +71,7 @@ class DatePickerRange extends PureComponent {
   };
 
   render() {
-    const { bordered, className, size, ...others } = this.props;
+    const { bordered, className, style, size, ...others } = this.props;
     const { selectedStartDate, mouseEnteredEndDate } = this.state;
     const modifiers = { from: selectedStartDate, to: mouseEnteredEndDate };
     const selectedDays = [selectedStartDate, { from: selectedStartDate, to: mouseEnteredEndDate }];
@@ -95,6 +95,7 @@ class DatePickerRange extends PureComponent {
           {...restProps}
           localeUtils={LocaleUtils}
           className={classNames}
+          style={style}
           classNames={theme}
           modifiers={convertModifiersToClassnames(modifiers, theme)}
           navbarElement={<NavigationBar size={size} />}

--- a/src/components/island/Island.js
+++ b/src/components/island/Island.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import Box, { pickBoxProps } from '../box';
 import cx from 'classnames';
@@ -11,7 +11,7 @@ const SIZES = {
   large: 5,
 };
 
-const Island = (props) => {
+const Island = forwardRef((props, ref) => {
   const { children, className, color, dark, size, ...others } = props;
 
   const classNames = cx(theme[color], className);
@@ -20,6 +20,7 @@ const Island = (props) => {
 
   return (
     <Box
+      ref={ref}
       data-teamleader-ui="island"
       backgroundColor={color === 'white' ? 'neutral' : color}
       backgroundTint={color === 'neutral' ? 'light' : 'lightest'}
@@ -37,7 +38,7 @@ const Island = (props) => {
       {children}
     </Box>
   );
-};
+});
 
 Island.propTypes = {
   children: PropTypes.node,
@@ -51,5 +52,7 @@ Island.defaultProps = {
   color: 'white',
   size: 'medium',
 };
+
+Island.displayName = 'Island';
 
 export default Island;

--- a/src/components/island/Island.js
+++ b/src/components/island/Island.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Box, { pickBoxProps } from '../box';
 import cx from 'classnames';
@@ -11,7 +11,7 @@ const SIZES = {
   large: 5,
 };
 
-const Island = forwardRef((props, ref) => {
+const Island = (props) => {
   const { children, className, color, dark, size, ...others } = props;
 
   const classNames = cx(theme[color], className);
@@ -20,7 +20,6 @@ const Island = forwardRef((props, ref) => {
 
   return (
     <Box
-      ref={ref}
       data-teamleader-ui="island"
       backgroundColor={color === 'white' ? 'neutral' : color}
       backgroundTint={color === 'neutral' ? 'light' : 'lightest'}
@@ -38,7 +37,7 @@ const Island = forwardRef((props, ref) => {
       {children}
     </Box>
   );
-});
+};
 
 Island.propTypes = {
   children: PropTypes.node,
@@ -52,7 +51,5 @@ Island.defaultProps = {
   color: 'white',
   size: 'medium',
 };
-
-Island.displayName = 'Island';
 
 export default Island;

--- a/src/components/island/Island.js
+++ b/src/components/island/Island.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Box, { pickBoxProps } from '../box';
 import cx from 'classnames';
@@ -11,35 +11,33 @@ const SIZES = {
   large: 5,
 };
 
-class Island extends PureComponent {
-  render() {
-    const { children, className, color, dark, size, ...others } = this.props;
+const Island = (props) => {
+  const { children, className, color, dark, size, ...others } = props;
 
-    const classNames = cx(theme[color], className);
-    const isDark = elementIsDark(color, dark);
-    const boxProps = pickBoxProps(others);
+  const classNames = cx(theme[color], className);
+  const isDark = elementIsDark(color, dark);
+  const boxProps = pickBoxProps(others);
 
-    return (
-      <Box
-        data-teamleader-ui="island"
-        backgroundColor={color === 'white' ? 'neutral' : color}
-        backgroundTint={color === 'neutral' ? 'light' : 'lightest'}
-        borderRadius="rounded"
-        borderColor={color === 'white' ? 'neutral' : color}
-        borderTint={isDark ? 'dark' : 'normal'}
-        borderBottomWidth={1}
-        borderLeftWidth={1}
-        borderRightWidth={1}
-        borderTopWidth={1}
-        className={classNames}
-        padding={SIZES[size]}
-        {...boxProps}
-      >
-        {children}
-      </Box>
-    );
-  }
-}
+  return (
+    <Box
+      data-teamleader-ui="island"
+      backgroundColor={color === 'white' ? 'neutral' : color}
+      backgroundTint={color === 'neutral' ? 'light' : 'lightest'}
+      borderRadius="rounded"
+      borderColor={color === 'white' ? 'neutral' : color}
+      borderTint={isDark ? 'dark' : 'normal'}
+      borderBottomWidth={1}
+      borderLeftWidth={1}
+      borderRightWidth={1}
+      borderTopWidth={1}
+      className={classNames}
+      padding={SIZES[size]}
+      {...boxProps}
+    >
+      {children}
+    </Box>
+  );
+};
 
 Island.propTypes = {
   children: PropTypes.node,

--- a/src/components/island/IslandGroup.js
+++ b/src/components/island/IslandGroup.js
@@ -1,76 +1,81 @@
-import React, { isValidElement } from 'react';
+import React, { forwardRef, isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import Box, { pickBoxProps } from '../box';
 
-const IslandGroup = ({ children: originalChildren, className, color, dark, direction, size, ...otherProps }) => {
-  const boxProps = pickBoxProps(otherProps);
-  const children = [];
+const IslandGroup = forwardRef(
+  ({ children: originalChildren, className, color, dark, direction, size, ...otherProps }, ref) => {
+    const boxProps = pickBoxProps(otherProps);
+    const children = [];
 
-  React.Children.forEach(originalChildren, (child) => {
-    if (isValidElement(child)) {
-      children.push(child);
-    }
-  });
+    React.Children.forEach(originalChildren, (child) => {
+      if (isValidElement(child)) {
+        children.push(child);
+      }
+    });
 
-  const hasMoreThanOneChild = children.length > 1;
+    const hasMoreThanOneChild = children.length > 1;
 
-  return (
-    <Box
-      {...boxProps}
-      className={className}
-      display="flex"
-      flexDirection={direction === 'horizontal' ? 'row' : 'column'}
-    >
-      {React.Children.map(children, (child, index) => {
-        const isFirstChild = index === 0;
-        const isLastChild = index === children.length - 1;
+    return (
+      <Box
+        ref={ref}
+        {...boxProps}
+        className={className}
+        display="flex"
+        flexDirection={direction === 'horizontal' ? 'row' : 'column'}
+      >
+        {React.Children.map(children, (child, index) => {
+          const isFirstChild = index === 0;
+          const isLastChild = index === children.length - 1;
 
-        return React.cloneElement(child, {
-          ...(!isFirstChild &&
-            !isLastChild && {
-              borderRadius: 'square',
-            }),
-          ...(direction === 'horizontal' &&
-            !isFirstChild && {
-              borderLeftWidth: 0,
-            }),
-          ...(direction === 'horizontal' &&
-            hasMoreThanOneChild &&
-            isFirstChild && {
-              borderBottomRightRadius: 'square',
-              borderTopRightRadius: 'square',
-            }),
-          ...(direction === 'horizontal' &&
-            hasMoreThanOneChild &&
-            isLastChild && {
-              borderBottomLeftRadius: 'square',
-              borderTopLeftRadius: 'square',
-            }),
-          ...(direction === 'vertical' &&
-            !isFirstChild && {
-              borderTopWidth: 0,
-            }),
-          ...(direction === 'vertical' &&
-            hasMoreThanOneChild &&
-            isFirstChild && {
-              borderBottomLeftRadius: 'square',
-              borderBottomRightRadius: 'square',
-            }),
-          ...(direction === 'vertical' &&
-            hasMoreThanOneChild &&
-            isLastChild && {
-              borderTopLeftRadius: 'square',
-              borderTopRightRadius: 'square',
-            }),
-          ...child.props,
-          color: color || child.props.color,
-          dark: dark || child.props.dark,
-          size: size || child.props.size,
-        });
-      })}
-    </Box>
-  );
-};
+          return React.cloneElement(child, {
+            ...(!isFirstChild &&
+              !isLastChild && {
+                borderRadius: 'square',
+              }),
+            ...(direction === 'horizontal' &&
+              !isFirstChild && {
+                borderLeftWidth: 0,
+              }),
+            ...(direction === 'horizontal' &&
+              hasMoreThanOneChild &&
+              isFirstChild && {
+                borderBottomRightRadius: 'square',
+                borderTopRightRadius: 'square',
+              }),
+            ...(direction === 'horizontal' &&
+              hasMoreThanOneChild &&
+              isLastChild && {
+                borderBottomLeftRadius: 'square',
+                borderTopLeftRadius: 'square',
+              }),
+            ...(direction === 'vertical' &&
+              !isFirstChild && {
+                borderTopWidth: 0,
+              }),
+            ...(direction === 'vertical' &&
+              hasMoreThanOneChild &&
+              isFirstChild && {
+                borderBottomLeftRadius: 'square',
+                borderBottomRightRadius: 'square',
+              }),
+            ...(direction === 'vertical' &&
+              hasMoreThanOneChild &&
+              isLastChild && {
+                borderTopLeftRadius: 'square',
+                borderTopRightRadius: 'square',
+              }),
+            ...child.props,
+            color: color || child.props.color,
+            dark: dark || child.props.dark,
+            size: size || child.props.size,
+          });
+        })}
+      </Box>
+    );
+  },
+);
+
+IslandGroup.displayName = 'IslandGroup';
 
 IslandGroup.propTypes = {
   children: PropTypes.any,

--- a/src/components/island/IslandGroup.js
+++ b/src/components/island/IslandGroup.js
@@ -1,80 +1,76 @@
-import React, { PureComponent, isValidElement } from 'react';
+import React, { isValidElement } from 'react';
 import PropTypes from 'prop-types';
 import Box, { pickBoxProps } from '../box';
 
-class IslandGroup extends PureComponent {
-  render() {
-    const { children: originalChildren, className, color, dark, direction, size, ...otherProps } = this.props;
+const IslandGroup = ({ children: originalChildren, className, color, dark, direction, size, ...otherProps }) => {
+  const boxProps = pickBoxProps(otherProps);
+  const children = [];
 
-    const boxProps = pickBoxProps(otherProps);
-    const children = [];
+  React.Children.forEach(originalChildren, (child) => {
+    if (isValidElement(child)) {
+      children.push(child);
+    }
+  });
 
-    React.Children.forEach(originalChildren, (child) => {
-      if (isValidElement(child)) {
-        children.push(child);
-      }
-    });
+  const hasMoreThanOneChild = children.length > 1;
 
-    const hasMoreThanOneChild = children.length > 1;
+  return (
+    <Box
+      {...boxProps}
+      className={className}
+      display="flex"
+      flexDirection={direction === 'horizontal' ? 'row' : 'column'}
+    >
+      {React.Children.map(children, (child, index) => {
+        const isFirstChild = index === 0;
+        const isLastChild = index === children.length - 1;
 
-    return (
-      <Box
-        {...boxProps}
-        className={className}
-        display="flex"
-        flexDirection={direction === 'horizontal' ? 'row' : 'column'}
-      >
-        {React.Children.map(children, (child, index) => {
-          const isFirstChild = index === 0;
-          const isLastChild = index === children.length - 1;
-
-          return React.cloneElement(child, {
-            ...(!isFirstChild &&
-              !isLastChild && {
-                borderRadius: 'square',
-              }),
-            ...(direction === 'horizontal' &&
-              !isFirstChild && {
-                borderLeftWidth: 0,
-              }),
-            ...(direction === 'horizontal' &&
-              hasMoreThanOneChild &&
-              isFirstChild && {
-                borderBottomRightRadius: 'square',
-                borderTopRightRadius: 'square',
-              }),
-            ...(direction === 'horizontal' &&
-              hasMoreThanOneChild &&
-              isLastChild && {
-                borderBottomLeftRadius: 'square',
-                borderTopLeftRadius: 'square',
-              }),
-            ...(direction === 'vertical' &&
-              !isFirstChild && {
-                borderTopWidth: 0,
-              }),
-            ...(direction === 'vertical' &&
-              hasMoreThanOneChild &&
-              isFirstChild && {
-                borderBottomLeftRadius: 'square',
-                borderBottomRightRadius: 'square',
-              }),
-            ...(direction === 'vertical' &&
-              hasMoreThanOneChild &&
-              isLastChild && {
-                borderTopLeftRadius: 'square',
-                borderTopRightRadius: 'square',
-              }),
-            ...child.props,
-            color: color || child.props.color,
-            dark: dark || child.props.dark,
-            size: size || child.props.size,
-          });
-        })}
-      </Box>
-    );
-  }
-}
+        return React.cloneElement(child, {
+          ...(!isFirstChild &&
+            !isLastChild && {
+              borderRadius: 'square',
+            }),
+          ...(direction === 'horizontal' &&
+            !isFirstChild && {
+              borderLeftWidth: 0,
+            }),
+          ...(direction === 'horizontal' &&
+            hasMoreThanOneChild &&
+            isFirstChild && {
+              borderBottomRightRadius: 'square',
+              borderTopRightRadius: 'square',
+            }),
+          ...(direction === 'horizontal' &&
+            hasMoreThanOneChild &&
+            isLastChild && {
+              borderBottomLeftRadius: 'square',
+              borderTopLeftRadius: 'square',
+            }),
+          ...(direction === 'vertical' &&
+            !isFirstChild && {
+              borderTopWidth: 0,
+            }),
+          ...(direction === 'vertical' &&
+            hasMoreThanOneChild &&
+            isFirstChild && {
+              borderBottomLeftRadius: 'square',
+              borderBottomRightRadius: 'square',
+            }),
+          ...(direction === 'vertical' &&
+            hasMoreThanOneChild &&
+            isLastChild && {
+              borderTopLeftRadius: 'square',
+              borderTopRightRadius: 'square',
+            }),
+          ...child.props,
+          color: color || child.props.color,
+          dark: dark || child.props.dark,
+          size: size || child.props.size,
+        });
+      })}
+    </Box>
+  );
+};
 
 IslandGroup.propTypes = {
   children: PropTypes.any,

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -16,7 +16,7 @@ class MenuItem extends PureComponent {
   };
 
   render() {
-    const { icon, caption, children, className, destructive, element, label, selected, disabled, ...others } =
+    const { icon, caption, children, className, style, destructive, element, label, selected, disabled, ...others } =
       this.props;
 
     const classNames = cx(
@@ -40,6 +40,7 @@ class MenuItem extends PureComponent {
           onClick={this.handleClick}
           alignItems="center"
           className={classNames}
+          style={style}
           disabled={disabled}
           display="flex"
           element={element}

--- a/src/components/widget/Body.js
+++ b/src/components/widget/Body.js
@@ -1,10 +1,16 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import Island from '../island';
 
-const Body = ({ children, ...others }) => {
-  return <Island {...others}>{children}</Island>;
-};
+const Body = forwardRef(({ children, ...others }, ref) => {
+  return (
+    <Island ref={ref} {...others}>
+      {children}
+    </Island>
+  );
+});
+
+Body.displayName = 'Body';
 
 Body.propTypes = {
   /** The content to display inside the widget body. */

--- a/src/components/widget/Body.js
+++ b/src/components/widget/Body.js
@@ -1,16 +1,10 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Island from '../island';
 
-const Body = forwardRef(({ children, ...others }, ref) => {
-  return (
-    <Island ref={ref} {...others}>
-      {children}
-    </Island>
-  );
-});
-
-Body.displayName = 'Body';
+const Body = ({ children, ...others }) => {
+  return <Island {...others}>{children}</Island>;
+};
 
 Body.propTypes = {
   /** The content to display inside the widget body. */

--- a/src/components/widget/Body.js
+++ b/src/components/widget/Body.js
@@ -1,14 +1,10 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Island from '../island';
 
-class Body extends PureComponent {
-  render() {
-    const { children, ...others } = this.props;
-
-    return <Island {...others}>{children}</Island>;
-  }
-}
+const Body = ({ children, ...others }) => {
+  return <Island {...others}>{children}</Island>;
+};
 
 Body.propTypes = {
   /** The content to display inside the widget body. */

--- a/src/components/widget/Widget.js
+++ b/src/components/widget/Widget.js
@@ -1,13 +1,13 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import Body from './Body';
 import Footer from './Footer';
 import Header from './Header';
 import { IslandGroup } from '../island';
 
-const Widget = ({ children, size, ...others }) => {
+const Widget = forwardRef(({ children, size, ...others }, ref) => {
   return (
-    <IslandGroup direction="vertical" {...others}>
+    <IslandGroup ref={ref} direction="vertical" {...others}>
       {React.Children.map(children, (child) => {
         if (!child) {
           return child;
@@ -20,7 +20,9 @@ const Widget = ({ children, size, ...others }) => {
       })}
     </IslandGroup>
   );
-};
+});
+
+Widget.displayName = 'Widget';
 
 Widget.propTypes = {
   /** The content to display inside the widget. */

--- a/src/components/widget/Widget.js
+++ b/src/components/widget/Widget.js
@@ -1,30 +1,26 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Body from './Body';
 import Footer from './Footer';
 import Header from './Header';
 import { IslandGroup } from '../island';
 
-class Widget extends PureComponent {
-  render() {
-    const { children, size, ...others } = this.props;
+const Widget = ({ children, size, ...others }) => {
+  return (
+    <IslandGroup direction="vertical" {...others}>
+      {React.Children.map(children, (child) => {
+        if (!child) {
+          return child;
+        }
 
-    return (
-      <IslandGroup direction="vertical" {...others}>
-        {React.Children.map(children, (child) => {
-          if (!child) {
-            return child;
-          }
-
-          return React.cloneElement(child, {
-            ...child.props,
-            size,
-          });
-        })}
-      </IslandGroup>
-    );
-  }
-}
+        return React.cloneElement(child, {
+          ...child.props,
+          size,
+        });
+      })}
+    </IslandGroup>
+  );
+};
 
 Widget.propTypes = {
   /** The content to display inside the widget. */


### PR DESCRIPTION
### Added

- `Widget`, `IslandGroup`: added ref forwarding

### Changed

- [BREAKING] `Checkbox`, `Input`, `TimeInput`, `NumericInput`, `SingleLineInputBase`, `Textarea`, `RadioButton`, `Select`, `Toggle`: due to the `style` prop now being part of `boxProps`, the property will no longer get passed to the internal elements, but rather the wrapping `Box`, same as `classname`
