### PR TITLE
Input: only use state value when value is not passed as prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Input`: controlled Inputs could get ouf sync when the controlled value was changed outside of the component (thus not via the onChange handler) ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2271](https://github.com/teamleadercrm/ui/pull/2271))
+
 ### Dependency updates
 
 ## [15.0.1] - 2022-07-08

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -22,7 +22,14 @@ const Input: GenericComponent<InputProps> = forwardRef<HTMLInputElement | HTMLTe
       onChange && onChange(event, event.currentTarget.value);
     };
 
-    return <SingleLineInputBase ref={forwardedRef} value={stateValue} onChange={handleChange} {...others} />;
+    return (
+      <SingleLineInputBase
+        ref={forwardedRef}
+        value={typeof value !== 'undefined' ? value : stateValue}
+        onChange={handleChange}
+        {...others}
+      />
+    );
   },
 );
 


### PR DESCRIPTION
Otherwise it gets out of sync when the value is controlled and it gets changed outside of the component.

