### PR TITLE
Add project token as an env variable

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -15,3 +15,4 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
         env:
           CHROMATIC: true
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
Chromatic keeps failing because the project token is missing even though it seems configured correctly.
Let's try passing it as an env variable instead.