### PR TITLE
[FEATURE] fade out dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `DialogBase`, `Dialog`: added `fadeOutOnClose` property ([@JorenSaeyTL](https://github.com/JorenSaeyTL) in [#1939](https://github.com/teamleadercrm/ui/pull/1939))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -79,6 +79,8 @@ Dialog.propTypes = {
   primaryAction: PropTypes.object.isRequired,
   /** If true, the content of the dialog will be scrollable when it exceeds the available height. */
   scrollable: PropTypes.bool,
+  /** If true, the the dialog will fade out when closing. */
+  fadeOutOnClose: PropTypes.bool,
   /** Object containing the the props of the secondary action (a Button). */
   secondaryAction: PropTypes.object,
   /** Object containing the props of the tertiary action (a Link, with the inherit props set to false). */

--- a/src/components/dialog/DialogBase.js
+++ b/src/components/dialog/DialogBase.js
@@ -32,14 +32,14 @@ export const DialogBase = ({
 
   const shouldRender = fadeOutOnClose ? delayedActive : active;
 
+  const handleExited = () => {
+    setDelayedActive(false);
+  };
+
   useEffect(() => {
     if (active) {
       setDelayedActive(true);
-      return;
     }
-    setTimeout(() => {
-      setDelayedActive(false);
-    }, FADE_OUT_TIME);
   }, [active]);
 
   if (!shouldRender) {
@@ -47,7 +47,12 @@ export const DialogBase = ({
   }
 
   const dialog = (
-    <Transition timeout={{ enter: 0, exit: fadeOutOnClose ? FADE_OUT_TIME : 0 }} in={active} appear>
+    <Transition
+      timeout={{ enter: 0, exit: fadeOutOnClose ? FADE_OUT_TIME : 0 }}
+      in={active}
+      appear
+      onExited={handleExited}
+    >
       {(state) => {
         const overlayClassNames = cx(theme['overlay'], {
           [theme['is-entering']]: state === 'entering',

--- a/src/components/dialog/dialog.stories.js
+++ b/src/components/dialog/dialog.stories.js
@@ -58,6 +58,7 @@ DefaultStory.args = {
     onClick: () => console.log('tertiaryAction.onClick'),
   },
   title: 'Dialog title',
+  fadeOutOnClose: false,
 };
 
 const FocusStates = () => {

--- a/src/components/dialog/theme.css
+++ b/src/components/dialog/theme.css
@@ -13,6 +13,23 @@
   display: flex;
   justify-content: center;
   z-index: 403;
+
+  &.is-entering {
+    opacity: 0;
+  }
+
+  &.is-entered {
+    opacity: 1;
+  }
+
+  &.is-exiting {
+    opacity: 0;
+    transition: opacity 0.5s ease-out;
+  }
+
+  &.is-exited {
+    opacity: 0;
+  }
 }
 
 .dialog-base {
@@ -48,6 +65,16 @@
   &.is-entered {
     opacity: 1;
     transform: translateY(0%);
+  }
+
+  &.is-exiting {
+    opacity: 0;
+    transform: translateY(0%);
+    transition: opacity 0.5s ease-out;
+  }
+
+  &.is-exited {
+    opacity: 0;
   }
 }
 


### PR DESCRIPTION
### Description

- Add `fadeOutOnClose` property
- Add property in storybook

This will make it possible to make the dialog fade out on close (Use case: https://www.figma.com/proto/ViF1ZZVAmlae4lCLZkrSne/Global-search?page-id=7088%3A25977&node-id=7088%3A25978&viewport=241%2C48%2C0.65&scaling=scale-down&starting-point-node-id=7088%3A25978)

### Screenshot after this PR

- My screen recording software crashes on me, perhaps best to manual check this through storybook

### Breaking changes

- N/A 
