### PR TITLE
Updated type index to include MarketingButtonGroup.Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `MarketingButtonGroup`: Added `MarketingButtonGroup.Button` to type index. ([@jelledc](https://github.com/jelledc) in [#2009](https://github.com/teamleadercrm/ui/pull/2009))
+
 ### Dependency updates
 
 ## [12.2.0] - 2022-02-25

--- a/index.d.ts
+++ b/index.d.ts
@@ -95,7 +95,9 @@ declare module '@teamleader/ui' {
   export const LoadingSpinner: React.ComponentType<any>;
   export const Marker: React.ComponentType<any>;
   export const MarketingButton: React.ComponentType<any>;
-  export const MarketingButtonGroup: React.ComponentType<any>;
+  export const MarketingButtonGroup: React.ComponentType<any> & {
+    Button: React.ComponentType<any>;
+  };
   export const MarketingLink: React.ComponentType<any>;
   export const MarketingLockBadge: React.ComponentType<any>;
   export const MarketingMarker: React.ComponentType<any>;


### PR DESCRIPTION
### Description

`MarketingButtonGroup.Button` was still missing in `index.d.ts`.