### PR TITLE
Investigate dialog on esc key down not triggering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Dialog`: onEscKeyDown not triggering ([@qubis741](https://github.com/qubis741) in [#1971](https://github.com/teamleadercrm/ui/pull/1971))
+
 ### Dependency updates
 
 ## [12.1.1] - 2022-02-02

--- a/src/components/dialog/dialog.stories.js
+++ b/src/components/dialog/dialog.stories.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { addStoryInGroup, MID_LEVEL_BLOCKS } from '../../../.storybook/utils';
 import { IconWarningBadgedMediumOutline } from '@teamleader/ui-icons';
 import { Box, Button, Dialog, TextBody } from '../../index';
@@ -137,7 +137,7 @@ DialogWithFocusStates.parameters = {
 
 export const DialogBaseStory = (args) => {
   const [active, setActive] = useState(false);
-
+  const bodyRef = useRef()
   const closeDialog = () => {
     setActive(false);
   };
@@ -149,8 +149,14 @@ export const DialogBaseStory = (args) => {
   return (
     <Box>
       <Button onClick={openDialog} label="Open a dialog base" />
-      <DialogBase active={active} onEscKeyDown={closeDialog} onOverlayClick={closeDialog} {...args}>
-        <Box padding={4}>
+      <DialogBase
+        active={active}
+        onEscKeyDown={closeDialog}
+        onOverlayClick={closeDialog}
+        {...args}
+        initialFocusRef={bodyRef}
+      >
+        <Box padding={4} ref={bodyRef}>
           <TextBody>
             Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
             dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet

--- a/src/components/dialog/dialog.stories.js
+++ b/src/components/dialog/dialog.stories.js
@@ -137,7 +137,7 @@ DialogWithFocusStates.parameters = {
 
 export const DialogBaseStory = (args) => {
   const [active, setActive] = useState(false);
-  const bodyRef = useRef()
+  const bodyRef = useRef();
   const closeDialog = () => {
     setActive(false);
   };

--- a/src/utils/useFocusTrap/useFocusTrap.js
+++ b/src/utils/useFocusTrap/useFocusTrap.js
@@ -45,20 +45,19 @@ const useFocusTrap = ({ active, returnFocusToSource = true, initialFocusRef }) =
       if (openFocusTraps.size > 0) {
         document.removeEventListener('focusin', getLastItemInSet(openFocusTraps), true);
       }
-      
-       if (initialFocusRef) {
-         const currentInitialFocusRef = initialFocusRef.current;
-         if (currentInitialFocusRef) {
-           const foundFocus = focusOnFirstDescendent(currentInitialFocusRef);
-           if (!foundFocus) {
-             focusOnFirstDescendent(topFocusBumperRef.current);
-           }
-         }
-       } else if (typeof initialFocusRef === 'undefined') {
-         focusOnFirstDescendent(currentFocusRef);
-       } else {
-         focusOnFirstDescendent(topFocusBumperRef.current);
-       }
+      if (initialFocusRef) {
+        const currentInitialFocusRef = initialFocusRef.current;
+        if (currentInitialFocusRef) {
+          const foundFocus = focusOnFirstDescendent(currentInitialFocusRef);
+          if (!foundFocus) {
+            focusOnFirstDescendent(topFocusBumperRef.current);
+          }
+        }
+      } else if (typeof initialFocusRef === 'undefined') {
+        focusOnFirstDescendent(currentFocusRef);
+      } else {
+        focusOnFirstDescendent(topFocusBumperRef.current);
+      }
 
       const trapFocus = (event) => {
         if (!currentFocusRef.contains(event.target)) {

--- a/src/utils/useFocusTrap/useFocusTrap.js
+++ b/src/utils/useFocusTrap/useFocusTrap.js
@@ -45,15 +45,20 @@ const useFocusTrap = ({ active, returnFocusToSource = true, initialFocusRef }) =
       if (openFocusTraps.size > 0) {
         document.removeEventListener('focusin', getLastItemInSet(openFocusTraps), true);
       }
-
-      if (initialFocusRef) {
-        const currentInitialFocusRef = initialFocusRef.current;
-        currentInitialFocusRef && focusOnFirstDescendent(currentInitialFocusRef);
-      } else if (typeof initialFocusRef === 'undefined') {
-        focusOnFirstDescendent(currentFocusRef);
-      } else {
-        focusOnFirstDescendent(topFocusBumperRef.current);
-      }
+      
+       if (initialFocusRef) {
+         const currentInitialFocusRef = initialFocusRef.current;
+         if (currentInitialFocusRef) {
+           const foundFocus = focusOnFirstDescendent(currentInitialFocusRef);
+           if (!foundFocus) {
+             focusOnFirstDescendent(topFocusBumperRef.current);
+           }
+         }
+       } else if (typeof initialFocusRef === 'undefined') {
+         focusOnFirstDescendent(currentFocusRef);
+       } else {
+         focusOnFirstDescendent(topFocusBumperRef.current);
+       }
 
       const trapFocus = (event) => {
         if (!currentFocusRef.contains(event.target)) {


### PR DESCRIPTION
https://teamleader.atlassian.net/browse/FRAF-183

### Description

By adding fallback by @ArnaudWeyts  in `useFocusTrap`, that focuses `topFocusBumper` is nothing focusable is found in `FocusRing`, Dialogs are now closable with ESC key right away.
`DialogBase` without any focusable element needs to have explicitly set `initialFocusRef`, so that ESC key can work.


_Proper focus passing after closing Dialog is not working right now, more in ticket comment_

### Manual Check
- [x] All 3 `Dialogs` in `Dialog (mid level block)` are closable with ESC key right after open (no additional clicking or focus needed)