### PR TITLE
[TIDAL-2600] Increase marketing dialog text width

### DIFF
--- a/src/components/dialog/DialogBase.tsx
+++ b/src/components/dialog/DialogBase.tsx
@@ -31,7 +31,7 @@ export interface DialogBaseProps extends Omit<BoxProps, 'form' | 'size'> {
   /** If true, the content of the dialog will be scrollable when it exceeds the available height. */
   scrollable?: boolean;
   /** The size of the dialog. */
-  size?: Exclude<typeof SIZES[number], 'tiny' | 'smallest' | 'hero'>;
+  size?: Exclude<typeof SIZES[number], 'tiny' | 'smallest'>;
   /** The initial part of the dialog where the focus will be set, useful to avoid focusing on the close button */
   initialFocusRef?: RefObject<HTMLElement>;
   /** The element used to drag a dialog, @see Dialog component header for an example */

--- a/src/components/marketingDialog/MarketingDialog.tsx
+++ b/src/components/marketingDialog/MarketingDialog.tsx
@@ -52,6 +52,7 @@ const MarketingDialog = ({
       onOverlayClick={onOverlayClick}
       className={theme['marketing-dialog']}
       initialFocusRef={ctaRef}
+      size="hero"
     >
       <DialogBase.Header onCloseClick={onCloseClick}>
         <Heading3>{title}</Heading3>

--- a/src/components/marketingDialog/theme.css
+++ b/src/components/marketingDialog/theme.css
@@ -1,8 +1,8 @@
 .marketing-dialog {
-  width: 900px;
+  width: 1000px;
 
   &-text {
-    width: 300px;
+    width: 400px;
     display: flex;
     flex-direction: column;
   }

--- a/src/components/marketingDialog/theme.css
+++ b/src/components/marketingDialog/theme.css
@@ -1,8 +1,6 @@
 .marketing-dialog {
-  width: 1000px;
-
   &-text {
-    width: 400px;
+    width: 385px;
     display: flex;
     flex-direction: column;
   }


### PR DESCRIPTION
### Description

The translations for the Customer Meeting interstitial dialog in core are too long to fit in the primary button.
Think the best way here is to just increase the width.
Translation should fit in the button in every language now.

#### Screenshot before this PR

![image](https://user-images.githubusercontent.com/55881661/190989887-88f91c69-b5bd-41b0-97a3-56a6cdf36522.png)

#### Screenshot after this PR

![image](https://user-images.githubusercontent.com/55881661/190989955-f080a2fb-459f-4aa1-9bd9-bbe48f0e981a.png)


### Breaking changes

N/A
