### PR TITLE
Remove TSFixMe

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -1,5 +1,0 @@
-export {};
-
-declare global {
-  type TSFixMe = any;
-}

--- a/src/components/datepicker/DatePickerInput.tsx
+++ b/src/components/datepicker/DatePickerInput.tsx
@@ -12,6 +12,7 @@ import { BoxProps } from '../box/Box';
 import { GenericComponent } from '../../@types/types';
 import { SIZES } from '../../constants';
 import { InputProps } from '../input/Input';
+import { PopoverProps } from '../popover/Popover';
 
 interface DatePickerInputProps extends Omit<BoxProps, 'size' | 'onChange'> {
   /** A class name for the wrapper to give custom styles. */
@@ -33,7 +34,7 @@ interface DatePickerInputProps extends Omit<BoxProps, 'size' | 'onChange'> {
   /** Callback function that is fired when the popover with the calendar gets closed (unfocused) */
   onBlur?: () => void;
   /** Object with props for the Popover component. */
-  popoverProps?: TSFixMe; // TODO: change this to our popover props
+  popoverProps?: PopoverProps;
   /** The current selected date. */
   selectedDate?: Date;
   /** Size of the Input & DatePicker components. */
@@ -71,7 +72,7 @@ const DatePickerInput: GenericComponent<DatePickerInputProps> = ({
   ...others
 }) => {
   const [isPopoverActive, setIsPopoverActive] = useState(false);
-  const [popoverAnchorEl, setPopoverAnchorEl] = useState<EventTarget | null>(null);
+  const [popoverAnchorEl, setPopoverAnchorEl] = useState<Element | null>(null);
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(others.selectedDate);
 
   const getFormattedDate = () => {

--- a/src/components/datepicker/DatePickerInput.tsx
+++ b/src/components/datepicker/DatePickerInput.tsx
@@ -11,6 +11,7 @@ import { IconCalendarSmallOutline } from '@teamleader/ui-icons';
 import { BoxProps } from '../box/Box';
 import { GenericComponent } from '../../@types/types';
 import { SIZES } from '../../constants';
+import { InputProps } from '../input/Input';
 
 interface DatePickerInputProps extends Omit<BoxProps, 'size' | 'onChange'> {
   /** A class name for the wrapper to give custom styles. */
@@ -22,7 +23,7 @@ interface DatePickerInputProps extends Omit<BoxProps, 'size' | 'onChange'> {
   /** A custom function to format a date. */
   formatDate?: (selectedDate: Date, locale: string) => string;
   /** Object with props for the Input component. */
-  inputProps?: TSFixMe; // TODO: change this to our input props
+  inputProps?: InputProps;
   /** If true, component will be rendered in inverse mode. */
   inverse?: boolean;
   /** The language ISO locale code ('en-GB', 'nl-BE', 'fr-FR',...). */
@@ -85,28 +86,28 @@ const DatePickerInput: GenericComponent<DatePickerInputProps> = ({
     return customFormatDate(selectedDate, locale);
   };
 
-  const handleInputFocus = (event: React.FocusEvent<HTMLInputElement>) => {
-    if (inputProps.readOnly) {
+  const handleInputFocus = (event: React.SyntheticEvent<HTMLElement>) => {
+    if (inputProps?.readOnly) {
       return;
     }
 
     if (openPickerOnFocus) {
       setPopoverAnchorEl(event.currentTarget);
       setIsPopoverActive(true);
-      inputProps.onFocus && inputProps.onFocus(event);
+      inputProps?.onFocus && inputProps.onFocus(event);
     } else {
-      inputProps.onFocus && inputProps.onFocus(event);
+      inputProps?.onFocus && inputProps.onFocus(event);
     }
   };
 
-  const handleInputClick = (event: React.MouseEvent<HTMLInputElement>) => {
+  const handleInputClick = (event: React.MouseEvent<HTMLElement>) => {
     if (!openPickerOnFocus) {
       setPopoverAnchorEl(event.currentTarget);
       setIsPopoverActive(true);
-      inputProps.onFocus && inputProps.onFocus(event);
+      inputProps?.onFocus && inputProps.onFocus(event);
     }
 
-    inputProps.onClick && inputProps.onClick(event);
+    inputProps?.onClick && inputProps.onClick(event);
   };
 
   const handlePopoverClose = () => {

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -5,9 +5,9 @@ import SingleLineInputBase, { SingleLineInputBaseProps } from './SingleLineInput
 export interface InputProps extends Omit<SingleLineInputBaseProps, 'onChange'> {
   /** Callback function that is fired when the component's value changes. */
   onChange?: (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>, value: string) => void;
-  /** Callback function that is fired when the component is focussed */
+  /** Callback function that is fired when the component is focussed. */
   onFocus?: (event: React.SyntheticEvent<HTMLElement>) => void;
-  /** Callback function that is fired when the component is clicked */
+  /** Callback function that is fired when the component is clicked. */
   onClick?: (event: React.MouseEvent<HTMLElement>) => void;
   /** Current value of the input element. */
   value?: string | number;

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -2,9 +2,13 @@ import React, { ChangeEvent, forwardRef, useState } from 'react';
 import { GenericComponent } from '../../@types/types';
 import SingleLineInputBase, { SingleLineInputBaseProps } from './SingleLineInputBase';
 
-interface InputProps extends Omit<SingleLineInputBaseProps, 'onChange'> {
+export interface InputProps extends Omit<SingleLineInputBaseProps, 'onChange'> {
   /** Callback function that is fired when the component's value changes. */
   onChange?: (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>, value: string) => void;
+  /** Callback function that is fired when the component is focussed */
+  onFocus?: (event: React.SyntheticEvent<HTMLElement>) => void;
+  /** Callback function that is fired when the component is clicked */
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
   /** Current value of the input element. */
   value?: string | number;
 }

--- a/src/components/popover/Popover.tsx
+++ b/src/components/popover/Popover.tsx
@@ -16,7 +16,7 @@ import { GenericComponent } from '../../@types/types';
 import { BoxProps } from '../box/Box';
 import { COLORS, TINTS } from '../../constants';
 
-interface PopoverProps extends Omit<BoxProps, 'ref'> {
+export interface PopoverProps extends Omit<BoxProps, 'ref'> {
   /** The state of the Popover, when true the Popover is rendered otherwise it is not. */
   active?: boolean;
   /** The Popovers anchor element. */


### PR DESCRIPTION
### Description

Running tsc in a project that uses the ui library without `skipLibCheck` results in 
```
node_modules/@teamleader/ui/dist/types/components/datepicker/DatePickerInput.d.ts:15:18 - error TS2304: Cannot find name 'TSFixMe'.

15     inputProps?: TSFixMe;
                    ~~~~~~~

node_modules/@teamleader/ui/dist/types/components/datepicker/DatePickerInput.d.ts:25:20 - error TS2304: Cannot find name 'TSFixMe'.

25     popoverProps?: TSFixMe;
                      ~~~~~~~


Found 2 errors in the same file, starting at: node_modules/@teamleader/ui/dist/types/components/datepicker/DatePickerInput.d.ts:15
```

You can fix this by also globally defining `TSFixMe` there but that's not a nice solution
Since it was pretty straight forward to 'fix' these occurrences now, I've done that and also removed `TSFixMe` again

#### Screenshot before this PR

/

#### Screenshot after this PR

/

### Breaking changes

/