### PR TITLE
[TIDAL-2039] Email selector menu can be the same width as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `EmailSelector`: Allow the autocomplete menu to take the same width as it's input with the `menuFullWidth` prop ([@BeirlaenAaron](https://github.com/BeirlaenAaron) in [#2205](https://github.com/teamleadercrm/ui/pull/2205))
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ## [14.6.1] - 2022-06-10
 
-### Fixed=======
+### Fixed
 
 - `Dialog, DialogBase`: Fix blurriness with certain text content in webkit-based browsers ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#2191](https://github.com/teamleadercrm/ui/pull/2191))
 

--- a/src/components/emailSelector/Autocomplete.tsx
+++ b/src/components/emailSelector/Autocomplete.tsx
@@ -14,6 +14,7 @@ interface AutocompleteProps {
   onClick?: (suggestion: Suggestion, event: React.SyntheticEvent) => void;
   onHover?: (suggestion: Suggestion, event: React.SyntheticEvent) => void;
   renderSuggestion?: React.ComponentType<React.ComponentProps<typeof EmailSuggestion>>;
+  menuWidth?: number;
 }
 
 const Autocomplete = ({
@@ -22,11 +23,12 @@ const Autocomplete = ({
   onClick,
   onHover,
   renderSuggestion = EmailSuggestion,
+  menuWidth,
 }: AutocompleteProps) => {
   const Component = renderSuggestion;
 
   return (
-    <Box className={cx(uiUtilities['box-shadow-200'], theme['autocomplete'])}>
+    <Box className={cx(uiUtilities['box-shadow-200'], theme['autocomplete'])} style={{ width: menuWidth }}>
       <Box backgroundColor="neutral" backgroundTint="lightest" borderWidth={1} borderRadius="rounded" overflow="hidden">
         {Array.isArray(suggestions)
           ? suggestions.map((suggestion) => (

--- a/src/components/emailSelector/EmailSelector.tsx
+++ b/src/components/emailSelector/EmailSelector.tsx
@@ -218,7 +218,7 @@ const EmailSelector = ({
             suggestions={validSuggestions}
             renderSuggestion={renderSuggestion}
             {...(menuFullWidth && {
-              menuWidth: ref.current?.clientWidth,
+              menuWidth: ref.current?.offsetWidth,
             })}
           />
         ))}

--- a/src/components/emailSelector/EmailSelector.tsx
+++ b/src/components/emailSelector/EmailSelector.tsx
@@ -20,6 +20,7 @@ interface EmailSelectorProps extends Omit<BoxProps, 'ref' | 'onBlur' | 'onFocus'
   onFocus?: (event: React.FocusEvent<HTMLElement>) => void;
   id?: string;
   renderSuggestion?: React.ComponentType<React.ComponentProps<typeof EmailSuggestion>>;
+  menuFullWidth?: boolean;
 }
 
 const EmailSelector = ({
@@ -33,6 +34,7 @@ const EmailSelector = ({
   suggestions,
   renderSuggestion,
   warning,
+  menuFullWidth,
   ...rest
 }: EmailSelectorProps) => {
   const ref = useRef<HTMLElement>();
@@ -215,7 +217,9 @@ const EmailSelector = ({
             onRemove={onRemove}
             suggestions={validSuggestions}
             renderSuggestion={renderSuggestion}
-            menuWidth={ref.current?.clientWidth}
+            {...(menuFullWidth && {
+              menuWidth: ref.current?.clientWidth,
+            })}
           />
         ))}
         {(editingLabel === null || selection[editingLabel].email !== '') && (

--- a/src/components/emailSelector/EmailSelector.tsx
+++ b/src/components/emailSelector/EmailSelector.tsx
@@ -215,6 +215,7 @@ const EmailSelector = ({
             onRemove={onRemove}
             suggestions={validSuggestions}
             renderSuggestion={renderSuggestion}
+            menuWidth={ref.current?.clientWidth}
           />
         ))}
         {(editingLabel === null || selection[editingLabel].email !== '') && (

--- a/src/components/emailSelector/Label.tsx
+++ b/src/components/emailSelector/Label.tsx
@@ -32,6 +32,7 @@ interface LabelProps {
   onFinish?: (index: number, newLabel: Suggestion | { email: string }) => void;
   suggestions?: Suggestions;
   renderSuggestion?: React.ComponentType<React.ComponentProps<typeof EmailSuggestion>>;
+  menuWidth?: number;
 }
 
 const Label = ({
@@ -46,6 +47,7 @@ const Label = ({
   onRemove,
   onFinish,
   renderSuggestion,
+  menuWidth,
 }: LabelProps) => {
   const [content, setContent] = useState(option.email);
   const [autocompleteOpen, setAutocompleteOpen] = useState(true);
@@ -222,6 +224,7 @@ const Label = ({
             onClick={onSuggestionClick}
             onHover={onSuggestionHover}
             renderSuggestion={renderSuggestion}
+            menuWidth={menuWidth}
           />
         )}
       </>

--- a/src/components/emailSelector/emailSelector.stories.tsx
+++ b/src/components/emailSelector/emailSelector.stories.tsx
@@ -30,6 +30,7 @@ export const basic: ComponentStory<typeof EmailSelector> = () => (
     validator={validator}
     defaultSelection={[suggestions[0]]}
     suggestions={suggestions}
+    menuFullWidth
   />
 );
 

--- a/src/components/emailSelector/theme.css
+++ b/src/components/emailSelector/theme.css
@@ -97,7 +97,7 @@
 .autocomplete {
   position: fixed;
   margin-left: calc(-1 * var(--spacer-smallest));
-  margin-top: var(--spacer-small);
+  margin-top: var(--spacer-smaller);
   min-width: 300px;
   z-index: var(--overlay-z-index);
 }


### PR DESCRIPTION
### Description

[Jira](https://teamleader.atlassian.net/browse/TIDAL-2039)

This PR allows the autocomplete menu of the email selector to take the same width as it's input
(Also makes the space between the input and the menu a little bit smaller as requested in the ticket)

#### Screenshot before this PR

![image](https://user-images.githubusercontent.com/55881661/173566686-649f8c42-10f9-4057-9787-fb9af39e9cb9.png)


#### Screenshot after this PR

If the `menuFullWidth` prop is on the email selector, it should look like this:
![image](https://user-images.githubusercontent.com/55881661/173566117-6fb2ef1e-f8db-4b13-b8c4-e18e9c15f731.png)


### Breaking changes

N/A
It's set as an optional prop to avoid breaking changes
