### PR TITLE
Release/16.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@
 
 ### Fixed
 
-- `Tooltip`: `tooltipActive` correctly close tooltip when prop is removed to restore behavior before 16.1.0 ([@lorgan3](https://github.com/lorgan3)) in [#2374](https://github.com/teamleadercrm/ui/pull/2374))
-
 ### Dependency updates
+
+## [16.2.1] - 2022-09-23
+
+### Fixed
+
+- `Tooltip`: `tooltipActive` correctly close tooltip when prop is removed to restore behavior before 16.1.0 ([@lorgan3](https://github.com/lorgan3)) in [#2374](https://github.com/teamleadercrm/ui/pull/2374))
 
 ## [16.2.0] - 2022-09-20
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "16.2.0",
+  "version": "16.2.1",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [16.2.1] - 2022-09-23

### Fixed

- `Tooltip`: `tooltipActive` correctly close tooltip when prop is removed to restore behavior before 16.1.0 ([@lorgan3](https://github.com/lorgan3)) in [#2374](https://github.com/teamleadercrm/ui/pull/2374))