### PR TITLE
Fix bug on popover

### DIFF
--- a/src/components/popover/positionCalculation.ts
+++ b/src/components/popover/positionCalculation.ts
@@ -234,24 +234,6 @@ const getDirection = (direction: Direction, anchorPosition: PositionValues, popo
   return direction;
 };
 
-const isVerticalDirectionPositionPossible = (
-  position: Position,
-  anchorPosition: PositionValues,
-  popoverDimensions: DimensionValues,
-) => {
-  switch (position) {
-    case POSITION_CENTER:
-      return (
-        anchorPosition.centerY + popoverDimensions.height / 2 < window.innerHeight &&
-        anchorPosition.centerY - popoverDimensions.height / 2 > 0
-      );
-    case POSITION_START:
-      return anchorPosition.top + popoverDimensions.height < window.innerHeight;
-    case POSITION_END:
-      return anchorPosition.bottom - popoverDimensions.height > 0;
-  }
-};
-
 const isHorizontalDirectionPositionPossible = (
   position: Position,
   anchorPosition: PositionValues,
@@ -270,15 +252,8 @@ const isHorizontalDirectionPositionPossible = (
   }
 };
 
-const isPositionPossible = (
-  direction: Direction,
-  position: Position,
-  anchorPosition: PositionValues,
-  popoverDimensions: DimensionValues,
-) =>
-  direction === DIRECTION_NORTH || direction === DIRECTION_SOUTH
-    ? isVerticalDirectionPositionPossible(position, anchorPosition, popoverDimensions)
-    : isHorizontalDirectionPositionPossible(position, anchorPosition, popoverDimensions);
+const isPositionPossible = (position: Position, anchorPosition: PositionValues, popoverDimensions: DimensionValues) =>
+  isHorizontalDirectionPositionPossible(position, anchorPosition, popoverDimensions);
 
 const getOppositePosition = (position: Position) => {
   switch (position) {
@@ -289,25 +264,20 @@ const getOppositePosition = (position: Position) => {
   }
 };
 
-const getPosition = (
-  direction: Direction,
-  position: Position,
-  anchorPosition: PositionValues,
-  popoverDimensions: DimensionValues,
-) => {
-  if (isPositionPossible(direction, position, anchorPosition, popoverDimensions)) {
+const getPosition = (position: Position, anchorPosition: PositionValues, popoverDimensions: DimensionValues) => {
+  if (isPositionPossible(position, anchorPosition, popoverDimensions)) {
     return position;
   }
 
   switch (position) {
     case POSITION_CENTER:
-      return isPositionPossible(direction, POSITION_START, anchorPosition, popoverDimensions)
+      return isPositionPossible(POSITION_START, anchorPosition, popoverDimensions)
         ? POSITION_START
-        : isPositionPossible(direction, POSITION_END, anchorPosition, popoverDimensions)
+        : isPositionPossible(POSITION_END, anchorPosition, popoverDimensions)
         ? POSITION_END
         : position;
     default:
-      return isPositionPossible(direction, POSITION_CENTER, anchorPosition, popoverDimensions)
+      return isPositionPossible(POSITION_CENTER, anchorPosition, popoverDimensions)
         ? POSITION_CENTER
         : getOppositePosition(position);
   }
@@ -333,7 +303,7 @@ export const calculatePositions = (
   const popoverDimensions = getElementDimensionValues(popoverEl);
 
   const direction = getDirection(inputDirection, anchorPosition, popoverDimensions);
-  const position = getPosition(direction, inputPosition, anchorPosition, popoverDimensions);
+  const position = getPosition(inputPosition, anchorPosition, popoverDimensions);
 
   return {
     maxHeight: getMaxHeightValue(direction, anchorPosition),


### PR DESCRIPTION
### Description
This is a bug introduced in the guild week, now timetracking is not working on core.

`getPosition` function was never using the `direction` prop. I checked history before TS conversion, it was always getting `position` as first argument instead of supposed `direction`.

##### Screenshot of Popover in javascript

![Screenshot 2022-07-13 at 00 27 54](https://user-images.githubusercontent.com/41387389/178610371-f1f412c3-647b-4839-9a5f-28db813016c5.png)

##### `isPositionPossible` function (which was used only on the getPosition func):

![Screenshot 2022-07-13 at 00 28 38](https://user-images.githubusercontent.com/41387389/178610455-f4bb886a-6a5e-4515-8cce-177e536a9b7b.png)
This condition always returned false, so the isVerticalDirectionPositionPossible was never used.

### Manual check

- link this branch locally with core
- time tracking on the top right should now work
