### PR TITLE
Restored mouse event propagation in `Overlay` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Overlay`: Restored mouse event propagation ([@jelledc](https://github.com/jelledc) in [#1938](https://github.com/teamleadercrm/ui/pull/1938))
+
 ### Dependency updates
 
 ## [12.0.0] - 2022-01-25

--- a/src/components/overlay/Overlay.js
+++ b/src/components/overlay/Overlay.js
@@ -51,18 +51,11 @@ class Overlay extends PureComponent {
     }
   };
 
-  handleClick = (event) => {
-    event.stopPropagation();
-    this.props.onClick?.(event);
-  };
-
   handleMouseDown = (event) => {
-    event.stopPropagation();
     this.clickOriginRef.current = event.target;
   };
 
   handleMouseUp = (event) => {
-    event.stopPropagation();
     // Only register clicks outside of the children
     if (
       this.props.onOverlayClick &&
@@ -90,7 +83,6 @@ class Overlay extends PureComponent {
               onKeyDown={this.handleEscKey}
               onMouseDown={this.handleMouseDown}
               onMouseUp={this.handleMouseUp}
-              onClick={this.handleClick}
               className={cx(
                 theme['overlay'],
                 theme[backdrop],


### PR DESCRIPTION
### Description

Restored event bubbling for click, mousedown and mouseup events in the Overlay component because the use of event.stopPropagation prevented the handling of said events outside of the overlay (eg. routing listening to onclick events).

Note: the handling of ESC key presses will still stop propagation.