### PR TITLE
Remove postcss-loader from peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "postcss-custom-media": "^8.0.0",
     "postcss-each": "^0.10.0",
     "postcss-import": "^14.0.0",
-    "postcss-loader": "^6.2.1",
     "postcss-nested": "^5.0.3",
     "postcss-preset-env": "^6.7.0",
     "postcss-pseudoelements": "^5.0.0",


### PR DESCRIPTION
### Description

- Removed `postcss-loader` from peer dependencies (it's still part of the devDependencies)

Reasoning: It's not necessarily a peer dependency, as end users could use any postcss compiling tool, but we use it for the storybook build

Will also fix one of these warnings when installing:

<img width="735" alt="Screenshot 2022-05-24 at 08 40 43" src="https://user-images.githubusercontent.com/10011712/169965211-355ec7db-ac49-447b-a493-47516b2f7ccf.png">

