### PR TITLE
Add object-fit for the avatar component

### DIFF
--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -43,6 +43,7 @@
   height: inherit;
   overflow: hidden;
   width: inherit;
+  object-fit: cover;
 }
 
 .overflow {


### PR DESCRIPTION
### Description

Add an Object-fit CSS property to the image of the Avatar component.
This way the images that are not rectangular are not squashed.

#### Screenshot before this PR

![Screenshot 2022-03-14 at 14 23 24](https://user-images.githubusercontent.com/10358801/158180804-1479206f-93b5-4de9-9d89-f26ad12efcf4.png)

#### Screenshot after this PR

![Screenshot 2022-03-14 at 14 22 52](https://user-images.githubusercontent.com/10358801/158180836-750e9a8c-3c75-4e60-bba0-42e00b67faa0.png)

### Breaking changes

N/A
