### PR TITLE
Release/12.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@
 
 ### Fixed
 
-- `Dialog`: onEscKeyDown not triggering ([@qubis741](https://github.com/qubis741) in [#1971](https://github.com/teamleadercrm/ui/pull/1971))
-
 ### Dependency updates
+
+## [12.1.2] - 2022-02-14
+
+### Fixed
+
+- `Dialog`: onEscKeyDown not triggering ([@qubis741](https://github.com/qubis741) in [#1971](https://github.com/teamleadercrm/ui/pull/1971))
 
 ## [12.1.1] - 2022-02-02
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "12.1.1",
+  "version": "12.1.2",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
### Fixed

- `Dialog`: onEscKeyDown not triggering ([@qubis741](https://github.com/qubis741) in [#1971](https://github.com/teamleadercrm/ui/pull/1971))