### PR TITLE
[FRAF-791] - Pass other props from DialogBase to Overlay

### DIFF
--- a/src/components/dialog/DialogBase.tsx
+++ b/src/components/dialog/DialogBase.tsx
@@ -60,6 +60,7 @@ export const DialogBase: DialogBaseComponent = ({
   dragHandleRef,
   form,
   onSubmit,
+  ...others
 }) => {
   const { ref, FocusRing } = useFocusTrap({ active, initialFocusRef });
   useDraggable({ active, dragTargetRef: ref, dragHandleRef });
@@ -86,6 +87,7 @@ export const DialogBase: DialogBaseComponent = ({
             className={theme['overlay']}
             onOverlayClick={onOverlayClick}
             onEscKeyDown={onEscKeyDown}
+            {...others}
           >
             <FocusRing>
               <Box

--- a/src/components/overlay/Overlay.tsx
+++ b/src/components/overlay/Overlay.tsx
@@ -5,8 +5,9 @@ import theme from './theme.css';
 import { KEY } from '../../constants';
 import { selectOverlayNode } from '../select/Select';
 import { GenericComponent } from '../../@types/types';
+import { BoxProps } from '../box/Box';
 
-export interface OverlayProps {
+export interface OverlayProps extends Omit<BoxProps, 'className' | 'children'> {
   active?: boolean;
   backdrop?: string;
   children?: ReactNode;


### PR DESCRIPTION
### Issue

https://teamleader.atlassian.net/browse/FRAF-791

### Description

There has been introduced a bug ([Commit](https://github.com/teamleadercrm/ui/commit/cccf75a10e89c7605917d420c274dfe1176621de)) with the overlapping of z-index between new dialog and legacy one. 
Since we don't have z-index stack order for this, and changing it back will bring the issue which Arnaud mentioned on the commit, I went for passing the style prop individually in case if needed.

This PR allows other props being passed on Dialog -> Overlay, so then custom z-index can be passed.

#### Screenshot before this PR

![before](https://user-images.githubusercontent.com/41387389/186909192-efb777ff-ca9a-40fc-8b8f-3595d72e96e2.png)


#### Screenshot after this PR

![After](https://user-images.githubusercontent.com/41387389/186909590-79a731a1-fbf6-4ac4-a473-9f6843f96e03.png)
