### PR TITLE
Release/12.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@
 
 ### Fixed
 
-- `Overlay`: Prevent clicks in underlying dialogs from closing parent overlays ([@jelledc](https://github.com/jelledc) in [#1958](https://github.com/teamleadercrm/ui/pull/1958))
-
 ### Dependency updates
+
+## [12.1.1] - 2022-02-02
+
+### Fixed
+
+- `Overlay`: Prevent clicks in underlying dialogs from closing parent overlays ([@jelledc](https://github.com/jelledc) in [#1958](https://github.com/teamleadercrm/ui/pull/1958))
 
 ## [12.1.0] - 2022-01-28
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "12.1.0",
+  "version": "12.1.1",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Fixed

- `Overlay`: Prevent clicks in underlying dialogs from closing parent overlays ([@jelledc](https://github.com/jelledc) in [#1958](https://github.com/teamleadercrm/ui/pull/1958))
