### PR TITLE
Release/16.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@
 
 ### Fixed
 
-- `DatePickerInput`: fix the DatePicker input value not changing if the selectedDate prop changes and extend `DayPickerProps` with React's DayPickerProps ([@BeirlaenAaron](https://github.com/BeirlaenAaron)) in [#2376](https://github.com/teamleadercrm/ui/pull/2376))
-
 ### Dependency updates
+
+## [16.2.2] - 2022-09-26
+
+### Fixed
+
+- `DatePickerInput`: fix the DatePicker input value not changing if the selectedDate prop changes and extend `DayPickerProps` with React's DayPickerProps ([@BeirlaenAaron](https://github.com/BeirlaenAaron)) in [#2376](https://github.com/teamleadercrm/ui/pull/2376))
 
 ## [16.2.1] - 2022-09-23
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "16.2.1",
+  "version": "16.2.2",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [16.2.2] - 2022-09-26

### Fixed

- `DatePickerInput`: fix the DatePicker input value not changing if the selectedDate prop changes and extend `DayPickerProps` with React's DayPickerProps ([@BeirlaenAaron](https://github.com/BeirlaenAaron)) in [#2376](https://github.com/teamleadercrm/ui/pull/2376))