### PR TITLE
Release/15.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Changed
 
-- `useFocusTrap`: added exception for `ckEditor` elements to allow focusing ([@qubis741](https://github.com/qubis741)) in [#2273](https://github.com/teamleadercrm/ui/pull/2273))
-
 ### Deprecated
 
 ### Removed
@@ -13,6 +11,12 @@
 ### Fixed
 
 ### Dependency updates
+
+## [15.0.3] - 2022-07-12
+
+### Changed
+
+- `useFocusTrap`: added exception for `ckEditor` elements to allow focusing ([@qubis741](https://github.com/qubis741)) in [#2273](https://github.com/teamleadercrm/ui/pull/2273))
 
 ## [15.0.2] - 2022-07-11
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "15.0.2",
+  "version": "15.0.3",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [15.0.2] - 2022-07-12

### Changed

- `useFocusTrap`: added exception for `ckEditor` elements to allow focusing ([@qubis741](https://github.com/qubis741)) in [#2273](https://github.com/teamleadercrm/ui/pull/2273))
