### PR TITLE
Allow passing rest props to DialogBase component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ### Added
 
-### Changed
+- `Dialog, DialogBase`: Added the `form` and `onSubmit` properties to render a Dialog as a form ([@lorgan3](https://github.com/lorgan3) in [#2074](https://github.com/teamleadercrm/ui/pull/2074))
 
-- `DialogBase`: Render the dialog as a `Box` instead of a `div` and allow passing additional props. ([@lorgan3](https://github.com/lorgan3) in [#2074](https://github.com/teamleadercrm/ui/pull/2074))
+### Changed
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `DialogBase`: Render the dialog as a `Box` instead of a `div` and allow passing additional props. ([@lorgan3](https://github.com/lorgan3) in [#2074](https://github.com/teamleadercrm/ui/pull/2074))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -44,7 +44,7 @@ class Dialog extends PureComponent {
   };
 
   render() {
-    const { children, className, scrollable, title, ...otherProps } = this.props;
+    const { children, className, scrollable, title, form, onSubmit, ...otherProps } = this.props;
 
     const classNames = cx(theme['dialog'], className);
 
@@ -63,6 +63,8 @@ class Dialog extends PureComponent {
         scrollable={false}
         initialFocusRef={this.bodyRef}
         dragHandleRef={this.dragHandleRef}
+        form
+        onSubmit={onSubmit}
       >
         {title && this.getHeader()}
         <DialogBase.Body ref={this.bodyRef} scrollable={scrollable}>
@@ -97,6 +99,10 @@ Dialog.propTypes = {
   tertiaryAction: PropTypes.object,
   /** The title of the dialog. */
   title: PropTypes.string,
+  /** If true the dialog will render as a form element. */
+  form: PropTypes.boolean,
+  /** Optional callback if the dialog is a form and is being submitted */
+  onSubmit: PropTypes.func,
 };
 
 Dialog.defaultProps = {

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -48,7 +48,13 @@ class Dialog extends PureComponent {
 
     const classNames = cx(theme['dialog'], className);
 
-    const restProps = omit(otherProps, ['onCloseClick', 'primaryAction', 'secondaryAction', 'tertiaryAction']);
+    const restProps = omit(otherProps, [
+      'onCloseClick',
+      'primaryAction',
+      'secondaryAction',
+      'tertiaryAction',
+      'leftAction',
+    ]);
 
     return (
       <DialogBase

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -63,7 +63,7 @@ class Dialog extends PureComponent {
         scrollable={false}
         initialFocusRef={this.bodyRef}
         dragHandleRef={this.dragHandleRef}
-        form
+        form={form}
         onSubmit={onSubmit}
       >
         {title && this.getHeader()}

--- a/src/components/dialog/DialogBase.js
+++ b/src/components/dialog/DialogBase.js
@@ -24,6 +24,7 @@ export const DialogBase = ({
   size,
   initialFocusRef,
   dragHandleRef,
+  ...rest
 }) => {
   const { ref, FocusRing } = useFocusTrap({ active, initialFocusRef });
   useDraggable({ active, dragTargetRef: ref, dragHandleRef });
@@ -52,7 +53,7 @@ export const DialogBase = ({
             onEscKeyDown={onEscKeyDown}
           >
             <FocusRing>
-              <div ref={ref} data-teamleader-ui="dialog" className={dialogClassNames}>
+              <Box ref={ref} data-teamleader-ui="dialog" className={dialogClassNames} {...rest}>
                 <div className={theme['inner']}>
                   {scrollable ? (
                     <Box display="flex" flexDirection="column" overflowY="auto">
@@ -62,7 +63,7 @@ export const DialogBase = ({
                     children
                   )}
                 </div>
-              </div>
+              </Box>
             </FocusRing>
           </Overlay>
         );

--- a/src/components/dialog/DialogBase.js
+++ b/src/components/dialog/DialogBase.js
@@ -24,7 +24,8 @@ export const DialogBase = ({
   size,
   initialFocusRef,
   dragHandleRef,
-  ...rest
+  form,
+  onSubmit,
 }) => {
   const { ref, FocusRing } = useFocusTrap({ active, initialFocusRef });
   useDraggable({ active, dragTargetRef: ref, dragHandleRef });
@@ -33,6 +34,7 @@ export const DialogBase = ({
     return null;
   }
 
+  const Element = form ? 'form' : 'div';
   const dialog = (
     <Transition timeout={0} in={active} appear>
       {(state) => {
@@ -53,7 +55,7 @@ export const DialogBase = ({
             onEscKeyDown={onEscKeyDown}
           >
             <FocusRing>
-              <Box ref={ref} data-teamleader-ui="dialog" className={dialogClassNames} {...rest}>
+              <Element ref={ref} data-teamleader-ui="dialog" className={dialogClassNames} {...(form && { onSubmit })}>
                 <div className={theme['inner']}>
                   {scrollable ? (
                     <Box display="flex" flexDirection="column" overflowY="auto">
@@ -63,7 +65,7 @@ export const DialogBase = ({
                     children
                   )}
                 </div>
-              </Box>
+              </Element>
             </FocusRing>
           </Overlay>
         );
@@ -95,6 +97,10 @@ DialogBase.propTypes = {
   initialFocusRef: PropTypes.any,
   /** The element used to drag a dialog, @see Dialog component header for an example */
   dragHandleRef: PropTypes.any,
+  /** If true the dialog will render as a form element. */
+  form: PropTypes.boolean,
+  /** Optional callback if the dialog is a form and is being submitted */
+  onSubmit: PropTypes.func,
 };
 
 DialogBase.defaultProps = {


### PR DESCRIPTION
### Description

This allows the `Dialog` / `DialogBase` to become a form element.
I did this so the primaryAction / secondaryAction are inside the form and they can submit it. Putting the form around the dialog did not work because the dialog is rendered outside of it using portals.

example code:
```
        <Dialog
          title="Form"
          active
          primaryAction={{ type: 'submit', label: 'Save'}}
          secondaryAction={{ onClick: onClose, label: 'Cancel' }}
          onCloseClick={onClose}
          onEscKeyDown={onClose}
          onOverlayClick={onClose}
          form
          onSubmit={handleSubmit}
        >
         {/* content here */}
        </Dialog>
```

#### Screenshot before this PR
#### Screenshot after this PR

there are no visual changes

### Breaking changes

N/a
