### PR TITLE
[FRAF-772] Add message prop in Select for replacing default "No options" label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `Select`: add `noOptionsMessage` prop for replacing no option label ([@eniskraasniqi1](https://github.com/eniskraasniqi1)) in [#2286](https://github.com/teamleadercrm/ui/pull/2286))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -363,8 +363,19 @@ class Select extends PureComponent {
   });
 
   render() {
-    const { components, creatable, error, inverse, helpText, size, success, warning, forwardedRef, ...otherProps } =
-      this.props;
+    const {
+      components,
+      noOptionsMessage = 'No options',
+      creatable,
+      error,
+      inverse,
+      helpText,
+      size,
+      success,
+      warning,
+      forwardedRef,
+      ...otherProps
+    } = this.props;
 
     const boxProps = pickBoxProps(otherProps);
     const restProps = omitBoxProps(otherProps);
@@ -393,6 +404,7 @@ class Select extends PureComponent {
           menuShouldBlockScroll
           styles={this.getStyles()}
           size={size}
+          noOptionsMessage={() => noOptionsMessage}
           {...restProps}
         />
         <ValidationText error={error} help={helpText} inverse={inverse} success={success} warning={warning} />
@@ -428,6 +440,8 @@ Select.propTypes = {
   warning: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   /** A custom width for the input field */
   width: PropTypes.string,
+  /** Message shown where are no options */
+  noOptionsMessage: PropTypes.string,
 };
 
 Select.defaultProps = {


### PR DESCRIPTION
### Description

The default "No options" Label is not translatable, so I added a prop which accepts a string and replaces the default one.
