### PR TITLE
Fix escape key closing on overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Overlay`: set tabIndex to fix onKeyDown events no longer registering after clicking inside the overlay ([@BeirlaenAaron](https://github.com/BeirlaenAaron)) in [#2394](https://github.com/teamleadercrm/ui/pull/2394))
+
 ### Dependency updates
 
 ## [16.4.0] - 2022-09-29

--- a/src/components/overlay/Overlay.tsx
+++ b/src/components/overlay/Overlay.tsx
@@ -82,6 +82,7 @@ export const Overlay: GenericComponent<OverlayProps> = ({
             onKeyDown={handleEscKey}
             onMouseDown={handleMouseDown}
             onMouseUp={handleMouseUp}
+            tabIndex={0}
             className={cx(
               theme['overlay'],
               theme[backdrop],


### PR DESCRIPTION
### Description

Fixed bug where pressing escape to close would no longer work after clicking inside a Dialog/Popover or any overlay component

### Breaking changes

N/A

### Manual check

Open a dialog and click inside of it, pressing escape should now close it
