### PR TITLE
[FRAF-754] - Fix element not being picked up in Badge

### DIFF
--- a/src/components/badge/Badge.tsx
+++ b/src/components/badge/Badge.tsx
@@ -62,7 +62,7 @@ const Badge: GenericComponent<BadgeProps> = forwardRef<HTMLElement, BadgeProps>(
     );
 
     const TextElement = size === 'small' ? UITextSmall : size === 'large' ? UITextDisplay : UITextBody;
-    const boxElement = element || onClick ? 'button' : 'div';
+    const boxElement = element || (onClick ? 'button' : 'div');
 
     return (
       <Box


### PR DESCRIPTION
### Description

- Badge component was not picking up element, only button or a div. This PR fixes it.

Manual check:
- Try on storybook to send a i.e: 'a' tag, and log it somewhere in the component. It should return the type specified. 