### PR TITLE
Release/10.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@
 
 ### Fixed
 
-- `WysiwygEditor`: Render LinkOptions on top of editor when rendered in a dialog ([@lorgan3](https://github.com/lorgan3) in [#1876](https://github.com/teamleadercrm/ui/pull/1876))
-
 ### Dependency updates
+
+## [10.1.2] - 2021-12-16
+
+### Fixed
+
+- `WysiwygEditor`: Render LinkOptions on top of editor when rendered in a dialog ([@lorgan3](https://github.com/lorgan3) in [#1876](https://github.com/teamleadercrm/ui/pull/1876))
 
 ## [10.1.1] - 2021-11-08
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [10.1.2] - 2021-12-16

### Fixed

- `WysiwygEditor`: Render LinkOptions on top of editor when rendered in a dialog ([@lorgan3](https://github.com/lorgan3) in [#1876](https://github.com/teamleadercrm/ui/pull/1876))