### PR TITLE
Make date picker input cursor default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `DatePickerInput`: Remove 'text' cursor when hovering over input ([@lorgan3](https://github.com/lorgan3)) in [#2390](https://github.com/teamleadercrm/ui/pull/2390))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/datepicker/DatePickerInput.tsx
+++ b/src/components/datepicker/DatePickerInput.tsx
@@ -1,5 +1,4 @@
 import { IconCalendarSmallOutline, IconCloseBadgedSmallFilled } from '@teamleader/ui-icons';
-import cx from 'classnames';
 import React, { ReactNode, useEffect, useState } from 'react';
 import { DayPickerProps as ReactDayPickerProps } from 'react-day-picker';
 import DatePicker from '.';
@@ -160,7 +159,6 @@ const DatePickerInput: GenericComponent<DatePickerInputProps> = ({
   }, [others.selectedDate]);
 
   const boxProps = pickBoxProps(others);
-  const datePickerClassNames = cx(theme['date-picker-input'], theme[`is-${datePickerSize || size}`]);
 
   return (
     <Box className={className} {...boxProps}>
@@ -190,7 +188,7 @@ const DatePickerInput: GenericComponent<DatePickerInputProps> = ({
       >
         <Box overflowY="auto">
           <DatePicker
-            className={datePickerClassNames}
+            className={theme[`is-${datePickerSize || size}`]}
             onChange={handleDatePickerDateChange}
             selectedDate={selectedDate as Date}
             size={datePickerSize || size}

--- a/src/components/datepicker/DatePickerInput.tsx
+++ b/src/components/datepicker/DatePickerInput.tsx
@@ -173,6 +173,7 @@ const DatePickerInput: GenericComponent<DatePickerInputProps> = ({
         {...inputProps}
         onClick={handleInputClick}
         onFocus={handleInputFocus}
+        className={theme['date-picker-input']}
       />
       <Popover
         active={isPopoverActive}

--- a/src/components/datepicker/theme.css
+++ b/src/components/datepicker/theme.css
@@ -17,6 +17,12 @@
 
 .date-picker {
   display: inline-block;
+
+  &-input {
+    input {
+      cursor: default;
+    }
+  }
 }
 
 .is-bordered {

--- a/src/components/toast/theme.css
+++ b/src/components/toast/theme.css
@@ -46,7 +46,7 @@
 
   .action-link,
   .action-link:hover {
-    color: var(--color-teal-light);
+    color: var(--color-teal-light) !important;
   }
 
   .label {


### PR DESCRIPTION
### Description

- Remove the 'text' cursor from the datepickerinput because you cannot type in it.
- The color of the toast link was still not correct. I think unfortunately adding `!important` is required here

#### Screenshot before this PR
#### Screenshot after this PR
I cannot take screenshots of my cursor so imagine your cursor remains default when hovering over a date picker input 😅 

### Manual check
Check the datepicker input still looks corrrect
