### PR TITLE
Bump react-day-picker to the latest version on v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "luxon": "^2.3.0",
     "prop-types": "^15.8.1",
     "react": "^16.3.1",
-    "react-day-picker": "^7.4.8",
+    "react-day-picker": "^7.4.10",
     "react-dom": "^16.3.1",
     "react-draft-wysiwyg": "^1.14.4",
     "react-input-mask": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11700,7 +11700,7 @@ react-colorful@^5.1.2:
   resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.2.2.tgz#0a69d0648db47e51359d343854d83d250a742243"
   integrity sha512-Xdb1Rl6lZ5SMdNBH59eE0lGqR1g2LVD8IgPlw0WeMDrOC65lYI8fgMEwj/0dDpVRVMh5qp73ciISDst/t2O2iQ==
 
-react-day-picker@^7.4.8:
+react-day-picker@^7.4.10:
   version "7.4.10"
   resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-7.4.10.tgz#d3928fa65c04379ad28c76de22aa85374a8361e1"
   integrity sha512-/QkK75qLKdyLmv0kcVzhL7HoJPazoZXS8a6HixbVoK6vWey1Od1WRLcxfyEiUsRfccAlIlf6oKHShqY2SM82rA==


### PR DESCRIPTION
### Description

Ensure we're on the latest version of the v7 branch of react-day-picker.
Support for react 17 was added in 7.4.9.

They have a v8 branch available but the API is very different and the upgrade guide is incomplete so I left it as is for now.

#### Screenshot before this PR

N/a

#### Screenshot after this PR

N/a
