### PR TITLE
[FRONT-116] Datepicker: use fixed amount of weeks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `DatePicker`: use a fixed amount of weeks to avoid it from jumping up and down when navigating between months ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2384](https://github.com/teamleadercrm/ui/pull/2384))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/datepicker/DatePicker.tsx
+++ b/src/components/datepicker/DatePicker.tsx
@@ -94,6 +94,7 @@ const DatePicker: GenericComponent<DatePickerProps> = ({
         selectedDays={selectedDate}
         weekdayElement={({ ...props }) => <WeekDay {...props} size={size} />}
         showWeekNumbers={showWeekNumbers}
+        fixedWeeks
         captionElement={
           withMonthPicker
             ? ({ date, locale, localeUtils }) => (

--- a/src/components/datepicker/datePicker.stories.tsx
+++ b/src/components/datepicker/datePicker.stories.tsx
@@ -65,7 +65,7 @@ singleDate.args = {
   selectedDate: new Date(),
   size: 'medium',
   withMonthPicker: true,
-  showWeekNumbers: true,
+  showWeekNumbers: false,
 };
 singleDate.parameters = {
   design: [


### PR DESCRIPTION
### Description

Use a fixed amount of weeks in the date picker, to avoid it from jumping up and down when navigating between months.

Also disabled the `showWeekNumbers` by default in the stories, cause it's not a default in the component, which is confusing.

#### Screenshot before this PR

![Screen Shot 2022-09-27 at 15 49 22](https://user-images.githubusercontent.com/330765/192466164-16eae594-d25f-4a3d-a3b3-b4dbaba89211.png)


#### Screenshot after this PR

![Screen Shot 2022-09-27 at 15 48 46](https://user-images.githubusercontent.com/330765/192466196-18e26df6-3832-4052-8a9b-f3a42b9dd733.png)



