### PR TITLE
Grid: columnGap and rowGap props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Grid`: Add two props to set column and row gap separately ([@BeirlaenAaron](https://github.com/BeirlaenAaron) in [#2214](https://github.com/teamleadercrm/ui/pull/2214))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/grid/Grid.tsx
+++ b/src/components/grid/Grid.tsx
@@ -11,26 +11,35 @@ export type GridProps = Partial<{
   rows: string[];
   columns: string[];
   gap: Gap;
+  columnGap: Gap;
+  rowGap: Gap;
   ref: ForwardedRef<HTMLDivElement>;
 }>;
 
-const Grid = forwardRef(({ children, areas, rows, columns, gap = 0 }: GridProps, ref: ForwardedRef<HTMLDivElement>) => {
-  const classNames = cx(theme['grid'], {
-    [theme[`gap-${gap}`]]: gap > 0,
-  });
+const Grid = forwardRef(
+  (
+    { children, areas, rows, columns, gap = 0, columnGap = 0, rowGap = 0 }: GridProps,
+    ref: ForwardedRef<HTMLDivElement>,
+  ) => {
+    const classNames = cx(theme['grid'], {
+      [theme[`gap-${gap}`]]: gap > 0,
+      [theme[`column-gap-${columnGap}`]]: columnGap > 0,
+      [theme[`row-gap-${rowGap}`]]: rowGap > 0,
+    });
 
-  const gridStyles = {
-    gridTemplateAreas: areas?.map((area) => `"${area}"`).join(' '),
-    gridTemplateRows: rows?.join(' '),
-    gridTemplateColumns: columns?.join(' '),
-  };
+    const gridStyles = {
+      gridTemplateAreas: areas?.map((area) => `"${area}"`).join(' '),
+      gridTemplateRows: rows?.join(' '),
+      gridTemplateColumns: columns?.join(' '),
+    };
 
-  return (
-    <div className={classNames} style={gridStyles} ref={ref}>
-      {children}
-    </div>
-  );
-});
+    return (
+      <div className={classNames} style={gridStyles} ref={ref}>
+        {children}
+      </div>
+    );
+  },
+);
 
 Grid.displayName = 'Grid';
 

--- a/src/components/grid/grid.stories.tsx
+++ b/src/components/grid/grid.stories.tsx
@@ -77,4 +77,6 @@ basic.args = {
   rows: ['100px', '1fr', '50px'],
   columns: ['20%', '1fr'],
   gap: 0,
+  columnGap: 0,
+  rowGap: 0,
 };

--- a/src/components/grid/theme.css
+++ b/src/components/grid/theme.css
@@ -11,4 +11,12 @@
   .gap-$(factor) {
     gap: $spacer;
   }
+
+  .column-gap-$(factor) {
+    column-gap: $spacer;
+  }
+
+  .row-gap-$(factor) {
+    row-gap: $spacer;
+  }
 }


### PR DESCRIPTION
### Description

This adds two props to set the column and row gap separately

#### Screenshot before this PR

![image](https://user-images.githubusercontent.com/55881661/174318697-3793a202-195b-41d7-8287-06267a24a9a5.png)

#### Screenshot after this PR

![image](https://user-images.githubusercontent.com/55881661/174318803-63954ee6-057f-4ea7-812c-aef0d9f79e11.png)
