### PR TITLE
[Guild] Fix Storybook rendering of string | number union type

### DIFF
--- a/src/components/input/input.stories.tsx
+++ b/src/components/input/input.stories.tsx
@@ -71,6 +71,13 @@ const types = [
 export default {
   component: Input,
   title: addStoryInGroup(LOW_LEVEL_BLOCKS, 'Form elements/Input'),
+  argTypes: {
+    value: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
 } as ComponentMeta<typeof Input>;
 
 export const input: ComponentStory<typeof Input> = (args) => {


### PR DESCRIPTION
### Description

PR that defines how Storybook should render the string | number union type in input.stories.tsx.

### Manual check

Check if value field is text input instead of object input.