### PR TITLE
Fix icon menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `IconMenu`: Fix IconMenu closing right away in projects using React 17 ([@lorgan3](https://github.com/lorgan3) in [#2138](https://github.com/teamleadercrm/ui/pull/2138))
+
 ### Dependency updates
 
 ## [14.5.1] - 2022-05-12

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -104,10 +104,14 @@ class Menu extends PureComponent {
   }
 
   addEvents() {
-    events.addEventsToDocument({
-      click: this.handleDocumentClick,
-      touchstart: this.handleDocumentClick,
-    });
+    window.setTimeout(
+      () =>
+        events.addEventsToDocument({
+          click: this.handleDocumentClick,
+          touchstart: this.handleDocumentClick,
+        }),
+      0,
+    );
   }
 
   removeEvents() {

--- a/src/components/utils/events.js
+++ b/src/components/utils/events.js
@@ -19,36 +19,24 @@ export default {
   },
 
   addEventsToDocument(eventMap) {
-    // remove this disable once this gets fixed
-    // https://github.com/eslint/eslint/issues/12117
-    /* eslint-disable-next-line no-unused-vars */
     for (const key in eventMap) {
       document.addEventListener(key, eventMap[key], false);
     }
   },
 
   removeEventsFromDocument(eventMap) {
-    // remove this disable once this gets fixed
-    // https://github.com/eslint/eslint/issues/12117
-    /* eslint-disable-next-line no-unused-vars */
     for (const key in eventMap) {
       document.removeEventListener(key, eventMap[key], false);
     }
   },
 
   addEventsToWindow(eventMap) {
-    // remove this disable once this gets fixed
-    // https://github.com/eslint/eslint/issues/12117
-    /* eslint-disable-next-line no-unused-vars */
     for (const key in eventMap) {
       window.addEventListener(key, eventMap[key], false);
     }
   },
 
   removeEventsFromWindow(eventMap) {
-    // remove this disable once this gets fixed
-    // https://github.com/eslint/eslint/issues/12117
-    /* eslint-disable-next-line no-unused-vars */
     for (const key in eventMap) {
       window.removeEventListener(key, eventMap[key], false);
     }
@@ -92,9 +80,6 @@ const TRANSITIONS = {
 };
 
 function transitionEventNamesFor(element) {
-  // remove this disable once this gets fixed
-  // https://github.com/eslint/eslint/issues/12117
-  /* eslint-disable-next-line no-unused-vars */
   for (const transition in TRANSITIONS) {
     if (element && element.style[transition] !== undefined) {
       return TRANSITIONS[transition];


### PR DESCRIPTION
### Description

It seems that in React 17 a click renders the menu, which then receives the same click again causing the menu to be hidden again right away.

### Manual check
 - Check you can open and close the `IconMenu` component