### PR TITLE
Bump react-draft-wysiwyg to support react 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react": "^16.3.1",
     "react-day-picker": "^7.4.8",
     "react-dom": "^16.3.1",
-    "react-draft-wysiwyg": "^1.14.4",
+    "react-draft-wysiwyg": "^1.14.7",
     "react-input-mask": "^2.0.4",
     "react-resize-detector": "^7.0.0",
     "react-select": "5.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11736,7 +11736,7 @@ react-dom@^16.3.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-draft-wysiwyg@^1.14.4:
+react-draft-wysiwyg@^1.14.7:
   version "1.14.7"
   resolved "https://registry.yarnpkg.com/react-draft-wysiwyg/-/react-draft-wysiwyg-1.14.7.tgz#5d27fe8ad87de7c692dad739b8787f3ac1f3c24e"
   integrity sha512-D4X8F/ourvQZuqHzCQ6Vs6Tnt6TbGH58kvHQxC+aZGq+45ko2EyatL6G5C/paMaNKDZq2JRe7yAzykneMLpNOg==


### PR DESCRIPTION
### Description

Bump react-draft-wysiwyg to the latest version in order to support react 17.
For react 18 we'll probably have to migrate to something else as it looks pretty dead and [none of the forks are promising either](https://techgaun.github.io/active-forks/index.html#jpuri/react-draft-wysiwyg)

No changelog update since there are no major changes.

#### Screenshot before this PR

N/a

#### Screenshot after this PR

N/a
