### PR TITLE
`Dialog`: prevent header title from wrapping to the next line, remove `headingLevel` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@
 
 ### Changed
 
+- `Dialog`: header title will now overflow into ellipsis instead of wrapping to the next line ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#2042](https://github.com/teamleadercrm/ui/pull/2042))
+
 ### Deprecated
 
 ### Removed
+
+- `Dialog`: removed the `headingLevel` property, the previous default (3) will be used ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#2042](https://github.com/teamleadercrm/ui/pull/2042))
 
 ### Fixed
 

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -25,7 +25,7 @@ class Dialog extends PureComponent {
 
     return (
       <DialogBase.Header color={headerColor} icon={icon} onCloseClick={onCloseClick}>
-        {headingLevel === 2 ? <Heading2>{title}</Heading2> : <Heading3>{title}</Heading3>}
+        {headingLevel === 2 ? <Heading2 maxLines={1}>{title}</Heading2> : <Heading3 maxLines={1}>{title}</Heading3>}
       </DialogBase.Header>
     );
   };

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -6,7 +6,6 @@ import cx from 'classnames';
 import theme from './theme.css';
 
 import { Button, ButtonGroup, DialogBase, Heading2, Heading3, Link } from '../../index';
-import { COLORS } from '../../constants';
 import { IconDragMediumFilled } from '@teamleader/ui-icons';
 
 class Dialog extends PureComponent {
@@ -84,7 +83,7 @@ Dialog.propTypes = {
   /** A class name for the wrapper to apply custom styles. */
   className: PropTypes.string,
   /** The color of the header of the dialog. */
-  headerColor: PropTypes.oneOf(COLORS),
+  headerColor: PropTypes.oneOf(['white', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua']),
   /** The icon in the header of the dialog. */
   headerIcon: PropTypes.element,
   /** The level of the heading of the dialog. */

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -25,7 +25,7 @@ class Dialog extends PureComponent {
     );
 
     return (
-      <DialogBase.Header color={headerColor} icon={icon} onClose={onCloseClick}>
+      <DialogBase.Header color={headerColor} icon={icon} onCloseClick={onCloseClick}>
         {headingLevel === 2 ? <Heading2>{title}</Heading2> : <Heading3>{title}</Heading3>}
       </DialogBase.Header>
     );

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -5,7 +5,7 @@ import cx from 'classnames';
 
 import theme from './theme.css';
 
-import { Button, ButtonGroup, DialogBase, Heading2, Heading3, Link } from '../../index';
+import { Button, ButtonGroup, DialogBase, Heading3, Link } from '../../index';
 import { IconDragMediumFilled } from '@teamleader/ui-icons';
 
 class Dialog extends PureComponent {
@@ -13,7 +13,7 @@ class Dialog extends PureComponent {
   dragHandleRef = createRef();
 
   getHeader = () => {
-    const { draggable, headerColor, headerIcon, headingLevel, onCloseClick, title } = this.props;
+    const { draggable, headerColor, headerIcon, onCloseClick, title } = this.props;
 
     const icon = draggable ? (
       <div className={theme['drag-icon']} ref={this.dragHandleRef}>
@@ -25,7 +25,7 @@ class Dialog extends PureComponent {
 
     return (
       <DialogBase.Header color={headerColor} icon={icon} onCloseClick={onCloseClick}>
-        {headingLevel === 2 ? <Heading2 maxLines={1}>{title}</Heading2> : <Heading3 maxLines={1}>{title}</Heading3>}
+        <Heading3 maxLines={1}>{title}</Heading3>
       </DialogBase.Header>
     );
   };
@@ -86,8 +86,6 @@ Dialog.propTypes = {
   headerColor: PropTypes.oneOf(['white', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua']),
   /** The icon in the header of the dialog. */
   headerIcon: PropTypes.element,
-  /** The level of the heading of the dialog. */
-  headingLevel: PropTypes.oneOf([2, 3]),
   /** Callback function that is fired when the close icon (in the header) is clicked. */
   onCloseClick: PropTypes.func,
   /** Object containing the props of the primary action (a Button, with level prop set to 'primary'). */
@@ -108,7 +106,6 @@ Dialog.propTypes = {
 
 Dialog.defaultProps = {
   headerColor: 'neutral',
-  headingLevel: 3,
   scrollable: true,
   size: 'medium',
 };

--- a/src/components/dialog/Header.js
+++ b/src/components/dialog/Header.js
@@ -19,7 +19,6 @@ const Header = ({ color, icon, onCloseClick, children, ...rest }) => {
         <IconButton
           icon={<IconCloseMediumOutline />}
           onClick={onCloseClick}
-          marginLeft={4}
           marginVertical={-1}
           className={theme['close-icon']}
         />

--- a/src/components/dialog/Header.js
+++ b/src/components/dialog/Header.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { IconCloseMediumOutline } from '@teamleader/ui-icons';
 
-import { COLORS } from '../../constants';
 import Section from '../section';
 import IconButton from '../iconButton';
 
@@ -20,7 +19,7 @@ Header.propTypes = {
   /** The content to display inside the dialog. */
   children: PropTypes.any,
   /** The color of the banner */
-  color: PropTypes.oneOf(COLORS),
+  color: PropTypes.oneOf(['white', 'neutral', 'mint', 'violet', 'ruby', 'gold', 'aqua']),
   /** The icon in the banner. */
   icon: PropTypes.element,
   /** Callback function that is fired when the close icon clicked. */

--- a/src/components/dialog/Header.js
+++ b/src/components/dialog/Header.js
@@ -1,14 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { IconCloseMediumOutline } from '@teamleader/ui-icons';
 
-import { Banner } from '../../index';
 import { COLORS } from '../../constants';
+import Section from '../section';
+import IconButton from '../iconButton';
 
 const Header = ({ color, icon, onCloseClick, children, ...rest }) => {
   return (
-    <Banner color={color} fullWidth icon={icon} onClose={onCloseClick} {...rest}>
+    <Section display="flex" alignItems="center" color={color} {...rest}>
+      {icon}
       {children}
-    </Banner>
+      {onCloseClick && <IconButton icon={<IconCloseMediumOutline />} onClick={onCloseClick} />}
+    </Section>
   );
 };
 

--- a/src/components/dialog/Header.js
+++ b/src/components/dialog/Header.js
@@ -1,20 +1,16 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Banner } from '../../index';
 import { COLORS } from '../../constants';
 
-class Header extends PureComponent {
-  render() {
-    const { color, icon, onCloseClick, children, ...rest } = this.props;
-
-    return (
-      <Banner color={color} fullWidth icon={icon} onClose={onCloseClick} {...rest}>
-        {children}
-      </Banner>
-    );
-  }
-}
+const Header = ({ color, icon, onCloseClick, children, ...rest }) => {
+  return (
+    <Banner color={color} fullWidth icon={icon} onClose={onCloseClick} {...rest}>
+      {children}
+    </Banner>
+  );
+};
 
 Header.propTypes = {
   /** The content to display inside the dialog. */

--- a/src/components/dialog/Header.js
+++ b/src/components/dialog/Header.js
@@ -4,13 +4,26 @@ import { IconCloseMediumOutline } from '@teamleader/ui-icons';
 
 import Section from '../section';
 import IconButton from '../iconButton';
+import Icon from '../icon';
+
+import theme from './theme.css';
 
 const Header = ({ color, icon, onCloseClick, children, ...rest }) => {
   return (
     <Section display="flex" alignItems="center" color={color} {...rest}>
-      {icon}
+      <Icon color="teal" tint="darkest" marginRight={3}>
+        {icon}
+      </Icon>
       {children}
-      {onCloseClick && <IconButton icon={<IconCloseMediumOutline />} onClick={onCloseClick} />}
+      {onCloseClick && (
+        <IconButton
+          icon={<IconCloseMediumOutline />}
+          onClick={onCloseClick}
+          marginLeft={4}
+          marginVertical={-1}
+          className={theme['close-icon']}
+        />
+      )}
     </Section>
   );
 };

--- a/src/components/dialog/theme.css
+++ b/src/components/dialog/theme.css
@@ -89,3 +89,7 @@
   margin: calc(-1 * var(--spacer-regular));
   padding: var(--spacer-regular);
 }
+
+.close-icon {
+  margin-left: auto;
+}


### PR DESCRIPTION
### Changed

- `Dialog`: header title will now overflow into ellipsis instead of wrapping to the next line ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#2042](https://github.com/teamleadercrm/ui/pull/2042))

### Removed

- `Dialog`: removed the `headingLevel` property, the previous default (3) will be used ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#2042](https://github.com/teamleadercrm/ui/pull/2042))

#### Screenshot before this PR

<img width="558" alt="Screenshot 2022-03-16 at 15 50 55" src="https://user-images.githubusercontent.com/10011712/158618608-91317e3c-2980-4a48-b71e-505a03a7a2ae.png">


#### Screenshot after this PR

<img width="556" alt="Screenshot 2022-03-16 at 15 54 24" src="https://user-images.githubusercontent.com/10011712/158619020-dbc8f6e7-6bac-41c5-b71d-f9e332e2b386.png">

