### PR TITLE
Fix tooltip tooltipActive prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Tooltip`: `tooltipActive` correctly close tooltip when prop is removed to restore behavior before 16.1.0 ([@lorgan3](https://github.com/lorgan3)) in [#2374](https://github.com/teamleadercrm/ui/pull/2374))
+
 ### Dependency updates
 
 ## [16.2.0] - 2022-09-20

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -83,7 +83,7 @@ const TooltippedComponent: GenericComponent<TooltippedComponentProps> = ({
   onClick,
   onMouseEnter,
   onMouseLeave,
-  tooltipActive = null,
+  tooltipActive,
   ComposedComponent,
   ...other
 }) => {
@@ -220,7 +220,7 @@ const TooltippedComponent: GenericComponent<TooltippedComponentProps> = ({
     ref,
   };
 
-  if (tooltipActive === null) {
+  if (tooltipActive === undefined) {
     childProps = {
       ...childProps,
       onClick: handleClick,

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -193,20 +193,14 @@ const TooltippedComponent: GenericComponent<TooltippedComponentProps> = ({
   };
 
   useEffect(() => {
-    if (tooltipActive) {
+    if (tooltipActive && !active) {
       activate(calculatePosition(ref.current));
     }
 
-    if (tooltipActive) {
-      if (tooltipActive && !active) {
-        activate(calculatePosition(ref.current));
-      }
-
-      if (!tooltipActive && active) {
-        setActive(false);
-      }
+    if (!tooltipActive && active) {
+      setActive(false);
     }
-  }, [tooltipActive, active]);
+  }, [tooltipActive]);
 
   const rest = omit(other, [
     'onTooltipEntered',

--- a/src/components/tooltip/tooltip.stories.tsx
+++ b/src/components/tooltip/tooltip.stories.tsx
@@ -29,7 +29,6 @@ const defaultTooltipProps = {
   tooltipColor: 'white',
   tooltipPosition: 'horizontal',
   tooltipSize: 'medium',
-  tooltipActive: null,
 };
 const tooltipArgTypes = {
   tooltipColor: {
@@ -46,7 +45,7 @@ const tooltipArgTypes = {
   },
   tooltipActive: {
     control: 'select',
-    options: [null, true, false],
+    options: [undefined, true, false],
   },
 };
 


### PR DESCRIPTION
### Description

When the tooltip was converted to a functional component there was a small change in behaviour regarding the `tooltipActive` prop. When setting it to `undefined`/`null` it used close and this was no longer the case.
I've also remove the default `null` since it's weird that `null` is not a valid type for it, but internally it can be.

#### Screenshot before this PR


https://user-images.githubusercontent.com/1833617/191789281-32313c03-6676-4779-a342-48c839b84fdc.mov


#### Screenshot after this PR


https://user-images.githubusercontent.com/1833617/191789430-70050c5e-e950-40e6-acbe-72ff5e3227ff.mov

