### PR TITLE
Visual improvement of dialog and select components in UI library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Changed
 
-- `Dialog, Select`: added `size` prop to documentation, `Dialog` Footer has top border ([@qubis741](https://github.com/qubis741) in [#1993](https://github.com/teamleadercrm/ui/pull/1993))
+- `Dialog`: added `size` prop to documentation, Footer has top border ([@qubis741](https://github.com/qubis741) in [#1993](https://github.com/teamleadercrm/ui/pull/1993))
+- `Select`: added `size` prop to documentation ([@qubis741](https://github.com/qubis741) in [#1993](https://github.com/teamleadercrm/ui/pull/1993))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Dialog, Select`: added `size` prop to documentation, `Dialog` Footer has top border ([@qubis741](https://github.com/qubis741) in [#1993](https://github.com/teamleadercrm/ui/pull/1993))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -77,6 +77,8 @@ Dialog.propTypes = {
   onCloseClick: PropTypes.func,
   /** Object containing the props of the primary action (a Button, with level prop set to 'primary'). */
   primaryAction: PropTypes.object.isRequired,
+  /** The size of the dialog. */
+  size: PropTypes.oneOf(['small', 'medium', 'large', 'fullscreen']),
   /** If true, the content of the dialog will be scrollable when it exceeds the available height. */
   scrollable: PropTypes.bool,
   /** Object containing the the props of the secondary action (a Button). */
@@ -91,6 +93,7 @@ Dialog.defaultProps = {
   headerColor: 'neutral',
   headingLevel: 3,
   scrollable: true,
+  size: 'medium',
 };
 
 export default Dialog;

--- a/src/components/dialog/Footer.js
+++ b/src/components/dialog/Footer.js
@@ -8,7 +8,14 @@ class Footer extends PureComponent {
     const { children, ...rest } = this.props;
 
     return (
-      <Box justifyContent="flex-end" padding={4} {...rest}>
+      <Box
+        justifyContent="flex-end"
+        padding={4}
+        borderColor="neutral"
+        borderTopWidth={1}
+        borderTint="normal"
+        {...rest}
+      >
         {children}
       </Box>
     );

--- a/src/components/select/select.stories.js
+++ b/src/components/select/select.stories.js
@@ -51,6 +51,14 @@ export default {
       propTablesExclude: [Label],
     },
   },
+  argTypes: {
+    size: {
+      options: ['tiny', 'small', 'medium', 'large'],
+      control: {
+        type: 'select',
+      },
+    },
+  },
 };
 
 export const basic = (args) => <Select {...args} />;
@@ -63,6 +71,7 @@ basic.args = {
   hideSelectedOptions: false,
   options,
   placeholder: 'Select your favourite(s)',
+  size: 'medium'
 };
 
 export const grouped = () => <Select options={groupedOptions} />;


### PR DESCRIPTION
https://teamleader.atlassian.net/browse/FRAF-281

### Description

- added border above `Dialog.Footer` (same color as Dialog.Header border)

- added `size` property to `Dialog` Storybook documentation

- added `size` property to Select  Storybook documentation

#### Screenshot before this PR

![Screenshot 2022-02-17 at 07 41 53](https://user-images.githubusercontent.com/9944471/154420002-ace45c39-7932-45da-a8cf-066752b15ae9.png)

#### Screenshot after this PR

![Screenshot 2022-02-17 at 07 45 28](https://user-images.githubusercontent.com/9944471/154420443-3eb1189e-e812-41b9-b024-f6d926b35424.png)


#### Manual check

- [x] `Dialog.Footer` has top border
- [x] `Dialog` has adjustable `size` in documentation
- [x] `Select` has adjustable `size` in documentation
