### PR TITLE
Make dependabot ignore patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']
     target-branch: next-release
     reviewers:
       - driesd


### PR DESCRIPTION
### Description

As discussed some time ago, let's try ignoring patch updates to reduce the amount of dependabot prs that require review.
Security updates are not ignored and if there's a bug we want to solve we can of course still manually upgrade a dependency.
You can read more about it [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore)
