### PR TITLE
Moving back the input props passed on Input

### DIFF
--- a/src/components/datepicker/DatePickerInput.tsx
+++ b/src/components/datepicker/DatePickerInput.tsx
@@ -142,9 +142,9 @@ const DatePickerInput: GenericComponent<DatePickerInputProps> = ({
         value={getFormattedDate()}
         width="120px"
         noInputStyling={dayPickerProps && dayPickerProps.withMonthPicker}
+        {...inputProps}
         onClick={handleInputClick}
         onFocus={handleInputFocus}
-        {...inputProps}
       />
       <Popover
         active={isPopoverActive}


### PR DESCRIPTION
### Description

[This](https://github.com/teamleadercrm/ui/commit/3c3c088e907645e6f98c3d7ebd2a3cbca4903f83) was in JS before.

These two functions will never be called if the props are there, `handleInputFocus` and `handleInputClick`, which have been created to handle the onFocus and onClick(props) inside these two functions.

Now when focussing a field its not possible to do something else, and also we're having [this](https://github.com/teamleadercrm/core/pull/28046) bug. This PR fixes it, and also works as intended.


