### PR TITLE
Use group constants instead of a hardcoded value in .mdx files

### DIFF
--- a/.storybook/stories/colors.stories.mdx
+++ b/.storybook/stories/colors.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
+import { FOUNDATION } from '../utils';
 
-<Meta title="Foundation / Colors" parameters={{ previewTabs: { canvas: { hidden: true } } }} />
+<Meta title={`${FOUNDATION} / Colors`} parameters={{ previewTabs: { canvas: { hidden: true } } }} />
 
 # Colors
 


### PR DESCRIPTION
### Description

- Tiny follow up where we also import the constant like we do in other places
