### PR TITLE
Fix types failing in stories files, only run `yarn build` on `prepublishOnly` instead of `prepare`

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "start": "PORT=${PORT:-3000}; start-storybook --port $PORT",
     "chromatic:storybook": "PORT=${PORT:-3000}; CHROMATIC=true start-storybook --port $PORT",
     "chromatic": "CHROMATIC=true chromatic",
-    "check-types": "tsc",
+    "check-types": "tsc --noEmit",
     "check-types:watch": "yarn check-types --watch",
     "build-types": "tsc -p ./tsconfig.build.json"
   }

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "lint": "eslint ./src",
     "lint:fix": "yarn lint --fix",
     "prettier": "prettier --write './{src,.storybook}/**/*.{js,json,md,css}'",
-    "prepare": "yarn build",
+    "prepublishOnly": "yarn build",
     "start": "PORT=${PORT:-3000}; start-storybook --port $PORT",
     "chromatic:storybook": "PORT=${PORT:-3000}; CHROMATIC=true start-storybook --port $PORT",
     "chromatic": "CHROMATIC=true chromatic",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,9 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist/types"
+  },
   "include": ["./src/index.js", "./src/@types"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,7 @@
     "esModuleInterop": true,
     "allowJs": true,
     "checkJs": false,
-    "jsx": "react",
-    "declaration": true,
-    "emitDeclarationOnly": true,
-    "outDir": "./dist/types"
+    "jsx": "react"
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
### Description

- Because of the `declaration` option being enabled, stories files would also be emitted when just running check-types, which should only happen when running build-types
- Only run `yarn build` when actually publishing, not when just installing

### Manual check

N/A, the check-types job should pass
