### PR TITLE
Add menu vertical offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- `Select`: Added the `menuVerticalOffset` property to allow offsetting where the menu is displayed ([@lorgan3](https://github.com/lorgan3) in [#2085](https://github.com/teamleadercrm/ui/pull/2085))
+- `Select`: Added the `menuHorizontalOffset` property to allow offsetting where the menu is displayed ([@lorgan3](https://github.com/lorgan3) in [#2085](https://github.com/teamleadercrm/ui/pull/2085))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Select`: Added the `menuVerticalOffset` property to allow offsetting where the menu is displayed ([@lorgan3](https://github.com/lorgan3) in [#2085](https://github.com/teamleadercrm/ui/pull/2085))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -183,11 +183,20 @@ class Select extends PureComponent {
     };
   };
 
-  getMenuStyles = (base) => ({
-    ...base,
-    marginTop: 3,
-    marginBottom: 3,
-  });
+  getMenuStyles = (base) => {
+    const { menuVerticalOffset } = this.props;
+    return {
+      ...base,
+      marginTop: 3,
+      marginBottom: 3,
+      ...(menuVerticalOffset
+        ? {
+            right: menuVerticalOffset,
+            position: 'absolute',
+          }
+        : {}),
+    };
+  };
 
   getMenuPortalStyles = (base) => {
     const { inverse, menuWidth } = this.props;
@@ -405,6 +414,8 @@ Select.propTypes = {
   inverse: PropTypes.bool,
   /** A custom width for the menu dropdown */
   menuWidth: PropTypes.string,
+  /** A custom vertical offset for the menu dropdown, useful when also using a custom menuWidth  */
+  menuVerticalOffset: PropTypes.string,
   /** Boolean indicating whether the select option text should render on one single line. */
   truncateOptionText: PropTypes.bool,
   /** Size of the input element. */

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -184,14 +184,14 @@ class Select extends PureComponent {
   };
 
   getMenuStyles = (base) => {
-    const { menuVerticalOffset } = this.props;
+    const { menuHorizontalOffset } = this.props;
     return {
       ...base,
       marginTop: 3,
       marginBottom: 3,
-      ...(menuVerticalOffset
+      ...(menuHorizontalOffset
         ? {
-            right: menuVerticalOffset,
+            right: menuHorizontalOffset,
             position: 'absolute',
           }
         : {}),
@@ -414,8 +414,8 @@ Select.propTypes = {
   inverse: PropTypes.bool,
   /** A custom width for the menu dropdown */
   menuWidth: PropTypes.string,
-  /** A custom vertical offset for the menu dropdown, useful when also using a custom menuWidth  */
-  menuVerticalOffset: PropTypes.string,
+  /** A custom horizontal offset for the menu dropdown, useful when also using a custom menuWidth  */
+  menuHorizontalOffset: PropTypes.string,
   /** Boolean indicating whether the select option text should render on one single line. */
   truncateOptionText: PropTypes.bool,
   /** Size of the input element. */

--- a/src/components/select/select.stories.js
+++ b/src/components/select/select.stories.js
@@ -72,6 +72,8 @@ basic.args = {
   options,
   placeholder: 'Select your favourite(s)',
   size: 'medium',
+  menuWidth: undefined,
+  menuVerticalOffset: undefined,
 };
 
 export const grouped = () => <Select options={groupedOptions} />;

--- a/src/components/select/select.stories.js
+++ b/src/components/select/select.stories.js
@@ -73,7 +73,7 @@ basic.args = {
   placeholder: 'Select your favourite(s)',
   size: 'medium',
   menuWidth: undefined,
-  menuVerticalOffset: undefined,
+  menuHorizontalOffset: undefined,
 };
 
 export const grouped = () => <Select options={groupedOptions} />;


### PR DESCRIPTION
### Description

If you use react-select together with `menuWidth` near the right edge of the screen, the menu will go off the screen.
I've added a `menuVerticalOffset` prop to compensate for this. Unfortunately because we use portals a simple `alignRight`/`alignLeft` setting is not possible

#### Screenshot before this PR

![image](https://user-images.githubusercontent.com/1833617/163361969-6a15125b-ce3b-4a20-b3ed-d9987a0ad4cc.png)


#### Screenshot after this PR

![image](https://user-images.githubusercontent.com/1833617/163361835-97dfa5b5-abf9-4efc-b5d9-8048d106ccfb.png)


### Breaking changes

N/a