### PR TITLE
Fix processing state of tiny buttons in UI-library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+- `Button`: fixed `Spinner` size when `Button` size is `tiny` ([@qubis741](https://github.com/qubis741) in [#1931](https://github.com/teamleadercrm/ui/pull/1931))
+
 ### Dependency updates
 
 - Upgraded all dependencies to latest except `react`, `react-dom`, `react-day-picker` (latest is beta), `postcss-preset-env`, `postcss-each` ([@qubis741](https://github.com/qubis741) in [#1893](https://github.com/teamleadercrm/ui/pull/1893))

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -65,6 +65,17 @@ const Button = forwardRef(
       }
     };
 
+    const getSpinnerSize = () => {
+      console.log(size);
+      switch (size) {
+        case 'tiny':
+        case 'small':
+          return 'small';
+        default:
+          return 'medium';
+      }
+    };
+
     const handleMouseUp = (event) => {
       blur();
       if (onMouseUp) {
@@ -137,7 +148,7 @@ const Button = forwardRef(
           <LoadingSpinner
             className={theme['spinner']}
             color={getSpinnerColor()}
-            size={size === 'small' ? 'small' : 'medium'}
+            size={getSpinnerSize()}
             tint={getSpinnerTint()}
           />
         )}

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -66,7 +66,6 @@ const Button = forwardRef(
     };
 
     const getSpinnerSize = () => {
-      console.log(size);
       switch (size) {
         case 'tiny':
         case 'small':


### PR DESCRIPTION
https://teamleader.atlassian.net/browse/ATL-858

### Description

Fixed bug, where `Button` with `size="tiny"` had `Spinner` of `size="medium"` instead of `size="small"` 

#### Screenshot before this PR
![Screenshot 2022-01-24 at 11 12 53](https://user-images.githubusercontent.com/9944471/150763769-428a8818-663a-437b-861e-124d313c910d.png)

#### Screenshot after this PR
![Screenshot 2022-01-24 at 11 12 20](https://user-images.githubusercontent.com/9944471/150763689-db26c6b3-6b42-49bd-b779-1c31db2eadc7.png)

### Manual Check

- [ ] checkout branch, test in storybook
