### PR TITLE
Set minimum node version to 14.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
   "main": "cjs/index.js",
   "module": "es/index.js",
   "engines": {
-    "node": "^12 || ^14 || >=16"
+    "node": "^14.15.0 || >=16"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description

`postcss-loader` v7 supports min mode version 14.15.0

### Breaking changes

- minimum supported `Node.js` version is `14.15.0`