### PR TITLE
Add marketing dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- `MarketingDialog`: Added new component ([@lorgan3](https://github.com/lorgan3) in [#2287](https://github.com/teamleadercrm/ui/pull/2287))
+
 ### Changed
 
 ### Deprecated

--- a/src/components/marketingButton/MarketingButton.tsx
+++ b/src/components/marketingButton/MarketingButton.tsx
@@ -8,7 +8,7 @@ import { BoxProps } from '../box/Box';
 import { SIZES } from '../../constants/sizes';
 import { GenericComponent } from '../../@types/types';
 
-interface MarketingButtonProps extends Omit<BoxProps, 'ref' | 'element'> {
+export interface MarketingButtonProps extends Omit<BoxProps, 'ref' | 'element'> {
   /** The content to display inside the button. */
   children?: ReactNode;
   /** A class name for the button to give custom styles. */

--- a/src/components/marketingDialog/MarketingDialog.tsx
+++ b/src/components/marketingDialog/MarketingDialog.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, ReactElement, ReactNode } from 'react';
+import React, { cloneElement, ReactElement, ReactNode, useRef } from 'react';
 import { DialogBase } from '../dialog';
 import theme from './theme.css';
 import { Heading1, Heading3, TextBody } from '../typography';
@@ -32,6 +32,8 @@ const MarketingDialog = ({
   primaryAction,
   secondaryAction,
 }: MarketingDialogProps) => {
+  const ctaRef = useRef<HTMLButtonElement>(null);
+
   return (
     <DialogBase
       active={active}
@@ -39,6 +41,7 @@ const MarketingDialog = ({
       onEscKeyDown={onEscKeyDown}
       onOverlayClick={onOverlayClick}
       className={theme['marketing-dialog']}
+      initialFocusRef={ctaRef}
     >
       <DialogBase.Header onCloseClick={onCloseClick}>
         <Heading3>{title}</Heading3>
@@ -63,7 +66,7 @@ const MarketingDialog = ({
           </TextBody>
 
           <Flex direction="column" alignItems="center" gap={3}>
-            <MarketingButton {...primaryAction} level="primary" fullWidth />
+            <MarketingButton ref={ctaRef} {...primaryAction} level="primary" fullWidth />
             {secondaryAction && <MarketingButton {...secondaryAction} level="link" />}
           </Flex>
         </Box>

--- a/src/components/marketingDialog/MarketingDialog.tsx
+++ b/src/components/marketingDialog/MarketingDialog.tsx
@@ -1,9 +1,75 @@
-import React from 'react';
+import React, { cloneElement, ReactElement, ReactNode } from 'react';
+import { DialogBase } from '../dialog';
+import theme from './theme.css';
+import { Heading1, Heading3, TextBody } from '../typography';
+import Box from '../box';
+import MarketingButton from '../marketingButton';
+import { MarketingButtonProps } from '../marketingButton/MarketingButton';
+import Flex from '../flex';
 
-interface MarketingDialogProps {}
+interface MarketingDialogProps {
+  active: boolean;
+  onCloseClick?: () => void;
+  onEscKeyDown?: () => void;
+  onOverlayClick?: () => void;
+  title: string;
+  graphic: ReactElement;
+  subtitle: string;
+  body: ReactNode;
+  primaryAction: Omit<MarketingButtonProps, 'level' | 'fullWidth'>;
+  secondaryAction?: Omit<MarketingButtonProps, 'level'>;
+}
 
-const MarketingDialog = (props: MarketingDialogProps) => {
-  return <div />;
+const MarketingDialog = ({
+  active,
+  onCloseClick,
+  onEscKeyDown,
+  onOverlayClick,
+  title,
+  graphic,
+  subtitle,
+  body,
+  primaryAction,
+  secondaryAction,
+}: MarketingDialogProps) => {
+  return (
+    <DialogBase
+      active={active}
+      onCloseClick={onCloseClick}
+      onEscKeyDown={onEscKeyDown}
+      onOverlayClick={onOverlayClick}
+      className={theme['marketing-dialog']}
+    >
+      <DialogBase.Header onCloseClick={onCloseClick}>
+        <Heading3>{title}</Heading3>
+      </DialogBase.Header>
+
+      <DialogBase.Body
+        scrollable
+        display="flex"
+        flexDirection="row"
+        padding={6}
+        justifyContent="space-between"
+        alignItems="center"
+      >
+        <Box borderWidth={1} borderRadius="rounded" overflow="hidden">
+          {cloneElement(graphic, { width: '480', height: '270', className: theme['marketing-dialog-graphic'] })}
+        </Box>
+
+        <Box className={theme['marketing-dialog-text']}>
+          <Heading1>{subtitle}</Heading1>
+          <TextBody marginTop={3} marginBottom={4}>
+            {body}
+          </TextBody>
+
+          <Flex direction="column" alignItems="center" gap={3}>
+            <MarketingButton {...primaryAction} level="primary" fullWidth />
+            {secondaryAction && <MarketingButton {...secondaryAction} level="link" />}
+          </Flex>
+        </Box>
+      </DialogBase.Body>
+    </DialogBase>
+  );
 };
 
 export default MarketingDialog;

--- a/src/components/marketingDialog/MarketingDialog.tsx
+++ b/src/components/marketingDialog/MarketingDialog.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+interface MarketingDialogProps {}
+
+const MarketingDialog = (props: MarketingDialogProps) => {
+  return <div />;
+};
+
+export default MarketingDialog;

--- a/src/components/marketingDialog/MarketingDialog.tsx
+++ b/src/components/marketingDialog/MarketingDialog.tsx
@@ -8,15 +8,25 @@ import { MarketingButtonProps } from '../marketingButton/MarketingButton';
 import Flex from '../flex';
 
 interface MarketingDialogProps {
+  /** If true, the dialog will show on screen. */
   active: boolean;
+  /** Callback function that is fired when the close icon clicked. */
   onCloseClick?: () => void;
+  /** Callback function that is fired when the escape key is pressed. */
   onEscKeyDown?: () => void;
+  /** Callback function that is fired when the mouse clicks on the overlay. */
   onOverlayClick?: () => void;
+  /** The title of the dialog. */
   title: string;
-  graphic: ReactElement;
+  /** React component for a graphic on the left of the dialog. It should be able to receive a width, height and className like an img or iframe. */
+  graphic: ReactElement<{ width: string; height: string; className: string }>;
+  /** The subtitle of the dialog. */
   subtitle: string;
+  /** The body of the dialog. */
   body: ReactNode;
+  /** Object containing the props of the primary action / call to action. */
   primaryAction: Omit<MarketingButtonProps, 'level' | 'fullWidth'>;
+  /** Object containing the props of the secondary action / call to action. */
   secondaryAction?: Omit<MarketingButtonProps, 'level'>;
 }
 

--- a/src/components/marketingDialog/MarketingDialog.tsx
+++ b/src/components/marketingDialog/MarketingDialog.tsx
@@ -27,7 +27,7 @@ interface MarketingDialogProps {
   /** Object containing the props of the primary action / call to action. */
   primaryAction: Omit<MarketingButtonProps, 'level' | 'fullWidth'>;
   /** Object containing the props of the secondary action / call to action. */
-  secondaryAction?: Omit<MarketingButtonProps, 'level'>;
+  secondaryAction?: Omit<MarketingButtonProps, 'level' | 'fullWidth'>;
 }
 
 const MarketingDialog = ({
@@ -77,7 +77,7 @@ const MarketingDialog = ({
 
           <Flex direction="column" alignItems="center" gap={3}>
             <MarketingButton ref={ctaRef} {...primaryAction} level="primary" fullWidth />
-            {secondaryAction && <MarketingButton {...secondaryAction} level="link" />}
+            {secondaryAction && <MarketingButton {...secondaryAction} level="link" fullWidth />}
           </Flex>
         </Box>
       </DialogBase.Body>

--- a/src/components/marketingDialog/index.ts
+++ b/src/components/marketingDialog/index.ts
@@ -1,0 +1,4 @@
+import MarketingDialog from './MarketingDialog';
+
+export default MarketingDialog;
+export { MarketingDialog };

--- a/src/components/marketingDialog/marketingDialog.stories.tsx
+++ b/src/components/marketingDialog/marketingDialog.stories.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { addStoryInGroup, MARKETING } from '../../../.storybook/utils';
+
+import MarketingDialog from './MarketingDialog';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+export default {
+  component: MarketingDialog,
+  title: addStoryInGroup(MARKETING, 'MarketingDialog'),
+
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/6nbw3mXc6VpIOYrbmUxn8C/Teamleader-Marketing-components?node-id=926%3A5336',
+    },
+  },
+} as ComponentMeta<typeof MarketingDialog>;
+
+export const Basic: ComponentStory<typeof MarketingDialog> = (props) => <MarketingDialog {...props} />;
+
+Basic.args = {};

--- a/src/components/marketingDialog/marketingDialog.stories.tsx
+++ b/src/components/marketingDialog/marketingDialog.stories.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { addStoryInGroup, MARKETING } from '../../../.storybook/utils';
 
 import MarketingDialog from './MarketingDialog';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
+import Button from '../button';
 
 export default {
   component: MarketingDialog,
@@ -16,6 +17,43 @@ export default {
   },
 } as ComponentMeta<typeof MarketingDialog>;
 
-export const Basic: ComponentStory<typeof MarketingDialog> = (props) => <MarketingDialog {...props} />;
+export const Basic: ComponentStory<typeof MarketingDialog> = (props) => {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const toggleDialog = () => {
+    setDialogOpen((dialogOpen) => !dialogOpen);
+  };
 
-Basic.args = {};
+  return (
+    <>
+      <Button onClick={toggleDialog} label="Open a dialog" />
+      <MarketingDialog
+        {...props}
+        active={dialogOpen}
+        onCloseClick={toggleDialog}
+        onEscKeyDown={toggleDialog}
+        onOverlayClick={toggleDialog}
+      />
+    </>
+  );
+};
+
+Basic.args = {
+  active: true,
+  title: 'Discover our packages for free',
+  graphic: <iframe src="https://fast.wistia.net/embed/iframe/f7928s2ype?controlsVisibleOnLoad=false&playButton=true" />,
+  subtitle: 'Create multiple quotations',
+  body: (
+    <>
+      Switch to a package and improve your sales process by <strong>creating and sending multiple quotations</strong> in
+      one deal.
+    </>
+  ),
+  primaryAction: {
+    children: 'Try for free',
+    onClick: () => console.log('primaryAction.onClick'),
+  },
+  secondaryAction: {
+    children: 'Read more',
+    onClick: () => console.log('secondaryAction.onClick'),
+  },
+};

--- a/src/components/marketingDialog/theme.css
+++ b/src/components/marketingDialog/theme.css
@@ -1,0 +1,16 @@
+.marketing-dialog {
+  width: 900px;
+
+  &-text {
+    width: 300px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &-graphic {
+    width: 480px;
+    height: 270px;
+    display: block;
+    border: none;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import Input, { InputBase, NumericInput, Textarea, TimeInput, DurationInput } fr
 import Menu, { IconMenu, MenuItem, MenuDivider, MenuTitle } from './components/menu';
 import Link from './components/link';
 import MarketingButton from './components/marketingButton';
+import MarketingDialog from './components/marketingDialog';
 import MarketingButtonGroup from './components/marketingButtonGroup';
 import MarketingLink from './components/marketingLink';
 import MarketingLockBadge from './components/marketingLockBadge';
@@ -210,4 +211,5 @@ export {
   FULLSCREEN,
   Margin,
   Padding,
+  MarketingDialog,
 };


### PR DESCRIPTION
### Description

We're moving the implementation of the Marketing Dialog to the ui library so we can have a consistent and documented dialog for this everywhere.

#### Screenshot before this PR

/

#### Screenshot after this PR

![image](https://user-images.githubusercontent.com/1833617/179246853-4c8f128a-3e9a-4106-9627-b7c124818934.png)


### Breaking changes

/
