### PR TITLE
Added exception for ckEditor elements in useFocusTrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `useFocusTrap`: added exception for `ckEditor` elements to allow focusing ([@qubis741](https://github.com/qubis741)) in [#2273](https://github.com/teamleadercrm/ui/pull/2273))
+
 ### Deprecated
 
 ### Removed

--- a/src/utils/useFocusTrap/useFocusTrap.tsx
+++ b/src/utils/useFocusTrap/useFocusTrap.tsx
@@ -75,7 +75,10 @@ const useFocusTrap = ({
       }
 
       const trapFocus: EventListener = (event) => {
-        if (!currentFocusRef.contains(event.target as Element)) {
+        const eventTarget = event.target as Element;
+        // If focus is called on CkeEditor Element (for example Link dialog), we want to keep focus there, not back in our dialog
+        const isCkEditorElement = eventTarget.className.includes('cke');
+        if (!isCkEditorElement && !currentFocusRef.contains(eventTarget)) {
           if (document.activeElement === event.target) {
             if (event.target === topFocusBumperRef.current) {
               // Reset the focus to the last element when focusing in reverse (shift-tab)


### PR DESCRIPTION
https://teamleader.atlassian.net/browse/FRAF-764

### Changed

- `useFocusTrap`: added exception for `ckEditor` elements to allow focusing 

CkEditors `LinkDialog` elements weren't focusable because of `focusTrap` used in `Dialog`.

### Manual check 
N/A