### PR TITLE
[LIG-835] Prevent clicks in underlying `Dialog` from closing parent `Overlay`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Overlay`: Prevent clicks in underlying dialogs from closing parent overlays ([@jelledc](https://github.com/jelledc) in [#1958](https://github.com/teamleadercrm/ui/pull/1958))
+
 ### Dependency updates
 
 ## [12.1.0] - 2022-01-28

--- a/src/components/overlay/Overlay.js
+++ b/src/components/overlay/Overlay.js
@@ -64,7 +64,9 @@ class Overlay extends PureComponent {
       !this.innerWrapperRef.current?.contains(this.clickOriginRef.current) &&
       // react-select has its own implementation of an overlay, conflicting with our custom implementation
       // so clicks on the select overlay shouldn't be registered either
-      !selectOverlayNode.contains(this.clickOriginRef.current)
+      !selectOverlayNode.contains(this.clickOriginRef.current) &&
+      // make sure only clicks within the current portal's DOM tree are handled
+      event.currentTarget.contains(event.target)
     ) {
       this.props.onOverlayClick(event);
     }


### PR DESCRIPTION
### Link to JIRA issue

https://teamleader.atlassian.net/browse/LIG-835

### Description

Added extra condition that checks if the click event was sent from the current portal's DOM tree. Nested overlays will be rendered in a different tree and won't trigger their parent's onOverlayClick event anymore.