### PR TITLE
Release/15.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ## [15.0.2] - 2022-07-11
 
+### Fixed
+
 - `Input`: controlled Inputs could get ouf sync when the controlled value was changed outside of the component (thus not via the onChange handler) ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2271](https://github.com/teamleadercrm/ui/pull/2271))
 
 ## [15.0.1] - 2022-07-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@
 
 ### Fixed
 
-- `Input`: controlled Inputs could get ouf sync when the controlled value was changed outside of the component (thus not via the onChange handler) ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2271](https://github.com/teamleadercrm/ui/pull/2271))
-
 ### Dependency updates
+
+## [15.0.2] - 2022-07-11
+
+- `Input`: controlled Inputs could get ouf sync when the controlled value was changed outside of the component (thus not via the onChange handler) ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2271](https://github.com/teamleadercrm/ui/pull/2271))
 
 ## [15.0.1] - 2022-07-08
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "15.0.1",
+  "version": "15.0.2",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [15.0.2] - 2022-07-11

- `Input`: controlled Inputs could get ouf sync when the controlled value was changed outside of the component (thus not via the onChange handler) ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2271](https://github.com/teamleadercrm/ui/pull/2271))
