### PR TITLE
[FRAF-873] - Pass onClick to the wrapper of checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Checkbox`: pass `onClick` prop to the parent container ([@eniskraasniqi1](https://github.com/eniskraasniqi1)) in [#2314](https://github.com/teamleadercrm/ui/pull/2314))
+
 ### Dependency updates
 
 ## [16.0.0] - 2022-07-20

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -55,7 +55,7 @@ const Checkbox: GenericComponent<CheckboxProps> = forwardRef<HTMLInputElement, C
     const IconCheckmark = size === 'large' ? IconCheckmarkMediumOutline : IconCheckmarkSmallOutline;
 
     const restProps = omit(others, ['onChange']);
-    const boxProps = pickBoxProps(restProps);
+    const boxProps = { ...pickBoxProps(restProps), onClick: restProps.onClick };
     const inputProps = omitBoxProps(restProps);
 
     const classNames = cx(


### PR DESCRIPTION
### Description

When using checkbox on a Datagrid Row, currently when clicking the checkbox triggers the row to be clicked also. 
This is happening because we're not passing the onClick to the container, so when trying stopPropagation it does nothing. 

### Manual check
- Link ui locally with core [PR](https://github.com/teamleadercrm/core/pull/28409)
- Go to one of the new company detail pages, and create a time tracking in the unbilled time widget
- Click Checkbox, it shouldn't trigger row click