### PR TITLE
Toggle type udpate

### DIFF
--- a/src/components/toggle/Toggle.tsx
+++ b/src/components/toggle/Toggle.tsx
@@ -15,7 +15,7 @@ export interface ToggleProps extends Omit<BoxProps, 'className' | 'size'> {
   maxLines?: number;
   name?: string;
   className?: string;
-  label?: string;
+  label?: ReactNode;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   size?: Size;
 }

--- a/src/components/toggle/toggle.stories.tsx
+++ b/src/components/toggle/toggle.stories.tsx
@@ -1,7 +1,12 @@
 import React, { ChangeEvent, useState } from 'react';
+import { IconInfoBadgedSmallFilled } from '@teamleader/ui-icons';
 import Toggle, { ToggleProps } from './Toggle';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
 import { ComponentMeta } from '@storybook/react';
+import Box from '../box';
+import Tooltip from '../tooltip';
+import Icon from '../icon';
+import { TextSmall } from '../typography';
 
 export default {
   component: Toggle,
@@ -28,4 +33,26 @@ export const DefaultStory = (args: ToggleProps) => {
 DefaultStory.args = {
   checked: true,
   label: 'I am a label',
+};
+
+const TooltippedIcon = Tooltip(Icon);
+export const withTooltip = () => {
+  const [checked, setChecked] = useState(false);
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setChecked(event.currentTarget.checked);
+  };
+  return (
+    <Toggle
+      checked={checked}
+      onChange={handleChange}
+      label={
+        <Box display="flex">
+          Label
+          <TooltippedIcon tooltip={<TextSmall>Tooltip</TextSmall>} marginLeft={2}>
+            <IconInfoBadgedSmallFilled />
+          </TooltippedIcon>
+        </Box>
+      }
+    />
+  );
 };


### PR DESCRIPTION
### Description

Changed `Toggle` `label` prop from `string` to `ReactNode` since it can contain elements.

