### PR TITLE
release/14.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,20 @@
 
 ### Removed
 
+### Fixed
+
+### Dependency updates
+
+## [14.0.0] - 2022-04-05
+
+### Removed
+
 - [BREAKING] `Alert`: removed `children` prop, use `body` instead ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#2067](https://github.com/teamleadercrm/ui/pull/2067))
 
 ### Fixed
 
 - `Alert`: Fixed double margin between title and buttons when no `body` is provided ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#2067](https://github.com/teamleadercrm/ui/pull/2067))
 - `Alert`: Center align title and body text ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#2067](https://github.com/teamleadercrm/ui/pull/2067))
-
-### Dependency updates
 
 ## [13.0.1] - 2022-03-31
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "13.0.1",
+  "version": "14.0.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [14.0.0] - 2022-04-05

### Removed

- [BREAKING] `Alert`: removed `children` prop, use `body` instead ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#2067](https://github.com/teamleadercrm/ui/pull/2067))

### Fixed

- `Alert`: Fixed double margin between title and buttons when no `body` is provided ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#2067](https://github.com/teamleadercrm/ui/pull/2067))
- `Alert`: Center align title and body text ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#2067](https://github.com/teamleadercrm/ui/pull/2067))
