### PR TITLE
Set menu width on month picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - `DatePickerInput`: Remove 'text' cursor when hovering over input ([@lorgan3](https://github.com/lorgan3)) in [#2390](https://github.com/teamleadercrm/ui/pull/2390))
+- `DatePicker`: Make MonthPicker dropdowns wider for medium and large sizes to fit month names better ([@lorgan3](https://github.com/lorgan3)) in [#2391](https://github.com/teamleadercrm/ui/pull/2391))
 
 ### Deprecated
 

--- a/src/components/datepicker/MonthPicker.tsx
+++ b/src/components/datepicker/MonthPicker.tsx
@@ -136,6 +136,7 @@ const MonthPickerSplit: GenericComponent<MonthPickerProps> = ({ date, locale, lo
           width={size === 'small' ? '88px' : '112px'}
           truncateOptionText
           size="small"
+          menuWidth="168px"
         />
         <NumericInput
           value={`${yearInput}`}


### PR DESCRIPTION
### Description

In medium month pickers most months were cut off, this pr solves that.
At first I played around with abbreviating the month but actually just making the menu wider made more sense

#### Screenshot before this PR

<img width="270" alt="image" src="https://user-images.githubusercontent.com/1833617/193030474-5cbff50c-b6bb-43fc-81db-1e0c26478ea2.png">

#### Screenshot after this PR

<img width="267" alt="image" src="https://user-images.githubusercontent.com/1833617/193030364-88e5091e-60e0-4f97-a06d-52dc7213dcb2.png">
<img width="360" alt="image" src="https://user-images.githubusercontent.com/1833617/193030412-13ec1e5f-ab38-4bb7-9444-83f365ee0304.png">


### Breaking changes

/
