### PR TITLE
Release/16.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@
 
 ### Fixed
 
-- `Checkbox`: pass `onClick` prop to the parent container ([@eniskraasniqi1](https://github.com/eniskraasniqi1)) in [#2314](https://github.com/teamleadercrm/ui/pull/2314))
-
 ### Dependency updates
+
+## [16.0.1] - 2022-08-08
+
+### Fixed
+
+- `Checkbox`: pass `onClick` prop to the parent container ([@eniskraasniqi1](https://github.com/eniskraasniqi1)) in [#2314](https://github.com/teamleadercrm/ui/pull/2314))
 
 ## [16.0.0] - 2022-07-20
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [16.0.1] - 2022-08-08

### Fixed

- `Checkbox`: pass `onClick` prop to the parent container ([@eniskraasniqi1](https://github.com/eniskraasniqi1)) in [#2314](https://github.com/teamleadercrm/ui/pull/2314))

