### PR TITLE
Consolidate label component

### DIFF
--- a/.storybook/stories/playground/zIndexes.stories.js
+++ b/.storybook/stories/playground/zIndexes.stories.js
@@ -1,5 +1,6 @@
+import { boolean, select } from '@storybook/addon-knobs';
+import { DateTime } from 'luxon';
 import React, { useState } from 'react';
-import { addStoryInGroup, PLAYGROUND } from '../../utils';
 import {
   Box,
   Button,
@@ -16,18 +17,14 @@ import {
   MenuItem,
   Popover,
   Select,
-  TextBody,
-  TextSmall,
-  Toast,
+  TextBody, Toast,
   ToastContainer,
-  Tooltip,
+  Tooltip
 } from '../../../src';
-import { boolean, select } from '@storybook/addon-knobs';
-import { DateTime } from 'luxon';
-import { IconInfoBadgedSmallFilled } from '@teamleader/ui-icons';
-import options, { groupedOptions } from '../../../src/static/data/select';
-import { LANGUAGES } from '../../../src/static/data/languages';
 import { rows1 } from '../../../src/static/data/datagrid';
+import { LANGUAGES } from '../../../src/static/data/languages';
+import options, { groupedOptions } from '../../../src/static/data/select';
+import { addStoryInGroup, PLAYGROUND } from '../../utils';
 
 export default {
   title: addStoryInGroup(PLAYGROUND, 'Depths'),
@@ -209,11 +206,6 @@ export const zIndexes = () => {
         <Box padding={4}>
           <Heading3 color="teal">I am a Popover</Heading3>
           <Label
-            connectedRight={
-              <TooltippedIcon tooltip={<TextSmall>This is the label tooltip text</TextSmall>} tooltipSize="small">
-                <IconInfoBadgedSmallFilled />
-              </TooltippedIcon>
-            }
             marginTop={3}
             marginBottom={0}
             required

--- a/src/components/checkbox/Checkbox.js
+++ b/src/components/checkbox/Checkbox.js
@@ -1,11 +1,11 @@
-import React, { createRef, PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import theme from './theme.css';
+import { IconCheckmarkMediumOutline, IconCheckmarkSmallOutline, IconMinusSmallOutline } from '@teamleader/ui-icons';
 import cx from 'classnames';
 import omit from 'lodash.omit';
+import PropTypes from 'prop-types';
+import React, { createRef, PureComponent } from 'react';
 import Box, { omitBoxProps, pickBoxProps } from '../box';
-import { TextBody, TextDisplay, TextSmall } from '../typography';
-import { IconCheckmarkSmallOutline, IconCheckmarkMediumOutline, IconMinusSmallOutline } from '@teamleader/ui-icons';
+import { TextBodyCompact, TextDisplay, TextSmall } from '../typography';
+import theme from './theme.css';
 
 class Checkbox extends PureComponent {
   inputNode = createRef();
@@ -36,7 +36,7 @@ class Checkbox extends PureComponent {
 
   render() {
     const { checked, disabled, className, size, label, children, indeterminate, ...others } = this.props;
-    const TextElement = size === 'small' ? TextSmall : size === 'medium' ? TextBody : TextDisplay;
+    const TextElement = size === 'small' ? TextSmall : size === 'medium' ? TextBodyCompact : TextDisplay;
     const IconCheckmark = size === 'large' ? IconCheckmarkMediumOutline : IconCheckmarkSmallOutline;
 
     const restProps = omit(others, ['onChange']);

--- a/src/components/checkbox/theme.css
+++ b/src/components/checkbox/theme.css
@@ -115,7 +115,7 @@
 
   &.is-medium {
     .label {
-      padding-top: 2px;
+      padding-top: var(--spacer-smallest);
     }
 
     .shape {
@@ -126,7 +126,7 @@
 
   &.is-large {
     .label {
-      padding-top: 4px;
+      padding-top: var(--spacer-smallest);
     }
 
     .shape {

--- a/src/components/label/Label.js
+++ b/src/components/label/Label.js
@@ -1,7 +1,7 @@
-import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
 import Box from '../box';
-import { TextBody, TextDisplay, TextSmall } from '../typography';
+import { TextBodyCompact, TextDisplay, TextSmall } from '../typography';
 
 export default class Label extends PureComponent {
   render() {
@@ -13,7 +13,7 @@ export default class Label extends PureComponent {
       size,
     };
 
-    const Element = size === 'large' ? TextDisplay : TextBody;
+    const Element = size === 'large' ? TextDisplay : TextBodyCompact;
 
     return (
       <Box display="block" element="label" marginBottom={3} {...others}>

--- a/src/components/label/Label.js
+++ b/src/components/label/Label.js
@@ -8,7 +8,7 @@ import { TextBodyCompact, TextDisplay, TextSmall } from '../typography';
 const TooltippedIcon = Tooltip(Icon);
 export default class Label extends PureComponent {
   render() {
-    const { children, connectedLeft, connectedRight, inverse, helpText, required, size, tooltip, ...others } = this.props;
+    const { children, inverse, helpText, required, size, tooltip, ...others } = this.props;
 
     const childProps = {
       inverse,
@@ -27,11 +27,6 @@ export default class Label extends PureComponent {
 
           return (
             <Box display="flex" alignItems="center">
-              {connectedLeft && (
-                <Box element="span" marginRight={1}>
-                  {connectedLeft}
-                </Box>
-              )}
               <Element color={inverse ? 'neutral' : 'teal'} tint={inverse ? 'lightest' : 'darkest'} element="span">
                 {child}
               </Element>
@@ -65,8 +60,6 @@ export default class Label extends PureComponent {
 
 Label.propTypes = {
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.array]),
-  connectedLeft: PropTypes.element,
-  connectedRight: PropTypes.element,
   inverse: PropTypes.bool,
   helpText: PropTypes.string,
   required: PropTypes.bool,

--- a/src/components/label/Label.js
+++ b/src/components/label/Label.js
@@ -1,11 +1,14 @@
+import { IconInfoBadgedSmallFilled } from '@teamleader/ui-icons';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
+import { Icon, Tooltip } from '../..';
 import Box from '../box';
 import { TextBodyCompact, TextDisplay, TextSmall } from '../typography';
 
+const TooltippedIcon = Tooltip(Icon);
 export default class Label extends PureComponent {
   render() {
-    const { children, connectedLeft, connectedRight, inverse, helpText, required, size, ...others } = this.props;
+    const { children, connectedLeft, connectedRight, inverse, helpText, required, size, tooltip, ...others } = this.props;
 
     const childProps = {
       inverse,
@@ -42,10 +45,15 @@ export default class Label extends PureComponent {
                   {helpText}
                 </TextSmall>
               )}
-              {connectedRight && (
-                <Box element="span" marginLeft={1}>
-                  {connectedRight}
-                </Box>
+              {tooltip && (
+                <TooltippedIcon
+                  tooltip={<TextSmall>{tooltip}</TextSmall>}
+                  tooltipSize="small"
+                  color={inverse ? 'neutral' : 'teal'}
+                  tint={inverse ? 'lightest' : 'darkest'}
+                >
+                  <IconInfoBadgedSmallFilled />
+                </TooltippedIcon>
               )}
             </Box>
           );
@@ -63,6 +71,7 @@ Label.propTypes = {
   helpText: PropTypes.string,
   required: PropTypes.bool,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
+  tooltip: PropTypes.string
 };
 
 Label.defaultProps = {

--- a/src/components/label/Label.js
+++ b/src/components/label/Label.js
@@ -8,7 +8,7 @@ import { TextBodyCompact, TextDisplay, TextSmall } from '../typography';
 const TooltippedIcon = Tooltip(Icon);
 export default class Label extends PureComponent {
   render() {
-    const { children, inverse, helpText, required, size, tooltip, ...others } = this.props;
+    const { children, inverse, required, size, tooltip, ...others } = this.props;
 
     const childProps = {
       inverse,
@@ -30,14 +30,14 @@ export default class Label extends PureComponent {
               <Element color={inverse ? 'neutral' : 'teal'} tint={inverse ? 'lightest' : 'darkest'} element="span">
                 {child}
               </Element>
-              {!required && (
+              {required && (
                 <TextSmall
-                  color={inverse ? 'teal' : 'neutral'}
+                  color="ruby"
                   element="span"
                   marginLeft={1}
-                  tint={inverse ? 'light' : 'darkest'}
+                  tint="dark"
                 >
-                  {helpText}
+                  *
                 </TextSmall>
               )}
               {tooltip && (
@@ -46,6 +46,7 @@ export default class Label extends PureComponent {
                   tooltipSize="small"
                   color={inverse ? 'neutral' : 'teal'}
                   tint={inverse ? 'lightest' : 'darkest'}
+                  marginLeft={1}
                 >
                   <IconInfoBadgedSmallFilled />
                 </TooltippedIcon>
@@ -61,15 +62,13 @@ export default class Label extends PureComponent {
 Label.propTypes = {
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.string, PropTypes.array]),
   inverse: PropTypes.bool,
-  helpText: PropTypes.string,
   required: PropTypes.bool,
   size: PropTypes.oneOf(['small', 'medium', 'large']),
-  tooltip: PropTypes.string
+  tooltip: PropTypes.string,
 };
 
 Label.defaultProps = {
   inverse: false,
-  helpText: 'Optional',
   required: false,
   size: 'medium',
 };

--- a/src/components/label/label.stories.js
+++ b/src/components/label/label.stories.js
@@ -11,7 +11,6 @@ export const DefaultStory = (args) => (
   <Label
     {...args}
     htmlFor="input1"
-    tooltip="This is the label tooltip text"
   >
     Input label
     <Input id="input1" placeholder="I am the placeholder" />
@@ -19,7 +18,7 @@ export const DefaultStory = (args) => (
 );
 
 DefaultStory.args = {
-  helpText: 'Optional',
+  tooltip: 'This is the label tooltip text',
 };
 DefaultStory.storyName = 'Label + Input';
 

--- a/src/components/label/label.stories.js
+++ b/src/components/label/label.stories.js
@@ -33,3 +33,12 @@ export const DefaultStory = (args) => (
 DefaultStory.args = {
   helpText: 'Optional',
 };
+DefaultStory.storyName = 'Label + Input';
+
+export const SoloLabelStory = (args) => (
+  <Label
+    {...args}    
+  >
+    Label
+  </Label>
+);

--- a/src/components/label/label.stories.js
+++ b/src/components/label/label.stories.js
@@ -1,9 +1,6 @@
 import React from 'react';
-import { IconInfoBadgedSmallFilled, IconMarkerSmallOutline } from '@teamleader/ui-icons';
-import { Icon, Input, Label, TextSmall, Tooltip } from '../../index';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
-
-const TooltippedIcon = Tooltip(Icon);
+import { Input, Label } from '../../index';
 
 export default {
   component: Label,
@@ -14,16 +11,7 @@ export const DefaultStory = (args) => (
   <Label
     {...args}
     htmlFor="input1"
-    connectedLeft={
-      <Icon>
-        <IconMarkerSmallOutline />
-      </Icon>
-    }
-    connectedRight={
-      <TooltippedIcon tooltip={<TextSmall>This is the label tooltip text</TextSmall>} tooltipSize="small">
-        <IconInfoBadgedSmallFilled />
-      </TooltippedIcon>
-    }
+    tooltip="This is the label tooltip text"
   >
     Input label
     <Input id="input1" placeholder="I am the placeholder" />

--- a/src/components/radio/RadioButton.js
+++ b/src/components/radio/RadioButton.js
@@ -1,10 +1,10 @@
-import React, { createRef, PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import theme from './theme.css';
 import cx from 'classnames';
 import omit from 'lodash.omit';
+import PropTypes from 'prop-types';
+import React, { createRef, PureComponent } from 'react';
 import Box, { omitBoxProps, pickBoxProps } from '../box';
-import { TextBody, TextDisplay, TextSmall } from '../typography';
+import { TextBodyCompact, TextDisplay, TextSmall } from '../typography';
+import theme from './theme.css';
 
 class RadioButton extends PureComponent {
   inputNode = createRef();
@@ -35,7 +35,7 @@ class RadioButton extends PureComponent {
 
   render() {
     const { checked, disabled, className, size, label, children, onMouseEnter, onMouseLeave, ...others } = this.props;
-    const TextElement = size === 'small' ? TextSmall : size === 'medium' ? TextBody : TextDisplay;
+    const TextElement = size === 'small' ? TextSmall : size === 'medium' ? TextBodyCompact : TextDisplay;
 
     const restProps = omit(others, ['onChange']);
     const boxProps = pickBoxProps(restProps);

--- a/src/components/radio/theme.css
+++ b/src/components/radio/theme.css
@@ -129,7 +129,7 @@
 
   &.is-medium {
     .label {
-      padding-top: 2px;
+      padding-top: var(--spacer-smallest);
     }
 
     .shape {
@@ -145,7 +145,7 @@
 
   &.is-large {
     .label {
-      padding-top: 4px;
+      padding-top: var(--spacer-smallest);
     }
 
     .shape {

--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -1,10 +1,10 @@
-import React, { createRef, PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import theme from './theme.css';
 import cx from 'classnames';
 import omit from 'lodash.omit';
+import PropTypes from 'prop-types';
+import React, { createRef, PureComponent } from 'react';
 import Box, { omitBoxProps, pickBoxProps } from '../box';
-import { TextBody, TextDisplay, TextSmall } from '../typography';
+import { TextBodyCompact, TextDisplay, TextSmall } from '../typography';
+import theme from './theme.css';
 
 class Toggle extends PureComponent {
   inputNode = createRef();
@@ -50,7 +50,7 @@ class Toggle extends PureComponent {
       className,
     );
 
-    const TextElement = size === 'small' ? TextSmall : size === 'medium' ? TextBody : TextDisplay;
+    const TextElement = size === 'small' ? TextSmall : size === 'medium' ? TextBodyCompact : TextDisplay;
 
     return (
       <Box element="label" data-teamleader-ui="toggle" className={classNames} {...boxProps}>

--- a/src/components/toggle/theme.css
+++ b/src/components/toggle/theme.css
@@ -150,7 +150,7 @@
 
   &.is-medium {
     .label {
-      padding-top: 2px;
+      padding-top: var(--spacer-smallest);
     }
 
     .track {
@@ -180,7 +180,7 @@
 
   &.is-large {
     .label {
-      padding-top: 4px;
+      padding-top: var(--spacer-smallest);
     }
 
     .track {


### PR DESCRIPTION
https://teamleader.atlassian.net/browse/FRAF-282

### Added

- [BREAKING]`Label`: `tooltip` property ([@qubis741](https://github.com/qubis741) in [#2061](https://github.com/teamleadercrm/ui/pull/2061))

### Changed

- [BREAKING]`Label`: visual representation of `required` property 
- `Checkbox, RadioButton, Toggle`: `paddingTop` style
- `Checkbox, RadioButton, Toggle`: text component in `small` and `medium` size 

### Removed

- `Label`: `helpText` property
- [BREAKING]`Label`: `connectedLeft` property 
- [BREAKING]`Label`: `connectedRight` property 

#### Screenshot before this PR

![Screenshot 2022-03-30 at 15 39 19](https://user-images.githubusercontent.com/9944471/160848032-ccb93139-a0da-4975-a800-f74d5d4c48c6.png)

#### Screenshot after this PR

![Screenshot 2022-03-30 at 15 39 36](https://user-images.githubusercontent.com/9944471/160848093-fd0fa2c1-63b8-47ea-893a-b6aaaee5fcae.png)


### Manual Check
Check if new `required` prop works properly
