### PR TITLE
Numeric input stepper customisation

### DIFF
--- a/.storybook/stories/playground/numericInput.stories.tsx
+++ b/.storybook/stories/playground/numericInput.stories.tsx
@@ -1,0 +1,71 @@
+import React, { ChangeEvent, useState } from 'react';
+import { addStoryInGroup, PLAYGROUND } from '../../utils';
+import { Banner, Box, NumericInput, UITextBody } from '../../../src';
+import { useCallback } from '@storybook/addons';
+
+export default {
+  title: addStoryInGroup(PLAYGROUND, 'Forms'),
+
+  parameters: {
+    info: {
+      source: false,
+      propTables: false,
+    },
+  },
+};
+
+export const numericInput = () => {
+  const [value, setValue] = useState<number>(3);
+  const [hasMinErrorVisible, setMinErrorVisible] = useState<boolean>(false);
+  const [hasMaxErrorVisible, setMaxErrorVisible] = useState<boolean>(false);
+
+  const min = 1;
+  const max = 10;
+
+  const handleChange = useCallback((event) => {
+    const newValue = (event as ChangeEvent<HTMLInputElement>).target.valueAsNumber;
+    setValue(newValue);
+    setMaxErrorVisible(newValue > max);
+    setMinErrorVisible(newValue < min);
+  });
+
+  const handleDecreaseClick = useCallback(() => {
+    setMinErrorVisible(value === min);
+    setMaxErrorVisible(false);
+  });
+
+  const handleIncreaseClick = useCallback(() => {
+    setMaxErrorVisible(value === max);
+    setMinErrorVisible(false);
+  });
+
+  return (
+    <Box style={{ maxWidth: '300px', gap: '12px' }} display="flex" flexDirection="column">
+      <NumericInput
+        stepper="connected"
+        decreaseDisabled={hasMinErrorVisible}
+        increaseDisabled={hasMaxErrorVisible}
+        onDecreaseMouseDown={handleDecreaseClick}
+        onIncreaseMouseDown={handleIncreaseClick}
+        min={min}
+        max={max}
+        value={value}
+        onChange={handleChange}
+      />
+      {hasMinErrorVisible && (
+        <Banner color="ruby">
+          <UITextBody>
+            Must be {'>='} {min}
+          </UITextBody>
+        </Banner>
+      )}
+      {(hasMaxErrorVisible || value === max) && (
+        <Banner color={hasMaxErrorVisible ? 'ruby' : 'aqua'}>
+          <UITextBody>You have reached the maximum amount ({max})</UITextBody>
+        </Banner>
+      )}
+    </Box>
+  );
+};
+
+numericInput.storyName = 'Numeric input stepper control';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - `DatePickerInput`: `clearable` prop ([@qubis741](https://github.com/qubis741)) in [#2387](https://github.com/teamleadercrm/ui/pull/2387))
+- `NumericInput`: Added `decreaseDisabled`, `increaseDisabled`, `onDecreaseMouseDown` and `onIncreaseMouseDown` props which allow fine-grained control over disabling decrease and increase stepper buttons. ([@jelledc](https://github.com/jelledc) in [#2380](https://github.com/teamleadercrm/ui/pull/2380))
 
 ### Changed
 

--- a/src/components/input/NumericInput.tsx
+++ b/src/components/input/NumericInput.tsx
@@ -66,6 +66,10 @@ export interface NumericInputProps
   connectedLeft?: ReactElement;
   /** Element stuck to the right hand side of the component. */
   connectedRight?: ReactElement;
+  /** Boolean indicating whether the decrease button should be disabled. If not set, this will be derived from the min value. */
+  decreaseDisabled?: boolean;
+  /** Boolean indicating whether the increase button should be disabled. If not set, this will be derived from the max value */
+  increaseDisabled?: boolean;
   /** Boolean indicating whether the input should render as inverse. */
   inverse?: boolean;
   /** The maximum value that can be inputted. */
@@ -97,6 +101,8 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
     {
       connectedLeft,
       connectedRight,
+      decreaseDisabled,
+      increaseDisabled,
       inverse = false,
       max = Number.MAX_SAFE_INTEGER,
       min = Number.MIN_SAFE_INTEGER,
@@ -220,7 +226,7 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
       if (stepper === 'connected') {
         return (
           <Button
-            disabled={isMaxReached()}
+            disabled={typeof increaseDisabled !== 'undefined' ? increaseDisabled : isMaxReached()}
             icon={<IconAddSmallOutline />}
             onBlur={handleBlur}
             onMouseDown={handleIncreaseMouseDown}
@@ -238,7 +244,7 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
       if (stepper === 'connected') {
         return (
           <Button
-            disabled={isMinReached()}
+            disabled={typeof decreaseDisabled !== 'undefined' ? decreaseDisabled : isMinReached()}
             icon={<IconMinusSmallOutline />}
             onMouseDown={handleDecreaseMouseDown}
             onMouseUp={handleClearStepperTimer}
@@ -260,14 +266,14 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
           <StepperControls
             inverse={inverse}
             stepperUpProps={{
-              disabled: isMaxReached(),
+              disabled: typeof increaseDisabled !== 'undefined' ? increaseDisabled : isMaxReached(),
               onBlur: handleBlur,
               onMouseDown: handleIncreaseMouseDown,
               onMouseUp: handleClearStepperTimer,
               onMouseLeave: handleClearStepperTimer,
             }}
             stepperDownProps={{
-              disabled: isMinReached(),
+              disabled: typeof decreaseDisabled !== 'undefined' ? decreaseDisabled : isMinReached(),
               onBlur: handleBlur,
               onMouseDown: handleDecreaseMouseDown,
               onMouseUp: handleClearStepperTimer,

--- a/src/components/input/NumericInput.tsx
+++ b/src/components/input/NumericInput.tsx
@@ -263,7 +263,7 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
       if (stepper === 'connected') {
         return (
           <Button
-            disabled={typeof increaseDisabled !== 'undefined' ? increaseDisabled : isMaxReached()}
+            disabled={increaseDisabled ?? isMaxReached()}
             icon={<IconAddSmallOutline />}
             onBlur={handleBlur}
             onMouseDown={handleIncreaseMouseDown}
@@ -281,7 +281,7 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
       if (stepper === 'connected') {
         return (
           <Button
-            disabled={typeof decreaseDisabled !== 'undefined' ? decreaseDisabled : isMinReached()}
+            disabled={decreaseDisabled ?? isMinReached()}
             icon={<IconMinusSmallOutline />}
             onMouseDown={handleDecreaseMouseDown}
             onMouseUp={handleClearStepperDecreaseTimer}
@@ -303,14 +303,14 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
           <StepperControls
             inverse={inverse}
             stepperUpProps={{
-              disabled: typeof increaseDisabled !== 'undefined' ? increaseDisabled : isMaxReached(),
+              disabled: increaseDisabled ?? isMaxReached(),
               onBlur: handleBlur,
               onMouseDown: handleIncreaseMouseDown,
               onMouseUp: handleClearStepperIncreaseTimer,
               onMouseLeave: handleClearStepperIncreaseTimer,
             }}
             stepperDownProps={{
-              disabled: typeof decreaseDisabled !== 'undefined' ? decreaseDisabled : isMinReached(),
+              disabled: decreaseDisabled ?? isMinReached(),
               onBlur: handleBlur,
               onMouseDown: handleDecreaseMouseDown,
               onMouseUp: handleClearStepperDecreaseTimer,

--- a/src/components/input/NumericInput.tsx
+++ b/src/components/input/NumericInput.tsx
@@ -82,6 +82,10 @@ export interface NumericInputProps
   onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
   /** Callback function that is fired when the component's value changes. */
   onChange?: (event: ChangeEvent<HTMLElement>, value: string) => void;
+  /** Callback function that is fired on mouse down on the decrease button */
+  onDecreaseMouseDown?: () => void;
+  /** Callback function that is fired on mouse down on the increase button */
+  onIncreaseMouseDown?: () => void;
   /** Callback function that is fired when the keyboard is touched. */
   onKeyDown?: (event: KeyboardEvent<HTMLElement>) => void;
   /** Size of the input element. */
@@ -108,6 +112,8 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
       min = Number.MIN_SAFE_INTEGER,
       onBlur,
       onChange,
+      onDecreaseMouseDown,
+      onIncreaseMouseDown,
       onKeyDown,
       size,
       step = 1,
@@ -176,6 +182,14 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
     };
 
     const handleDecreaseMouseDown = () => {
+      if (onDecreaseMouseDown) {
+        onDecreaseMouseDown();
+
+        if (isMinReached()) {
+          return;
+        }
+      }
+
       handleDecreaseValue();
 
       timeoutRef.current = setTimeout(() => {
@@ -190,6 +204,14 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
     };
 
     const handleIncreaseMouseDown = () => {
+      if (onIncreaseMouseDown) {
+        onIncreaseMouseDown();
+
+        if (isMaxReached()) {
+          return;
+        }
+      }
+
       handleIncreaseValue();
 
       timeoutRef.current = setTimeout(() => {

--- a/src/components/input/NumericInput.tsx
+++ b/src/components/input/NumericInput.tsx
@@ -125,8 +125,10 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
     forwardedRef,
   ) => {
     const inputElementRef = useRef<HTMLElement | null>(null);
-    const timerRef = useRef<any>(null);
-    const timeoutRef = useRef<any>(null);
+    const decreaseTimerRef = useRef<any>(null);
+    const decreaseTimeoutRef = useRef<any>(null);
+    const increaseTimerRef = useRef<any>(null);
+    const increaseTimeoutRef = useRef<any>(null);
     const valueRef = useRef<string | number | undefined>(value);
 
     useEffect(() => {
@@ -176,10 +178,23 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
       updateStep(-1);
     };
 
-    const handleClearStepperTimer = () => {
-      clearTimeout(timeoutRef.current);
-      clearInterval(timerRef.current);
+    const handleClearStepperIncreaseTimer = () => {
+      clearTimeout(increaseTimeoutRef.current);
+      clearInterval(increaseTimerRef.current);
     };
+
+    useEffect(() => {
+      handleClearStepperIncreaseTimer();
+    }, [increaseDisabled]);
+
+    const handleClearStepperDecreaseTimer = () => {
+      clearTimeout(decreaseTimeoutRef.current);
+      clearInterval(decreaseTimerRef.current);
+    };
+
+    useEffect(() => {
+      handleClearStepperDecreaseTimer();
+    }, [decreaseDisabled]);
 
     const handleDecreaseMouseDown = () => {
       if (onDecreaseMouseDown) {
@@ -192,10 +207,10 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
 
       handleDecreaseValue();
 
-      timeoutRef.current = setTimeout(() => {
-        timerRef.current = setInterval(() => {
+      decreaseTimeoutRef.current = setTimeout(() => {
+        decreaseTimerRef.current = setInterval(() => {
           if (isMinReached()) {
-            handleClearStepperTimer();
+            handleClearStepperDecreaseTimer();
           } else {
             handleDecreaseValue();
           }
@@ -214,10 +229,10 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
 
       handleIncreaseValue();
 
-      timeoutRef.current = setTimeout(() => {
-        timerRef.current = setInterval(() => {
+      increaseTimeoutRef.current = setTimeout(() => {
+        increaseTimerRef.current = setInterval(() => {
           if (isMaxReached()) {
-            handleClearStepperTimer();
+            handleClearStepperIncreaseTimer();
           } else {
             handleIncreaseValue();
           }
@@ -252,8 +267,8 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
             icon={<IconAddSmallOutline />}
             onBlur={handleBlur}
             onMouseDown={handleIncreaseMouseDown}
-            onMouseUp={handleClearStepperTimer}
-            onMouseLeave={handleClearStepperTimer}
+            onMouseUp={handleClearStepperIncreaseTimer}
+            onMouseLeave={handleClearStepperIncreaseTimer}
             size={size}
           />
         );
@@ -269,8 +284,8 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
             disabled={typeof decreaseDisabled !== 'undefined' ? decreaseDisabled : isMinReached()}
             icon={<IconMinusSmallOutline />}
             onMouseDown={handleDecreaseMouseDown}
-            onMouseUp={handleClearStepperTimer}
-            onMouseLeave={handleClearStepperTimer}
+            onMouseUp={handleClearStepperDecreaseTimer}
+            onMouseLeave={handleClearStepperDecreaseTimer}
             onBlur={handleBlur}
             size={size}
           />
@@ -291,15 +306,15 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
               disabled: typeof increaseDisabled !== 'undefined' ? increaseDisabled : isMaxReached(),
               onBlur: handleBlur,
               onMouseDown: handleIncreaseMouseDown,
-              onMouseUp: handleClearStepperTimer,
-              onMouseLeave: handleClearStepperTimer,
+              onMouseUp: handleClearStepperIncreaseTimer,
+              onMouseLeave: handleClearStepperIncreaseTimer,
             }}
             stepperDownProps={{
               disabled: typeof decreaseDisabled !== 'undefined' ? decreaseDisabled : isMinReached(),
               onBlur: handleBlur,
               onMouseDown: handleDecreaseMouseDown,
-              onMouseUp: handleClearStepperTimer,
-              onMouseLeave: handleClearStepperTimer,
+              onMouseUp: handleClearStepperDecreaseTimer,
+              onMouseLeave: handleClearStepperDecreaseTimer,
             }}
           />,
         ];


### PR DESCRIPTION
### Description

Allow overriding a stepper button's `disabled` state and hooking into their `mouseDown` events. Allows fine-grained control over disabling decrease and increase stepper buttons.

https://user-images.githubusercontent.com/984441/192465833-062d4c63-3651-42e5-8cfa-4b38cb758808.mov

A manual check can be done in storybook under the playground's forms section.