### PR TITLE
Release/14.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### Added
 
-- `Dialog, DialogBase`: Added the `form` and `onSubmit` properties to render a Dialog as a form ([@lorgan3](https://github.com/lorgan3) in [#2074](https://github.com/teamleadercrm/ui/pull/2074))
-
 ### Changed
 
 ### Deprecated
@@ -12,9 +10,17 @@
 
 ### Fixed
 
-- `NumericInput`: Prevent mousedown events from creating event loops ([@jelledc](https://github.com/jelledc) in [#2078](https://github.com/teamleadercrm/ui/pull/2078))
-
 ### Dependency updates
+
+## [14.1.0] - 2022-04-12
+
+### Added
+
+- `Dialog, DialogBase`: Added the `form` and `onSubmit` properties to render a Dialog as a form ([@lorgan3](https://github.com/lorgan3) in [#2074](https://github.com/teamleadercrm/ui/pull/2074))
+
+### Fixed
+
+- `NumericInput`: Prevent mousedown events from creating event loops ([@jelledc](https://github.com/jelledc) in [#2078](https://github.com/teamleadercrm/ui/pull/2078))
 
 ## [14.0.0] - 2022-04-05
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "14.0.0",
+  "version": "14.1.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [14.1.0] - 2022-04-12

### Added

- `Dialog, DialogBase`: Added the `form` and `onSubmit` properties to render a Dialog as a form ([@lorgan3](https://github.com/lorgan3) in [#2074](https://github.com/teamleadercrm/ui/pull/2074))

### Fixed

- `NumericInput`: Prevent mousedown events from creating event loops ([@jelledc](https://github.com/jelledc) in [#2078](https://github.com/teamleadercrm/ui/pull/2078))
