### PR TITLE
Fix close button alignment issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ### Dependency updates
 
-- `storybook`: Bump storybook from 6.5.9 to 6.5.10 ([@KristofColpaert](https://github.com/KristofColpaert)) in  [#2327](https://github.com/teamleadercrm/ui/pull/2327)
+- `storybook`: Bump storybook from 6.5.9 to 6.5.10 ([@KristofColpaert](https://github.com/KristofColpaert)) in [#2327](https://github.com/teamleadercrm/ui/pull/2327)
 
 ## [16.0.1] - 2022-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Dialog`: Fix close button alignment in cases where css order changes during build. ([@lorgan3](https://github.com/lorgan3)) in [#2351](https://github.com/teamleadercrm/ui/pull/2351))
+
 ### Dependency updates
 
 ## [16.0.3] - 2022-09-05

--- a/src/components/dialog/theme.css
+++ b/src/components/dialog/theme.css
@@ -29,6 +29,10 @@
   transition-delay: var(--animation-delay);
   width: 100vw;
   z-index: 2;
+
+  .close-icon {
+    margin-left: auto;
+  }
 }
 
 .inner {
@@ -88,10 +92,6 @@
   cursor: move;
   margin: calc(-1 * var(--spacer-regular));
   padding: var(--spacer-regular);
-}
-
-.close-icon {
-  margin-left: auto;
 }
 
 .scroll-shadow {


### PR DESCRIPTION
### Description

Make the close-button css more specific in order to solve an issue that the transformed css is not in the same order as in development.

Doesn't seem like this requires a changelog entry since I think this is coupled to our build process in core but happy to add one if necessary.

Sharing before and after screenshot in a google doc in case this contains info that shouldn't be public yet
https://docs.google.com/document/d/1B8PC6TQWwYPaxgWwpn3X7QRabuLdqTy-nJkHo6QaOKA/edit?usp=sharing
