### PR TITLE
Add ability to remove the remove button from the first item in EmailSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `EmailSelector`: A prop to disable the removal of the initial emailaddress ([@stefaandevylder](https://github.com/stefaandevylder)) in [#2197](https://github.com/teamleadercrm/ui/pull/2197))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/emailSelector/EmailSelector.tsx
+++ b/src/components/emailSelector/EmailSelector.tsx
@@ -70,7 +70,7 @@ const EmailSelector = ({
 
   const onLabelClick = useCallback(
     (index: number) => {
-      setEditingLabel(index);
+      !disableRemovalOfFirst && setEditingLabel(index);
       setSelection(selection.filter((selection, i) => i <= index || selection.email.trim() !== ''));
     },
     [setEditingLabel, setSelection, selection],

--- a/src/components/emailSelector/EmailSelector.tsx
+++ b/src/components/emailSelector/EmailSelector.tsx
@@ -214,7 +214,7 @@ const EmailSelector = ({
             onFinish={onUpdateLabel}
             onFocus={onTagFocus}
             onBlur={onBlurLabel}
-            {...(!(i == 0 && disableRemovalOfFirst) && { onRemove: onRemoveHandler })}
+            {...(!(i === 0 && disableRemovalOfFirst) && { onRemove: onRemoveHandler })}
             suggestions={validSuggestions}
             renderSuggestion={renderSuggestion}
           />

--- a/src/components/emailSelector/EmailSelector.tsx
+++ b/src/components/emailSelector/EmailSelector.tsx
@@ -214,9 +214,10 @@ const EmailSelector = ({
             onFinish={onUpdateLabel}
             onFocus={onTagFocus}
             onBlur={onBlurLabel}
-            {...(!(i === 0 && disableRemovalOfFirst) && { onRemove: onRemoveHandler })}
+            onRemove={onRemoveHandler}
             suggestions={validSuggestions}
             renderSuggestion={renderSuggestion}
+            disableRemovalOfFirst={disableRemovalOfFirst}
           />
         ))}
         {(editingLabel === null || selection[editingLabel].email !== '') && (

--- a/src/components/emailSelector/EmailSelector.tsx
+++ b/src/components/emailSelector/EmailSelector.tsx
@@ -20,6 +20,7 @@ interface EmailSelectorProps extends Omit<BoxProps, 'ref' | 'onBlur' | 'onFocus'
   onFocus?: (event: React.FocusEvent<HTMLElement>) => void;
   id?: string;
   renderSuggestion?: React.ComponentType<React.ComponentProps<typeof EmailSuggestion>>;
+  disableRemovalOfFirst?: boolean;
 }
 
 const EmailSelector = ({
@@ -33,6 +34,7 @@ const EmailSelector = ({
   suggestions,
   renderSuggestion,
   warning,
+  disableRemovalOfFirst,
   ...rest
 }: EmailSelectorProps) => {
   const ref = useRef<HTMLElement>();
@@ -168,7 +170,7 @@ const EmailSelector = ({
     setEditingLabel(null);
   }, [selection, setSelection, setEditingLabel]);
 
-  const onRemove = useCallback(
+  const onRemoveHandler = useCallback(
     (index: number) => {
       if (editingLabel !== index && selection[index].email !== '') {
         onUpdateLabel(index);
@@ -212,7 +214,7 @@ const EmailSelector = ({
             onFinish={onUpdateLabel}
             onFocus={onTagFocus}
             onBlur={onBlurLabel}
-            onRemove={onRemove}
+            {...(!(i == 0 && disableRemovalOfFirst) && { onRemove: onRemoveHandler })}
             suggestions={validSuggestions}
             renderSuggestion={renderSuggestion}
           />

--- a/src/components/emailSelector/Label.tsx
+++ b/src/components/emailSelector/Label.tsx
@@ -32,6 +32,7 @@ interface LabelProps {
   onFinish?: (index: number, newLabel: Suggestion | { email: string }) => void;
   suggestions?: Suggestions;
   renderSuggestion?: React.ComponentType<React.ComponentProps<typeof EmailSuggestion>>;
+  disableRemovalOfFirst?: boolean;
 }
 
 const Label = ({
@@ -46,6 +47,7 @@ const Label = ({
   onRemove,
   onFinish,
   renderSuggestion,
+  disableRemovalOfFirst,
 }: LabelProps) => {
   const [content, setContent] = useState(option.email);
   const [autocompleteOpen, setAutocompleteOpen] = useState(true);
@@ -147,7 +149,7 @@ const Label = ({
           break;
 
         case BACKSPACE:
-          if (!event.repeat && content === '' && onRemove) {
+          if (!event.repeat && content === '' && onRemove && !((index === 0 || index === 1) && disableRemovalOfFirst)) {
             onRemove(index);
           }
           break;
@@ -234,7 +236,7 @@ const Label = ({
       margin={1}
       marginRight={2}
       onFocus={onTagFocus}
-      onRemoveClick={onRemove && onTagRemove}
+      onRemoveClick={!(index === 0 && disableRemovalOfFirst) && onRemove && onTagRemove}
     >
       <Link element="button" className={theme['label-text']} inherit={false} onClick={onTagClick}>
         {option.label || option.email}

--- a/src/components/emailSelector/emailSelector.stories.tsx
+++ b/src/components/emailSelector/emailSelector.stories.tsx
@@ -62,3 +62,13 @@ export const customSuggestions: ComponentStory<typeof EmailSelector> = () => (
     )}
   />
 );
+
+export const disableRemovalOfFirst: ComponentStory<typeof EmailSelector> = () => (
+  <EmailSelector
+    error={text('Error', '')}
+    validator={validator}
+    defaultSelection={[suggestions[0]]}
+    suggestions={suggestions}
+    disableRemovalOfFirst
+  />
+);


### PR DESCRIPTION
### Description

This PR adds a prop to `EmailSelector` so you can disable the removal of the first email address.

#### Screenshot before this PR

<img width="467" alt="Screenshot 2022-06-10 at 10 00 42" src="https://user-images.githubusercontent.com/10358801/173019750-57739718-6b8b-486b-9ba2-4af82577864b.png">

#### Screenshot after this PR

<img width="467" alt="Screenshot 2022-06-10 at 10 00 57" src="https://user-images.githubusercontent.com/10358801/173019781-3b87d94a-0c27-4ef1-9073-b2ff025db406.png">

