### PR TITLE
[FIX] Flex basis for correct width on SingleLineInputBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Fixed
 
-- `SingleLineInputBase`: Fixed `flex` basis setting. ([@stefaandevylder]https://github.com/stefaandevylder) in [#2014](https://github.com/teamleadercrm/ui/pull/2014)
+- `SingleLineInputBase`: Fixed input being 2px too large when applying `width: 100%`. ([@stefaandevylder](https://github.com/stefaandevylder) in [#2014](https://github.com/teamleadercrm/ui/pull/2014))
 
 ### Dependency updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `SingleLineInputBase`: Fixed `flex` basis setting. ([@stefaandevylder]https://github.com/stefaandevylder) in [#2014](https://github.com/teamleadercrm/ui/pull/2014)
+
 ### Dependency updates
 
 ## [12.2.1] - 2022-02-25

--- a/src/components/input/SingleLineInputBase.js
+++ b/src/components/input/SingleLineInputBase.js
@@ -88,7 +88,7 @@ class SingleLineInputBase extends PureComponent {
       <Box className={classNames} {...boxProps}>
         <div className={cx(theme['input-wrapper'], noInputStyling && theme['is-input-disabled'])}>
           {connectedLeft}
-          <div className={theme['input-inner-wrapper']} style={{ width, flex: width && '0 0 auto' }}>
+          <div className={theme['input-inner-wrapper']} style={{ width, flex: width && '0 1 auto' }}>
             {prefix && <div className={theme['prefix-wrapper']}>{this.renderOneOrMultipleElements(prefix)}</div>}
             <InputBase {...inputProps} />
             {suffix && <div className={theme['suffix-wrapper']}>{this.renderOneOrMultipleElements(suffix)}</div>}


### PR DESCRIPTION
### Description

- Fix the flex basis in SingleLineInputBase so the datepicker is correctly positioned when using a width of 100%.

#### Screenshot before this PR

![Screenshot 2022-02-28 at 10 39 59](https://user-images.githubusercontent.com/10358801/155960332-396d38a8-fb92-488c-af5f-c76d43e17d89.png)

#### Screenshot after this PR

![Screenshot 2022-02-28 at 10 41 15](https://user-images.githubusercontent.com/10358801/155960545-8fa20ae9-2827-4385-a3d4-9836ebb19439.png)
^ Look at the two input fields, they are now the same size. In the screenshot before they are 1px off.

### Breaking changes

N/A