### PR TITLE
Make teal default color in Text elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- `Text`: Default value of `color` property is `teal` ([@qubis741](https://github.com/qubis741) in [#2092](https://github.com/teamleadercrm/ui/pull/2092))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/typography/Text.js
+++ b/src/components/typography/Text.js
@@ -56,6 +56,7 @@ const factory = (baseType, type, defaultElement) => {
 
   Text.defaultProps = {
     element: null,
+    color: 'teal',
     tint: 'darkest',
   };
 


### PR DESCRIPTION
### Changed

- `Text`: Default value of `color` property is `teal` ([@qubis741](https://github.com/qubis741) in [#2092](https://github.com/teamleadercrm/ui/pull/2092))