### PR TITLE
Made children prop of Tooltip optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Tooltip`: `children` prop is optional ([@qubis741](https://github.com/qubis741)) in [#2364](https://github.com/teamleadercrm/ui/pull/2364))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -44,7 +44,7 @@ const SIZE_MAP: Record<AllowedSize, BoxProps> = {
 };
 
 interface TooltippedComponentProps {
-  children: ReactNode;
+  children?: ReactNode;
   className?: string;
   onClick?: MouseEventHandler;
   onMouseEnter?: MouseEventHandler;


### PR DESCRIPTION
### Changed

- `Tooltip`: `children` prop is optional 

Sometimes, we use it without children in our codebase, its just visual block .
![Screenshot 2022-09-16 at 13 18 51](https://user-images.githubusercontent.com/9944471/190627570-644469ce-1d35-4c50-946a-251abbbf386f.png)

### Manuel check
N/A