### PR TITLE
Add z-index to email selector overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- `EmailSelector`: Fix suggestions not always going away when clicking away ([@lorgan3](https://github.com/lorgan3) in [#2041](https://github.com/teamleadercrm/ui/pull/2041))
+
 ### Dependency updates
 
 ## [12.3.0] - 2022-02-28

--- a/src/components/emailSelector/Label.js
+++ b/src/components/emailSelector/Label.js
@@ -185,7 +185,9 @@ const Label = ({
   if (editing) {
     return (
       <>
-        {hasValidSuggestions && <Overlay active onOverlayClick={onTagBlur} backdrop="" />}
+        {hasValidSuggestions && (
+          <Overlay active onOverlayClick={onTagBlur} backdrop="" className={theme['label-overlay']} />
+        )}
         <Box
           contentEditable
           suppressContentEditableWarning

--- a/src/components/emailSelector/theme.css
+++ b/src/components/emailSelector/theme.css
@@ -88,6 +88,10 @@
   &-text {
     font-weight: 500 !important;
   }
+
+  &-overlay {
+    z-index: calc(var(--overlay-z-index) - 1);
+  }
 }
 
 .autocomplete {


### PR DESCRIPTION
### Description

The overlay by itself does not have a z-index so it did not properly detect clicks on some elements that may end up on top of it.
(This is analogous to how it works for dialogs)

#### Screenshot before this PR


https://user-images.githubusercontent.com/1833617/158608900-54ae41e5-3777-455b-89b4-81dba43c87e4.mov


#### Screenshot after this PR


https://user-images.githubusercontent.com/1833617/158608710-549320b3-2917-4fcc-8c81-8f5762608b72.mov


### Breaking changes

/
