### PR TITLE
Add tooltips to Avatar and AvatarStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Avatar, AvatarStack`: Added `tooltip` property ([@lowiebenoot](https://github.com/lowiebenoot) in [#2105](https://github.com/teamleadercrm/ui/pull/2105))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -80,7 +80,7 @@ class Avatar extends PureComponent {
   };
 
   render() {
-    const { className, selectable, selected, size, shape, ...others } = this.props;
+    const { className, selectable, selected, size, shape, tooltip, fullName, ...others } = this.props;
 
     const avatarClassNames = cx(
       theme['wrapper'],
@@ -143,6 +143,8 @@ Avatar.propTypes = {
   size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'hero']),
   /** If true, a team icon will be shown. */
   team: PropTypes.bool,
+  /** If true, the name will be shown in a tooltip on hover. */
+  tooltip: PropTypes.bool,
 };
 
 Avatar.defaultProps = {
@@ -153,6 +155,7 @@ Avatar.defaultProps = {
   shape: 'circle',
   size: 'medium',
   team: false,
+  tooltip: false,
 };
 
 export default Avatar;

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -7,10 +7,14 @@ import AvatarInitials from './AvatarInitials';
 import AvatarTeam from './AvatarTeam';
 import Box from '../box';
 import Icon from '../icon';
+import { TextBodyCompact } from '../typography';
+import Tooltip from '../tooltip';
 import cx from 'classnames';
 import theme from './theme.css';
 import omit from 'lodash.omit';
 import { IconCloseMediumOutline, IconCloseSmallOutline } from '@teamleader/ui-icons';
+
+const TooltippedBox = Tooltip(Box);
 
 /** @type {React.ComponentType<any>} */
 class Avatar extends PureComponent {
@@ -93,25 +97,28 @@ class Avatar extends PureComponent {
       className,
     );
 
-    const restProps = omit(others, [
-      'children',
-      'creatable',
-      'editable',
-      'imageUrl',
-      'fullName',
-      'id',
-      'onImageChange',
-      'team',
-    ]);
+    const restProps = omit(others, ['children', 'creatable', 'editable', 'imageUrl', 'id', 'onImageChange', 'team']);
+
+    const enableTooltip = tooltip && typeof fullName === 'string' && fullName.length > 0;
+    const Component = enableTooltip ? TooltippedBox : Box;
+    const tooltipProps = enableTooltip
+      ? {
+          tooltip: <TextBodyCompact>{fullName}</TextBodyCompact>,
+          tooltipColor: 'white',
+          tooltipPosition: 'top',
+          tooltipSize: 'small',
+        }
+      : {};
 
     return (
-      <Box
+      <Component
         {...restProps}
         {...(selectable && { boxSizing: 'content-box', padding: size === 'hero' ? 2 : 1 })}
+        {...tooltipProps}
         className={avatarClassNames}
       >
         {this.renderComponent()}
-      </Box>
+      </Component>
     );
   }
 }

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Box from '../box';
 import cx from 'classnames';
 import theme from './theme.css';
-import uiUtilities from '@teamleader/ui-utilities';
 import AvatarStackOverflow from './AvatarStackOverflow';
 
 const OVERLAP_SPACINGS = {

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -4,6 +4,7 @@ import Box from '../box';
 import cx from 'classnames';
 import theme from './theme.css';
 import uiUtilities from '@teamleader/ui-utilities';
+import AvatarStackOverflow from './AvatarStackOverflow';
 
 const OVERLAP_SPACINGS = {
   tiny: -6,
@@ -81,16 +82,11 @@ class AvatarStack extends PureComponent {
           });
         })}
         {hasOverflow && (
-          <Box
-            alignItems="center"
-            className={cx(uiUtilities['reset-font-smoothing'], theme['overflow'])}
-            display="flex"
-            justifyContent="center"
-            onClick={onOverflowClick}
-          >
-            {displayMax > 0 && `+`}
-            {overflowAmount}
-          </Box>
+          <AvatarStackOverflow
+            displayMax={displayMax}
+            overflowAmount={overflowAmount}
+            onOverflowClick={onOverflowClick}
+          />
         )}
       </Box>
     );

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -86,6 +86,8 @@ class AvatarStack extends PureComponent {
             displayMax={displayMax}
             overflowAmount={overflowAmount}
             onOverflowClick={onOverflowClick}
+            overflowChildren={children.slice(displayMax)}
+            tooltip={tooltip}
           />
         )}
       </Box>

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -72,6 +72,7 @@ class AvatarStack extends PureComponent {
             ...child.props,
             selectable,
             size,
+            tooltip,
             style: {
               ...spacingStyles,
               zIndex: childrenToDisplay.length - index,

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -27,6 +27,7 @@ class AvatarStack extends PureComponent {
       onOverflowClick,
       selectable,
       size,
+      getNamesOverflowLabel,
       tooltip,
       ...others
     } = this.props;
@@ -86,6 +87,7 @@ class AvatarStack extends PureComponent {
             overflowAmount={overflowAmount}
             onOverflowClick={onOverflowClick}
             overflowChildren={children.slice(displayMax)}
+            getNamesOverflowLabel={getNamesOverflowLabel}
             tooltip={tooltip}
           />
         )}
@@ -105,6 +107,8 @@ AvatarStack.propTypes = {
   displayMax: PropTypes.number,
   /** If true, component will be rendered in inverse mode. */
   inverse: PropTypes.bool,
+  /** Function to get the names overflow label that is displayed in the tooltip when it overflows. It get's the overflow amount as a parameter. */
+  getNamesOverflowLabel: PropTypes.func,
   /** Callback function that is fired when the overflow circle is clicked. */
   onOverflowClick: PropTypes.func,
   /** If true, avatars will not be overlapping each other and will become interactive. */

--- a/src/components/avatar/AvatarStack.js
+++ b/src/components/avatar/AvatarStack.js
@@ -18,8 +18,18 @@ const SPACING = 6;
 /** @type {React.ComponentType<any>} */
 class AvatarStack extends PureComponent {
   render() {
-    const { children, className, direction, displayMax, inverse, onOverflowClick, selectable, size, ...others } =
-      this.props;
+    const {
+      children,
+      className,
+      direction,
+      displayMax,
+      inverse,
+      onOverflowClick,
+      selectable,
+      size,
+      tooltip,
+      ...others
+    } = this.props;
 
     const childrenToDisplay = children.length > displayMax ? children.slice(0, displayMax) : children;
     const overflowAmount = children.length - displayMax;
@@ -103,6 +113,8 @@ AvatarStack.propTypes = {
   selectable: PropTypes.bool,
   /** The size of the avatar stack. */
   size: PropTypes.oneOf(['tiny', 'small', 'medium', 'large', 'hero']),
+  /** If true, the names will be shown in a tooltip on hover. */
+  tooltip: PropTypes.bool,
 };
 
 AvatarStack.defaultProps = {
@@ -111,6 +123,7 @@ AvatarStack.defaultProps = {
   inverse: false,
   selectable: false,
   size: 'medium',
+  tooltip: false,
 };
 
 export default AvatarStack;

--- a/src/components/avatar/AvatarStackOverflow.tsx
+++ b/src/components/avatar/AvatarStackOverflow.tsx
@@ -17,9 +17,17 @@ interface Props {
   overflowChildren: React.ReactChild[];
   onOverflowClick: () => void;
   tooltip: boolean;
+  getNamesOverflowLabel?: (overflowAmount: number) => string;
 }
 
-const AvatarStackOverflow = ({ displayMax, overflowAmount, overflowChildren, onOverflowClick, tooltip }: Props) => {
+const AvatarStackOverflow = ({
+  displayMax,
+  overflowAmount,
+  overflowChildren,
+  onOverflowClick,
+  tooltip,
+  getNamesOverflowLabel,
+}: Props) => {
   const names = React.Children.map(
     overflowChildren,
     (child) => React.isValidElement(child) && child.props.fullName,
@@ -42,7 +50,9 @@ const AvatarStackOverflow = ({ displayMax, overflowAmount, overflowChildren, onO
     ? {
         tooltip: (
           <TextBodyCompact>
-            {namesToDisplay.join(', ') + (hasNamesOverflow ? `, +${namesOverflowAmount} more...` : '')}
+            {namesToDisplay.join(', ')}
+            {hasNamesOverflow &&
+              `, +${getNamesOverflowLabel ? getNamesOverflowLabel(namesOverflowAmount) : namesOverflowAmount}...`}
           </TextBodyCompact>
         ),
         tooltipColor: 'white',

--- a/src/components/avatar/AvatarStackOverflow.tsx
+++ b/src/components/avatar/AvatarStackOverflow.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import cx from 'classnames';
+import uiUtilities from '@teamleader/ui-utilities';
+
+import Box from '../box';
+import theme from './theme.css';
+
+interface Props {
+  displayMax: number;
+  overflowAmount: number;
+  onOverflowClick: () => void;
+}
+
+const AvatarStackOverflow = ({ displayMax, overflowAmount, onOverflowClick }: Props) => {
+  return (
+    <Box
+      alignItems="center"
+      className={cx(uiUtilities['reset-font-smoothing'], theme['overflow'])}
+      display="flex"
+      justifyContent="center"
+      onClick={onOverflowClick}
+    >
+      {displayMax > 0 && `+`}
+      {overflowAmount}
+    </Box>
+  );
+};
+
+export default AvatarStackOverflow;

--- a/src/components/avatar/AvatarStackOverflow.tsx
+++ b/src/components/avatar/AvatarStackOverflow.tsx
@@ -3,26 +3,66 @@ import cx from 'classnames';
 import uiUtilities from '@teamleader/ui-utilities';
 
 import Box from '../box';
+import { TextBodyCompact } from '../typography';
+import Tooltip from '../tooltip';
 import theme from './theme.css';
+
+const TooltippedBox = Tooltip(Box);
+
+const MAX_NAMES_TO_SHOW_IN_TOOLTIP = 15;
 
 interface Props {
   displayMax: number;
   overflowAmount: number;
+  overflowChildren: React.ReactChild[];
   onOverflowClick: () => void;
+  tooltip: boolean;
 }
 
-const AvatarStackOverflow = ({ displayMax, overflowAmount, onOverflowClick }: Props) => {
+const AvatarStackOverflow = ({ displayMax, overflowAmount, overflowChildren, onOverflowClick, tooltip }: Props) => {
+  const names = React.Children.map(
+    overflowChildren,
+    (child) => React.isValidElement(child) && child.props.fullName,
+  ).filter(Boolean);
+
+  console.log(names);
+
+  const enableTooltip = tooltip && names.length > 0;
+  const namesToDisplay = names.slice(0, MAX_NAMES_TO_SHOW_IN_TOOLTIP);
+  const namesOverflowAmount = names.length - MAX_NAMES_TO_SHOW_IN_TOOLTIP;
+  const hasNamesOverflow = namesOverflowAmount > 0;
+
+  console.log(namesToDisplay);
+  console.log(namesToDisplay.join(', '));
+  console.log(namesOverflowAmount);
+  console.log(hasNamesOverflow);
+
+  const Component = enableTooltip ? TooltippedBox : Box;
+  const tooltipProps = enableTooltip
+    ? {
+        tooltip: (
+          <TextBodyCompact>
+            {namesToDisplay.join(', ') + (hasNamesOverflow ? `, +${namesOverflowAmount} more...` : '')}
+          </TextBodyCompact>
+        ),
+        tooltipColor: 'white',
+        tooltipPosition: 'top',
+        tooltipSize: 'small',
+      }
+    : {};
+
   return (
-    <Box
+    <Component
       alignItems="center"
       className={cx(uiUtilities['reset-font-smoothing'], theme['overflow'])}
       display="flex"
       justifyContent="center"
       onClick={onOverflowClick}
+      {...tooltipProps}
     >
       {displayMax > 0 && `+`}
       {overflowAmount}
-    </Box>
+    </Component>
   );
 };
 

--- a/src/components/avatar/AvatarStackOverflow.tsx
+++ b/src/components/avatar/AvatarStackOverflow.tsx
@@ -33,17 +33,10 @@ const AvatarStackOverflow = ({
     (child) => React.isValidElement(child) && child.props.fullName,
   ).filter(Boolean);
 
-  console.log(names);
-
   const enableTooltip = tooltip && names.length > 0;
   const namesToDisplay = names.slice(0, MAX_NAMES_TO_SHOW_IN_TOOLTIP);
   const namesOverflowAmount = names.length - MAX_NAMES_TO_SHOW_IN_TOOLTIP;
   const hasNamesOverflow = namesOverflowAmount > 0;
-
-  console.log(namesToDisplay);
-  console.log(namesToDisplay.join(', '));
-  console.log(namesOverflowAmount);
-  console.log(hasNamesOverflow);
 
   const Component = enableTooltip ? TooltippedBox : Box;
   const tooltipProps = enableTooltip

--- a/src/components/avatar/avatarStack.stories.js
+++ b/src/components/avatar/avatarStack.stories.js
@@ -16,7 +16,7 @@ export default {
 };
 
 export const DefaultStory = (args) => (
-  <AvatarStack {...args} getNamesOverflowLabel={(amount) => `${amount} more`}>
+  <AvatarStack {...args} getNamesOverflowLabel={(amount) => `${amount} more`} size="medium">
     {[...avatars, ...avatars, ...avatars, ...avatars].map(({ image }, index) => (
       <Avatar key={index} imageUrl={image} fullName={`John Doe ${index}`} />
     ))}

--- a/src/components/avatar/avatarStack.stories.js
+++ b/src/components/avatar/avatarStack.stories.js
@@ -16,8 +16,8 @@ export default {
 };
 
 export const DefaultStory = (args) => (
-  <AvatarStack {...args}>
     {avatars.map(({ image }, index) => (
+  <AvatarStack {...args} getNamesOverflowLabel={(amount) => `${amount} more`}>
       <Avatar key={index} imageUrl={image} fullName={`John Doe ${index}`} />
     ))}
   </AvatarStack>
@@ -25,4 +25,5 @@ export const DefaultStory = (args) => (
 
 DefaultStory.args = {
   displayMax: 5,
+  tooltip: true,
 };

--- a/src/components/avatar/avatarStack.stories.js
+++ b/src/components/avatar/avatarStack.stories.js
@@ -16,8 +16,8 @@ export default {
 };
 
 export const DefaultStory = (args) => (
-    {avatars.map(({ image }, index) => (
   <AvatarStack {...args} getNamesOverflowLabel={(amount) => `${amount} more`}>
+    {[...avatars, ...avatars, ...avatars, ...avatars].map(({ image }, index) => (
       <Avatar key={index} imageUrl={image} fullName={`John Doe ${index}`} />
     ))}
   </AvatarStack>

--- a/src/components/avatar/avatarStack.stories.js
+++ b/src/components/avatar/avatarStack.stories.js
@@ -18,7 +18,7 @@ export default {
 export const DefaultStory = (args) => (
   <AvatarStack {...args}>
     {avatars.map(({ image }, index) => (
-      <Avatar key={index} imageUrl={image} />
+      <Avatar key={index} imageUrl={image} fullName={`John Doe ${index}`} />
     ))}
   </AvatarStack>
 );


### PR DESCRIPTION
### Description

Added (optional) tooltips on Avatar and AvatarStack.
If you hover over the avatar it will show the full name (if there is one).
If the AvatarStack has an overflow, it will show the names in a tooltip as well.


![Screenshot 2022-05-04 at 14 21 15](https://user-images.githubusercontent.com/330765/166680086-30fe7333-32d4-4398-a97d-f37c504c28ab.png)

![Screenshot 2022-05-04 at 14 21 56](https://user-images.githubusercontent.com/330765/166680192-9fa7d355-853e-4ad7-b67d-cb79b3359d77.png)

