### PR TITLE
Allow any react node in the dialog title

### DIFF
--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -28,7 +28,7 @@ interface DialogProps extends Omit<DialogBaseProps, 'ref'> {
   /** Object containing the props of the tertiary action (a Link, with the inherit props set to false). */
   tertiaryAction?: object;
   /** The title of the dialog. */
-  title?: string;
+  title?: ReactNode;
   /** If true the dialog will render as a form element. */
   form?: boolean;
   /** Optional callback if the dialog is a form and is being submitted */


### PR DESCRIPTION
### Description

Just `string` is a bit too strict as we want to add a label in the title (see https://github.com/teamleadercrm/core/pull/27380)

No changelog entry since its just a type change
