### PR TITLE
[FRAF-909] - Fix bug (first item getting focused on menu item)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `MenuItem`: Pass `tabIndex` attribute to the li element so the first item doesn't get focused by default. ([@eniskraasniqi1](https://github.com/eniskraasniqi1)) in [#2344](https://github.com/teamleadercrm/ui/pull/2344))
+
 ### Dependency updates
 
 ## [16.0.2] - 2022-08-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixed
 
-- `MenuItem`: Pass `tabIndex` attribute to the li element so the first item doesn't get focused by default. ([@eniskraasniqi1](https://github.com/eniskraasniqi1)) in [#2344](https://github.com/teamleadercrm/ui/pull/2344))
+- `MenuItem`: Append invisible element before rendering menu items, so the first item doesn't get focused by default. ([@eniskraasniqi1](https://github.com/eniskraasniqi1)) in [#2344](https://github.com/teamleadercrm/ui/pull/2344))
 
 ### Dependency updates
 

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -233,6 +233,10 @@ const Menu: GenericComponent<MenuProps> = ({
         />
       )}
       <ul ref={menuNode} className={theme['menu-inner']} style={getMenuStyle()}>
+        {/* An invisible element so the first element doesn't look like its selected or focused */}
+        <Box className={theme['invisible-menu-item']} data-teamleader-ui="menu-item" element="li">
+          <Box element="button" />
+        </Box>
         {getItems()}
       </ul>
     </Box>

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -68,7 +68,7 @@ const MenuItem: GenericComponent<MenuItemProps> = ({
   const restProps = omitBoxProps(others);
 
   return (
-    <Box {...boxProps} data-teamleader-ui="menu-item" display="flex" element="li">
+    <Box {...boxProps} data-teamleader-ui="menu-item" display="flex" element="li" tabIndex={-1}>
       <Box
         onClick={handleClick}
         alignItems="center"

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -68,7 +68,7 @@ const MenuItem: GenericComponent<MenuItemProps> = ({
   const restProps = omitBoxProps(others);
 
   return (
-    <Box {...boxProps} data-teamleader-ui="menu-item" display="flex" element="li" tabIndex={-1}>
+    <Box {...boxProps} data-teamleader-ui="menu-item" display="flex" element="li">
       <Box
         onClick={handleClick}
         alignItems="center"

--- a/src/components/menu/theme.css
+++ b/src/components/menu/theme.css
@@ -110,6 +110,11 @@
   }
 }
 
+.invisible-menu-item {
+  opacity: 0;
+  height: 0;
+}
+
 .outline {
   background-color: var(--menu-background-color);
   border-radius: var(--menu-outline-border-radius);


### PR DESCRIPTION
### Description

#### Link - https://teamleader.atlassian.net/browse/FRAF-909

Menu item was getting focused on initial render, since the focus selector wasn't working correctly. According to this [stackoverflow answer](https://stackoverflow.com/a/49329527/10006363), in order for focus to work correctly on an `li` element it should have `tabIndex="-1"`.

(EDIT) - Went for the invisible element solution.

#### Screenshot before this PR

![Screen Shot 2022-09-04 at 18 39 47](https://user-images.githubusercontent.com/41387389/188324015-de8c6a5b-eae5-44c2-84d8-c633a4c729dc.png)

#### Screenshot after this PR

![Screen Shot 2022-09-04 at 18 41 22](https://user-images.githubusercontent.com/41387389/188324082-8b72b0ae-4f8c-42d0-b674-05b861e2acc7.png)

### Manual check
- Link core with ui locally
- Go to an invoice detail page
- Click the 3 dots icon, the first item should not be focused.
