### PR TITLE
Add missing prop for box component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [unreleased]
+### Fixed
+
+- `Box`: Added missing props for Box Component ([@eniskrasniqi1](https://github.com/eniskraasniqi1) in [#2131](https://github.com/teamleadercrm/ui/pull/2131))
 
 ### Added
 
@@ -9,10 +12,6 @@
 ### Removed
 
 ### Dependency updates
-
-### Fixed
-
-- `Box`: Added missing props for Box Component ([@eniskrasniqi1](https://github.com/eniskraasniqi1) in [#2131](https://github.com/teamleadercrm/ui/pull/2131))
 
 ## [14.5.0] - 2022-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 ## [unreleased]
-### Fixed
-
-- `Box`: Added missing props for Box Component ([@eniskrasniqi1](https://github.com/eniskraasniqi1) in [#2131](https://github.com/teamleadercrm/ui/pull/2131))
 
 ### Added
 
 ### Changed
 
 ### Deprecated
+
+### Fixed
+
+- `Box`: Added missing props for Box Component ([@eniskrasniqi1](https://github.com/eniskraasniqi1) in [#2131](https://github.com/teamleadercrm/ui/pull/2131))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Dependency updates
 
+## [14.5.1] - 2022-05-11
+
+### Fixed
+
+- `Box`: Added missing props for Box Component ([@eniskrasniqi1](https://github.com/eniskraasniqi1) in [#2131](https://github.com/teamleadercrm/ui/pull/2131))
+
 ## [14.5.0] - 2022-05-10
 
 ### Dependency updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@
 
 ### Dependency updates
 
-## [14.5.1] - 2022-05-11
-
 ### Fixed
 
 - `Box`: Added missing props for Box Component ([@eniskrasniqi1](https://github.com/eniskraasniqi1) in [#2131](https://github.com/teamleadercrm/ui/pull/2131))

--- a/src/components/box/Box.tsx
+++ b/src/components/box/Box.tsx
@@ -65,7 +65,7 @@ export type BoxProps = Partial<
     paddingTop: Padding;
     style: CSSProperties;
     textAlign: 'center' | 'left' | 'right';
-    to: string;
+    [key: string]: unknown;
   } & HTMLProps<HTMLElement>
 >;
 

--- a/src/components/box/Box.tsx
+++ b/src/components/box/Box.tsx
@@ -65,6 +65,7 @@ export type BoxProps = Partial<
     paddingTop: Padding;
     style: CSSProperties;
     textAlign: 'center' | 'left' | 'right';
+    to: string;
   } & HTMLProps<HTMLElement>
 >;
 

--- a/src/components/box/Box.tsx
+++ b/src/components/box/Box.tsx
@@ -36,7 +36,7 @@ export type BoxProps = Partial<
     boxSizing: 'border-box' | 'content-box';
     children: ReactNode;
     className: string;
-    display: 'inline' | 'inline-block' | 'block' | 'flex' | 'inline-flex';
+    display: 'inline' | 'inline-block' | 'block' | 'flex' | 'inline-flex' | 'grid';
     element: React.ElementType;
     flex: CSSProperties['flex'];
     flexBasis: CSSProperties['flexBasis'];

--- a/src/components/box/boxProps.js
+++ b/src/components/box/boxProps.js
@@ -48,7 +48,6 @@ const boxProps = [
   'paddingRight',
   'paddingTop',
   'textAlign',
-  'to',
 ];
 
 const omitBoxProps = (props) => omit(props, boxProps);

--- a/src/components/box/boxProps.js
+++ b/src/components/box/boxProps.js
@@ -48,6 +48,7 @@ const boxProps = [
   'paddingRight',
   'paddingTop',
   'textAlign',
+  'to',
 ];
 
 const omitBoxProps = (props) => omit(props, boxProps);


### PR DESCRIPTION
### Description

Added the missing prop `to` for box component and also option `grid` for display, needed for upgrading dependencies in `service-auth-frontend` `react 17.0.2`
