### PR TITLE
Guild/typescript interfaces and touchups

### DIFF
--- a/src/components/advancedCollapsible/AdvancedCollapsible.tsx
+++ b/src/components/advancedCollapsible/AdvancedCollapsible.tsx
@@ -13,7 +13,7 @@ export type AllowedAdvancedCollapsibleColor = Exclude<
   typeof COLORS[number],
   'aqua' | 'gold' | 'mint' | 'ruby' | 'violet'
 >;
-interface AdvancedCollapsibleProps extends Omit<BoxProps, 'size'> {
+export interface AdvancedCollapsibleProps extends Omit<BoxProps, 'size'> {
   color?: AllowedAdvancedCollapsibleColor;
   children: ReactNode;
   title: string;

--- a/src/components/advancedCollapsible/index.ts
+++ b/src/components/advancedCollapsible/index.ts
@@ -1,2 +1,3 @@
-import AdvancedCollapsible from './AdvancedCollapsible';
+import AdvancedCollapsible, { AdvancedCollapsibleProps } from './AdvancedCollapsible';
 export default AdvancedCollapsible;
+export type { AdvancedCollapsibleProps };

--- a/src/components/alert/Alert.tsx
+++ b/src/components/alert/Alert.tsx
@@ -12,7 +12,7 @@ type Action = Omit<ButtonProps, 'fullWidth' | 'marginTop'>;
 
 type Type = 'confirm' | 'destructive' | 'error';
 
-interface AlertProps extends Omit<DialogBaseProps, 'scrollable' | 'size'> {
+export interface AlertProps extends Omit<DialogBaseProps, 'scrollable' | 'size'> {
   /** Object containing the props of the primary action (a Button, with level prop set to 'primary'). */
   primaryAction: Action;
   /** Object containing the the props of the secondary action (a Button). */

--- a/src/components/alert/index.ts
+++ b/src/components/alert/index.ts
@@ -1,2 +1,3 @@
-import Alert from './Alert';
+import Alert, { AlertProps } from './Alert';
 export default Alert;
+export type { AlertProps };

--- a/src/components/avatar/AvatarStack.tsx
+++ b/src/components/avatar/AvatarStack.tsx
@@ -18,7 +18,7 @@ const OVERLAP_SPACINGS = {
 
 const SPACING = 6;
 
-interface AvatarStackProps extends Omit<BoxProps, 'size' | 'ref'> {
+export interface AvatarStackProps extends Omit<BoxProps, 'size' | 'ref'> {
   /** The avatars to display in a stack. */
   children: React.ReactNode;
   /** A class name for the wrapper to give custom styles. */

--- a/src/components/avatar/index.ts
+++ b/src/components/avatar/index.ts
@@ -1,5 +1,6 @@
-import Avatar from './Avatar';
-import AvatarStack from './AvatarStack';
+import Avatar, { AvatarProps } from './Avatar';
+import AvatarStack, { AvatarStackProps } from './AvatarStack';
 
 export default Avatar;
 export { Avatar, AvatarStack };
+export type { AvatarProps, AvatarStackProps };

--- a/src/components/badge/Badge.tsx
+++ b/src/components/badge/Badge.tsx
@@ -9,7 +9,7 @@ import { UITextBody, UITextDisplay, UITextSmall } from '../typography';
 import theme from './theme.css';
 
 export type AllowedBadgeSize = Exclude<typeof SIZES[number], 'tiny' | 'fullscreen' | 'smallest' | 'hero'>;
-interface BadgeProps extends Omit<BoxProps, 'ref' | 'size'> {
+export interface BadgeProps extends Omit<BoxProps, 'ref' | 'size'> {
   /** The content to display inside the badge. */
   children?: ReactNode;
   /** A class name for the wrapper to give custom styles. */

--- a/src/components/badge/index.ts
+++ b/src/components/badge/index.ts
@@ -1,3 +1,4 @@
-import Badge from './Badge';
+import Badge, { BadgeProps } from './Badge';
 
 export default Badge;
+export type { BadgeProps };

--- a/src/components/badgedLink/index.ts
+++ b/src/components/badgedLink/index.ts
@@ -1,3 +1,4 @@
-import BadgedLink from './BadgedLink';
+import BadgedLink, { BadgedLinkProps } from './BadgedLink';
 
 export default BadgedLink;
+export type { BadgedLinkProps };

--- a/src/components/box/index.ts
+++ b/src/components/box/index.ts
@@ -1,6 +1,6 @@
 import Box from './Box';
-import type { Margin, Padding } from './Box';
+import type { Margin, Padding, BoxProps } from './Box';
 import boxProps, { omitBoxProps, pickBoxProps } from './boxProps';
 
 export default Box;
-export { Box, boxProps, omitBoxProps, pickBoxProps, Margin, Padding };
+export { Box, boxProps, omitBoxProps, pickBoxProps, Margin, Padding, BoxProps };

--- a/src/components/bullet/Bullet.tsx
+++ b/src/components/bullet/Bullet.tsx
@@ -5,7 +5,7 @@ import theme from './theme.css';
 import { BoxProps } from '../box/Box';
 import { COLORS, SIZES, TINTS } from '../../constants';
 
-interface BulletProps extends Omit<BoxProps, 'size' | 'ref'> {
+export interface BulletProps extends Omit<BoxProps, 'size' | 'ref'> {
   /** A border color to give to the counter */
   borderColor?: typeof COLORS[number];
   /** A border tint to give to the counter */

--- a/src/components/bullet/index.ts
+++ b/src/components/bullet/index.ts
@@ -1,3 +1,4 @@
-import Bullet from './Bullet';
+import Bullet, { BulletProps } from './Bullet';
 
 export default Bullet;
+export type { BulletProps };

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -1,4 +1,5 @@
-import Button, { BUTTON_LEVELS } from './Button';
+import Button, { ButtonProps, BUTTON_LEVELS } from './Button';
 
 export default Button;
 export { Button, BUTTON_LEVELS };
+export type { ButtonProps };

--- a/src/components/buttonGroup/ButtonGroup.tsx
+++ b/src/components/buttonGroup/ButtonGroup.tsx
@@ -10,7 +10,7 @@ import { BUTTON_LEVELS } from '../button/Button';
 import isReactElement from '../utils/is-react-element';
 import { SIZES } from '../../constants';
 
-interface ButtonGroupProps extends Omit<BoxProps, 'size' | 'onChange' | 'ref'> {
+export interface ButtonGroupProps extends Omit<BoxProps, 'size' | 'onChange' | 'ref'> {
   /** The content to display inside the button group. */
   children?: React.ReactNode;
   /** A class name for the wrapper to give custom styles. */

--- a/src/components/buttonGroup/index.ts
+++ b/src/components/buttonGroup/index.ts
@@ -1,4 +1,5 @@
-import ButtonGroup from './ButtonGroup';
+import ButtonGroup, { ButtonGroupProps } from './ButtonGroup';
 
 export default ButtonGroup;
 export { ButtonGroup };
+export type { ButtonGroupProps };

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -10,7 +10,7 @@ import { TextBodyCompact, TextDisplay, TextSmall } from '../typography';
 import theme from './theme.css';
 
 export type AllowedCheckboxSize = Exclude<typeof SIZES[number], 'tiny' | 'fullscreen' | 'smallest' | 'hero'>;
-interface CheckboxProps extends Omit<BoxProps, 'onChange' | 'size'> {
+export interface CheckboxProps extends Omit<BoxProps, 'onChange' | 'size'> {
   /** If true, the checkbox will be checked. */
   checked?: boolean;
   /** The content to display next to the checkbox. */

--- a/src/components/checkbox/index.ts
+++ b/src/components/checkbox/index.ts
@@ -1,2 +1,3 @@
-import Checkbox from './Checkbox';
+import Checkbox, { CheckboxProps } from './Checkbox';
 export default Checkbox;
+export type { CheckboxProps };

--- a/src/components/container/index.ts
+++ b/src/components/container/index.ts
@@ -1,4 +1,5 @@
-import Container from './Container';
+import Container, { ContainerProps } from './Container';
 
 export default Container;
 export { Container };
+export type { ContainerProps };

--- a/src/components/counter/Counter.tsx
+++ b/src/components/counter/Counter.tsx
@@ -8,7 +8,7 @@ import { COLORS, TINTS } from '../../constants';
 import { BoxProps } from '../box/Box';
 import { GenericComponent } from '../../@types/types';
 
-interface Props extends Omit<BoxProps, 'size' | 'ref'> {
+export interface CounterProps extends Omit<BoxProps, 'size' | 'ref'> {
   /** A border color to give to the counter */
   borderColor?: typeof COLORS[number];
   /** A border tint to give to the counter */
@@ -27,7 +27,7 @@ interface Props extends Omit<BoxProps, 'size' | 'ref'> {
   size: 'small' | 'medium';
 }
 
-const Counter: GenericComponent<Props> = ({
+const Counter: GenericComponent<CounterProps> = ({
   children,
   className,
   color = 'neutral',

--- a/src/components/counter/index.ts
+++ b/src/components/counter/index.ts
@@ -1,3 +1,4 @@
-import Counter from './Counter';
+import Counter, { CounterProps } from './Counter';
 
 export default Counter;
+export type { CounterProps };

--- a/src/components/datepicker/DatePicker.tsx
+++ b/src/components/datepicker/DatePicker.tsx
@@ -13,7 +13,7 @@ import localeUtils from './localeUtils';
 import { GenericComponent } from '../../@types/types';
 import { SIZES } from '../../constants';
 
-interface DatePickerProps extends Omit<BoxProps & DayPickerProps, 'size' | 'onChange' | 'modifiers' | 'ref'> {
+export interface DatePickerProps extends Omit<BoxProps & DayPickerProps, 'size' | 'onChange' | 'modifiers' | 'ref'> {
   /** If true we give a border to our wrapper. */
   bordered?: boolean;
   /** A class name for the DatePicker to give custom styles. */

--- a/src/components/datepicker/DatePickerInput.tsx
+++ b/src/components/datepicker/DatePickerInput.tsx
@@ -14,7 +14,7 @@ import { PopoverProps } from '../popover/Popover';
 import { formatDate } from './localeUtils';
 import theme from './theme.css';
 
-interface DatePickerInputProps extends Omit<BoxProps, 'size' | 'onChange'> {
+export interface DatePickerInputProps extends Omit<BoxProps, 'size' | 'onChange'> {
   /** A class name for the wrapper to give custom styles. */
   className?: string;
   /** Object with props for the DatePicker component. */

--- a/src/components/datepicker/index.ts
+++ b/src/components/datepicker/index.ts
@@ -1,5 +1,6 @@
-import DatePicker from './DatePicker';
-import DatePickerInput from './DatePickerInput';
+import DatePicker, { DatePickerProps } from './DatePicker';
+import DatePickerInput, { DatePickerInputProps } from './DatePickerInput';
 
 export default DatePicker;
 export { DatePicker, DatePickerInput };
+export type { DatePickerProps, DatePickerInputProps };

--- a/src/components/detailPage/DetailPage.tsx
+++ b/src/components/detailPage/DetailPage.tsx
@@ -5,7 +5,7 @@ import Box from '../box';
 import { BoxProps } from '../box/Box';
 import { GenericComponent } from '../../@types/types';
 
-interface DetailPageProps extends Omit<BoxProps, 'ref'> {
+export interface DetailPageProps extends Omit<BoxProps, 'ref'> {
   children: ReactNode;
 }
 

--- a/src/components/detailPage/index.ts
+++ b/src/components/detailPage/index.ts
@@ -1,6 +1,7 @@
-import DetailPage from './DetailPage';
-import DetailPageBody from './DetailPageBody';
-import DetailPageHeader from './DetailPageHeader';
+import DetailPage, { DetailPageProps } from './DetailPage';
+import DetailPageBody, { DetailPageBodyProps } from './DetailPageBody';
+import DetailPageHeader, { DetailPageHeaderProps } from './DetailPageHeader';
 
 export default DetailPage;
 export { DetailPageBody, DetailPageHeader };
+export type { DetailPageProps, DetailPageBodyProps, DetailPageHeaderProps };

--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -9,7 +9,7 @@ import { DialogBaseProps } from './DialogBase';
 import theme from './theme.css';
 import { SIZES } from '../../constants';
 
-interface DialogProps extends Omit<DialogBaseProps, 'ref'> {
+export interface DialogProps extends Omit<DialogBaseProps, 'ref'> {
   /** If true, the dialog will show on screen. */
   active?: boolean;
   /** The content to display inside the dialog. */

--- a/src/components/dialog/index.ts
+++ b/src/components/dialog/index.ts
@@ -1,5 +1,6 @@
-import Dialog from './Dialog';
-import DialogBase from './DialogBase';
+import Dialog, { DialogProps } from './Dialog';
+import DialogBase, { DialogBaseProps } from './DialogBase';
 
 export { Dialog, DialogBase };
+export type { DialogProps, DialogBaseProps };
 export default Dialog;

--- a/src/components/emailSelector/EmailSelector.tsx
+++ b/src/components/emailSelector/EmailSelector.tsx
@@ -10,7 +10,7 @@ import theme from './theme.css';
 import { Suggestion, Suggestions } from './types';
 import { excludeSuggestions } from './utils';
 
-interface EmailSelectorProps extends Omit<BoxProps, 'ref' | 'onBlur' | 'onFocus'> {
+export interface EmailSelectorProps extends Omit<BoxProps, 'ref' | 'onBlur' | 'onFocus'> {
   error?: boolean | string;
   warning?: boolean | string;
   defaultSelection?: Suggestion[];

--- a/src/components/emailSelector/index.ts
+++ b/src/components/emailSelector/index.ts
@@ -1,4 +1,5 @@
-import EmailSelector from './EmailSelector';
+import EmailSelector, { EmailSelectorProps } from './EmailSelector';
 
 export default EmailSelector;
 export { EmailSelector };
+export type { EmailSelectorProps };

--- a/src/components/emptyState/EmptyState.tsx
+++ b/src/components/emptyState/EmptyState.tsx
@@ -12,7 +12,7 @@ import { BoxProps } from '../box/Box';
 import { GenericComponent } from '../../@types/types';
 import { SIZES } from '../../constants';
 
-interface EmptyStateProps extends Omit<BoxProps, 'size'> {
+export interface EmptyStateProps extends Omit<BoxProps, 'size'> {
   hidePointer?: boolean;
   metaText?: ReactNode | string;
   size?: Exclude<typeof SIZES[number], 'tiny' | 'fullscreen' | 'smallest' | 'hero'>;

--- a/src/components/emptyState/index.ts
+++ b/src/components/emptyState/index.ts
@@ -1,4 +1,5 @@
-import EmptyState from './EmptyState';
+import EmptyState, { EmptyStateProps } from './EmptyState';
 
 export default EmptyState;
 export { EmptyState };
+export type { EmptyStateProps };

--- a/src/components/filterSelection/FilterSelection.tsx
+++ b/src/components/filterSelection/FilterSelection.tsx
@@ -41,7 +41,7 @@ const BACKGROUND_TINT_BY_STATUS: Record<string, typeof TINTS[number] | undefined
   [STATUS.BROKEN]: 'lightest',
 };
 
-interface FilterSelectionProps {
+export interface FilterSelectionProps {
   /** The title shown on the Selection */
   label?: string;
   /** The tooltop shown on top of the Selection */

--- a/src/components/filterSelection/index.ts
+++ b/src/components/filterSelection/index.ts
@@ -1,3 +1,4 @@
-import FilterSelection from './FilterSelection';
+import FilterSelection, { FilterSelectionProps } from './FilterSelection';
 
 export default FilterSelection;
+export type { FilterSelectionProps };

--- a/src/components/flex/Flex.tsx
+++ b/src/components/flex/Flex.tsx
@@ -5,7 +5,7 @@ import theme from './theme.css';
 
 type Gap = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
-type FlexProps = Partial<{
+export type FlexProps = Partial<{
   children: ReactNode;
   direction: 'row' | 'column';
   gap: Gap;

--- a/src/components/flex/index.ts
+++ b/src/components/flex/index.ts
@@ -1,3 +1,4 @@
-import Flex from './Flex';
+import Flex, { FlexProps } from './Flex';
 
 export default Flex;
+export type { FlexProps };

--- a/src/components/grid/GridItem.tsx
+++ b/src/components/grid/GridItem.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import { GenericComponent } from '../../@types/types';
 
-type GridItemProps = Partial<{ children: ReactNode; area: string }>;
+export type GridItemProps = Partial<{ children: ReactNode; area: string }>;
 
 const GridItem: GenericComponent<GridItemProps> = ({ children, area }) => {
   const gridItemStyles = { gridArea: area };

--- a/src/components/grid/index.ts
+++ b/src/components/grid/index.ts
@@ -1,5 +1,6 @@
-import Grid from './Grid';
-import GridItem from './GridItem';
+import Grid, { GridProps } from './Grid';
+import GridItem, { GridItemProps } from './GridItem';
 
 export default Grid;
 export { Grid, GridItem };
+export type { GridProps, GridItemProps };

--- a/src/components/icon/Icon.tsx
+++ b/src/components/icon/Icon.tsx
@@ -6,7 +6,7 @@ import { BoxProps } from '../box/Box';
 import { GenericComponent } from '../../@types/types';
 import { COLORS, TINTS } from '../../constants';
 
-interface IconProps extends Omit<BoxProps, 'children' | 'className'> {
+export interface IconProps extends Omit<BoxProps, 'children' | 'className'> {
   /** Element wrapped in Icon tags or sent as children prop */
   children?: ReactNode;
   /** Classname for the Icon component */

--- a/src/components/icon/index.ts
+++ b/src/components/icon/index.ts
@@ -1,3 +1,4 @@
-import Icon from './Icon';
+import Icon, { IconProps } from './Icon';
 
 export default Icon;
+export type { IconProps };

--- a/src/components/iconButton/index.ts
+++ b/src/components/iconButton/index.ts
@@ -1,4 +1,5 @@
-import IconButton from './IconButton';
+import IconButton, { IconButtonProps } from './IconButton';
 
 export default IconButton;
 export { IconButton };
+export type { IconButtonProps };

--- a/src/components/input/DurationInput.tsx
+++ b/src/components/input/DurationInput.tsx
@@ -9,7 +9,7 @@ import { SIZES } from '../../constants';
 
 const MINUTES_STEP = 15;
 
-interface DurationInputProps
+export interface DurationInputProps
   extends Omit<NumericInputProps, 'className' | 'id' | 'max' | 'onBlur' | 'onChange' | 'onKeyDown' | 'size' | 'value'>,
     Omit<BoxProps, 'size' | 'ref'> {
   /** Sets a class name for the wrapper to give custom styles. */

--- a/src/components/input/Textarea.tsx
+++ b/src/components/input/Textarea.tsx
@@ -7,7 +7,7 @@ import InputBase, { InputBaseProps } from './InputBase';
 import ValidationText from '../validationText';
 import { GenericComponent } from '../../@types/types';
 
-interface TextareaProps extends Omit<InputBaseProps, 'ref' | 'type'>, Omit<BoxProps, 'size' | 'ref'> {
+export interface TextareaProps extends Omit<InputBaseProps, 'ref' | 'type'>, Omit<BoxProps, 'size' | 'ref'> {
   /** The text to use as error message below the input. */
   error?: boolean | ReactNode;
   /** The text to use as help text below the input. */

--- a/src/components/input/TimeInput.tsx
+++ b/src/components/input/TimeInput.tsx
@@ -7,7 +7,7 @@ import { GenericComponent } from '../../@types/types';
 
 const isValidTime = (input: string) => /([0-1][0-9]|[2][0-3]):([0-5][0-9])/.test(input);
 
-interface TimeInputProps extends Omit<SingleLineInputBaseProps, 'disabled' | 'readOnly'> {
+export interface TimeInputProps extends Omit<SingleLineInputBaseProps, 'disabled' | 'readOnly'> {
   /** Boolean indicating whether the input should render as disabled. */
   disabled?: boolean;
   /** Boolean indicating whether the input should render as read only. */

--- a/src/components/input/index.ts
+++ b/src/components/input/index.ts
@@ -1,10 +1,19 @@
-import Input from './Input';
-import InputBase from './InputBase';
-import SingleLineInputBase from './SingleLineInputBase';
-import NumericInput from './NumericInput';
-import Textarea from './Textarea';
-import TimeInput from './TimeInput';
-import DurationInput from './DurationInput';
+import DurationInput, { DurationInputProps } from './DurationInput';
+import Input, { InputProps } from './Input';
+import InputBase, { InputBaseProps } from './InputBase';
+import NumericInput, { NumericInputProps } from './NumericInput';
+import SingleLineInputBase, { SingleLineInputBaseProps } from './SingleLineInputBase';
+import Textarea, { TextareaProps } from './Textarea';
+import TimeInput, { TimeInputProps } from './TimeInput';
 
 export { InputBase, NumericInput, SingleLineInputBase, Textarea, TimeInput, DurationInput };
+export type {
+  InputProps,
+  InputBaseProps,
+  SingleLineInputBaseProps,
+  NumericInputProps,
+  TextareaProps,
+  TimeInputProps,
+  DurationInputProps,
+};
 export default Input;

--- a/src/components/label/Label.tsx
+++ b/src/components/label/Label.tsx
@@ -11,7 +11,7 @@ import theme from './theme.css';
 
 const TooltippedIcon = Tooltip(Icon);
 
-interface LabelProps extends Omit<BoxProps, 'children'> {
+export interface LabelProps extends Omit<BoxProps, 'children'> {
   children: ReactNode;
   inverse?: boolean;
   required?: boolean;

--- a/src/components/label/index.ts
+++ b/src/components/label/index.ts
@@ -1,2 +1,3 @@
-import Label from './Label';
+import Label, { LabelProps } from './Label';
 export default Label;
+export type { LabelProps };

--- a/src/components/labelValuePair/LabelValuePair.tsx
+++ b/src/components/labelValuePair/LabelValuePair.tsx
@@ -7,7 +7,7 @@ import isReactElement from '../utils/is-react-element';
 import Label, { LabelProps } from './Label';
 import Value, { ValueProps } from './Value';
 
-interface LabelValuePairProps extends Omit<BoxProps, 'children'> {
+export interface LabelValuePairProps extends Omit<BoxProps, 'children'> {
   alignValue?: 'left' | 'right';
   children: ReactNode;
   inline?: boolean;

--- a/src/components/labelValuePair/LabelValuePairGroup.tsx
+++ b/src/components/labelValuePair/LabelValuePairGroup.tsx
@@ -4,7 +4,7 @@ import Box from '../box';
 import { BoxProps } from '../box/Box';
 import { Heading4 } from '../typography';
 
-interface LabelValuePairGroupProps extends Omit<BoxProps, 'children'> {
+export interface LabelValuePairGroupProps extends Omit<BoxProps, 'children'> {
   children: ReactNode;
   title?: string | ReactNode;
 }

--- a/src/components/labelValuePair/index.ts
+++ b/src/components/labelValuePair/index.ts
@@ -1,5 +1,6 @@
-import LabelValuePair from './LabelValuePair';
-import LabelValuePairGroup from './LabelValuePairGroup';
+import LabelValuePair, { LabelValuePairProps } from './LabelValuePair';
+import LabelValuePairGroup, { LabelValuePairGroupProps } from './LabelValuePairGroup';
 
 export default LabelValuePair;
 export { LabelValuePair, LabelValuePairGroup };
+export type { LabelValuePairProps, LabelValuePairGroupProps };

--- a/src/components/link/index.ts
+++ b/src/components/link/index.ts
@@ -1,3 +1,4 @@
-import Link from './Link';
+import Link, { LinkProps } from './Link';
 
 export default Link;
+export type { LinkProps };

--- a/src/components/loadingBar/index.ts
+++ b/src/components/loadingBar/index.ts
@@ -1,3 +1,4 @@
-import LoadingBar from './LoadingBar';
+import LoadingBar, { LoadingBarProps } from './LoadingBar';
 
 export default LoadingBar;
+export type { LoadingBarProps };

--- a/src/components/loadingSpinner/index.ts
+++ b/src/components/loadingSpinner/index.ts
@@ -1,3 +1,4 @@
-import LoadingSpinner from './LoadingSpinner';
+import LoadingSpinner, { LoadingSpinnerProps } from './LoadingSpinner';
 
 export default LoadingSpinner;
+export type { LoadingSpinnerProps };

--- a/src/components/marketingButton/index.ts
+++ b/src/components/marketingButton/index.ts
@@ -1,4 +1,5 @@
-import MarketingButton from './MarketingButton';
+import MarketingButton, { MarketingButtonProps } from './MarketingButton';
 
 export default MarketingButton;
 export { MarketingButton };
+export type { MarketingButtonProps };

--- a/src/components/marketingButtonGroup/MarketingButtonGroup.tsx
+++ b/src/components/marketingButtonGroup/MarketingButtonGroup.tsx
@@ -8,7 +8,7 @@ import theme from './theme.css';
 import { BoxProps } from '../box/Box';
 import { GenericComponent } from '../../@types/types';
 
-interface MarketingButtonGroupProps extends Omit<BoxProps, 'ref'> {
+export interface MarketingButtonGroupProps extends Omit<BoxProps, 'ref'> {
   /** The content to display inside the button group. */
   children?: ReactNode;
   /** A class name for the wrapper to give custom styles. */

--- a/src/components/marketingButtonGroup/index.ts
+++ b/src/components/marketingButtonGroup/index.ts
@@ -1,3 +1,4 @@
-import MarketingButtonGroup from './MarketingButtonGroup';
+import MarketingButtonGroup, { MarketingButtonGroupProps } from './MarketingButtonGroup';
 
 export default MarketingButtonGroup;
+export type { MarketingButtonGroupProps };

--- a/src/components/marketingDialog/MarketingDialog.tsx
+++ b/src/components/marketingDialog/MarketingDialog.tsx
@@ -7,7 +7,7 @@ import MarketingButton from '../marketingButton';
 import { MarketingButtonProps } from '../marketingButton/MarketingButton';
 import Flex from '../flex';
 
-interface MarketingDialogProps {
+export interface MarketingDialogProps {
   /** If true, the dialog will show on screen. */
   active: boolean;
   /** Callback function that is fired when the close icon clicked. */

--- a/src/components/marketingDialog/index.ts
+++ b/src/components/marketingDialog/index.ts
@@ -1,4 +1,5 @@
-import MarketingDialog from './MarketingDialog';
+import MarketingDialog, { MarketingDialogProps } from './MarketingDialog';
 
 export default MarketingDialog;
 export { MarketingDialog };
+export type { MarketingDialogProps };

--- a/src/components/marketingLink/MarketingLink.tsx
+++ b/src/components/marketingLink/MarketingLink.tsx
@@ -6,7 +6,7 @@ import uiUtilities from '@teamleader/ui-utilities';
 import { GenericComponent } from '../../@types/types';
 import { BoxProps } from '../box/Box';
 
-interface MarketingLinkProps extends Omit<BoxProps, 'ref'> {
+export interface MarketingLinkProps extends Omit<BoxProps, 'ref'> {
   /** The content to display inside the link. */
   children: ReactNode;
   /** A class name for the link to give custom styles. */

--- a/src/components/marketingLink/index.ts
+++ b/src/components/marketingLink/index.ts
@@ -1,2 +1,3 @@
-import MarketingLink from './MarketingLink';
+import MarketingLink, { MarketingLinkProps } from './MarketingLink';
 export default MarketingLink;
+export type { MarketingLinkProps };

--- a/src/components/marketingLockBadge/MarketingLockBadge.tsx
+++ b/src/components/marketingLockBadge/MarketingLockBadge.tsx
@@ -8,7 +8,7 @@ import { GenericComponent } from '../../@types/types';
 import { BoxProps } from '../box/Box';
 import { SIZES } from '../../constants';
 
-interface MarketingLockBadgeProps extends Omit<BoxProps, 'ref'> {
+export interface MarketingLockBadgeProps extends Omit<BoxProps, 'ref'> {
   className?: string;
   size?: Exclude<typeof SIZES[number], 'tiny' | 'large' | 'fullscreen' | 'smallest' | 'hero'>;
 }

--- a/src/components/marketingLockBadge/index.ts
+++ b/src/components/marketingLockBadge/index.ts
@@ -1,2 +1,3 @@
-import MarketingLockBadge from './MarketingLockBadge';
+import MarketingLockBadge, { MarketingLockBadgeProps } from './MarketingLockBadge';
 export default MarketingLockBadge;
+export type { MarketingLockBadgeProps };

--- a/src/components/marketingMarker/MarketingMarker.tsx
+++ b/src/components/marketingMarker/MarketingMarker.tsx
@@ -5,7 +5,7 @@ import theme from './theme.css';
 import { GenericComponent } from '../../@types/types';
 import { BoxProps } from '../box/Box';
 
-interface MarketingMarkerProps extends Omit<BoxProps, 'ref'> {
+export interface MarketingMarkerProps extends Omit<BoxProps, 'ref'> {
   children?: ReactNode | string;
   className?: string;
 }

--- a/src/components/marketingMarker/index.ts
+++ b/src/components/marketingMarker/index.ts
@@ -1,2 +1,3 @@
-import MarketingMarker from './MarketingMarker';
+import MarketingMarker, { MarketingMarkerProps } from './MarketingMarker';
 export default MarketingMarker;
+export type { MarketingMarkerProps };

--- a/src/components/marketingStatusLabel/MarketingStatusLabel.tsx
+++ b/src/components/marketingStatusLabel/MarketingStatusLabel.tsx
@@ -9,7 +9,7 @@ import { GenericComponent } from '../../@types/types';
 import { BoxProps } from '../box/Box';
 import { SIZES } from '../../constants';
 
-interface MarketingStatusLabelProps extends Omit<BoxProps, 'ref'> {
+export interface MarketingStatusLabelProps extends Omit<BoxProps, 'ref'> {
   children?: ReactNode;
   fullWidth?: boolean;
   size?: Exclude<typeof SIZES[number], 'tiny' | 'large' | 'fullscreen' | 'smallest' | 'hero'>;

--- a/src/components/marketingStatusLabel/index.ts
+++ b/src/components/marketingStatusLabel/index.ts
@@ -1,2 +1,3 @@
-import MarketingStatusLabel from './MarketingStatusLabel';
+import MarketingStatusLabel, { MarketingStatusLabelProps } from './MarketingStatusLabel';
 export default MarketingStatusLabel;
+export type { MarketingStatusLabelProps };

--- a/src/components/marketingTab/MarketingTab.tsx
+++ b/src/components/marketingTab/MarketingTab.tsx
@@ -8,7 +8,7 @@ import { GenericComponent } from '../../@types/types';
 import { BoxProps } from '../box/Box';
 import { SIZES } from '../../constants';
 
-interface MarketingTabProps extends Omit<BoxProps, 'ref'> {
+export interface MarketingTabProps extends Omit<BoxProps, 'ref'> {
   active?: boolean;
   children: ReactNode;
   className?: string;

--- a/src/components/marketingTab/index.ts
+++ b/src/components/marketingTab/index.ts
@@ -1,2 +1,3 @@
-import MarketingTab from './MarketingTab';
+import MarketingTab, { MarketingTabProps } from './MarketingTab';
 export default MarketingTab;
+export type { MarketingTabProps };

--- a/src/components/marketingTypography/index.ts
+++ b/src/components/marketingTypography/index.ts
@@ -1,4 +1,5 @@
-import MarketingHeading1 from './MarketingHeading1';
+import MarketingHeading1, { MarketingHeadingProps } from './MarketingHeading1';
 import MarketingHeading2 from './MarketingHeading2';
 
 export { MarketingHeading1, MarketingHeading2 };
+export type { MarketingHeadingProps };

--- a/src/components/menu/IconMenu.tsx
+++ b/src/components/menu/IconMenu.tsx
@@ -8,7 +8,7 @@ import Box, { pickBoxProps } from '../box';
 import { BoxProps } from '../box/Box';
 import { GenericComponent } from '../../@types/types';
 
-interface IconMenuProps extends Omit<BoxProps, 'children' | 'className'> {
+export interface IconMenuProps extends Omit<BoxProps, 'children' | 'className'> {
   children?: ReactNode;
   className?: string;
   icon?: ReactElement;

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -27,7 +27,7 @@ const POSITION: Record<string, 'auto' | 'static' | 'top-left' | 'top-right' | 'b
   BOTTOM_RIGHT: 'bottom-right',
 };
 
-interface MenuProps extends Omit<BoxProps, 'children' | 'className'> {
+export interface MenuProps extends Omit<BoxProps, 'children' | 'className'> {
   /** If true, the menu will be active. */
   active?: boolean;
   /** The content to display inside the menu. */

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -7,7 +7,7 @@ import theme from './theme.css';
 import { BoxProps } from '../box/Box';
 import { GenericComponent } from '../../@types/types';
 
-interface MenuItemProps extends Omit<BoxProps, 'children' | 'className' | 'element' | 'style'> {
+export interface MenuItemProps extends Omit<BoxProps, 'children' | 'className' | 'element' | 'style'> {
   /** A caption displayed underneath the label. */
   caption?: string;
   /** The content to display inside the menu item. */

--- a/src/components/menu/MenuTitle.tsx
+++ b/src/components/menu/MenuTitle.tsx
@@ -5,7 +5,7 @@ import { BoxProps } from '../box/Box';
 import { Heading4 } from '../typography';
 import theme from './theme.css';
 
-interface MenuTitleProps extends Omit<BoxProps, 'children'> {
+export interface MenuTitleProps extends Omit<BoxProps, 'children'> {
   children: ReactNode;
 }
 

--- a/src/components/menu/index.ts
+++ b/src/components/menu/index.ts
@@ -1,8 +1,9 @@
+import IconMenu, { IconMenuProps } from './IconMenu';
+import Menu, { MenuProps } from './Menu';
 import MenuDivider from './MenuDivider';
-import MenuItem from './MenuItem';
-import MenuTitle from './MenuTitle';
-import Menu from './Menu';
-import IconMenu from './IconMenu';
+import MenuItem, { MenuItemProps } from './MenuItem';
+import MenuTitle, { MenuTitleProps } from './MenuTitle';
 
 export default Menu;
 export { MenuDivider, MenuItem, MenuTitle, Menu, IconMenu };
+export type { MenuItemProps, MenuTitleProps, MenuProps, IconMenuProps };

--- a/src/components/message/index.ts
+++ b/src/components/message/index.ts
@@ -1,4 +1,5 @@
-import Message from './Message';
+import Message, { MessageProps } from './Message';
 
 export default Message;
 export { Message };
+export type { MessageProps };

--- a/src/components/overviewPage/OverviewPage.tsx
+++ b/src/components/overviewPage/OverviewPage.tsx
@@ -5,7 +5,7 @@ import Box from '../box';
 import { BoxProps } from '../box/Box';
 import { GenericComponent } from '../../@types/types';
 
-interface OverviewPageProps extends Omit<BoxProps, 'children'> {
+export interface OverviewPageProps extends Omit<BoxProps, 'children'> {
   children: ReactNode;
 }
 

--- a/src/components/overviewPage/index.ts
+++ b/src/components/overviewPage/index.ts
@@ -1,6 +1,7 @@
-import OverviewPage from './OverviewPage';
-import OverviewPageBody from './OverviewPageBody';
-import OverviewPageHeader from './OverviewPageHeader';
+import OverviewPage, { OverviewPageProps } from './OverviewPage';
+import OverviewPageBody, { OverviewPageBodyProps } from './OverviewPageBody';
+import OverviewPageHeader, { OverviewPageHeaderProps } from './OverviewPageHeader';
 
 export default OverviewPage;
 export { OverviewPageBody, OverviewPageHeader };
+export type { OverviewPageProps, OverviewPageBodyProps, OverviewPageHeaderProps };

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -16,7 +16,7 @@ interface ChildrenFunctionArgument {
   className?: string;
 }
 
-interface PaginationProps extends Omit<BoxProps, 'className' | 'children'> {
+export interface PaginationProps extends Omit<BoxProps, 'className' | 'children'> {
   className?: string;
   currentPage?: number;
   maxNumPagesVisible?: number;

--- a/src/components/pagination/index.ts
+++ b/src/components/pagination/index.ts
@@ -1,3 +1,4 @@
-import Pagination from './Pagination';
+import Pagination, { PaginationProps } from './Pagination';
 
 export default Pagination;
+export type { PaginationProps };

--- a/src/components/passport/EmptyPassport.tsx
+++ b/src/components/passport/EmptyPassport.tsx
@@ -11,7 +11,7 @@ import { AvatarProps } from '../avatar/Avatar';
 import { BoxProps } from '../box/Box';
 import { LinkProps } from '../link/Link';
 
-interface EmptyPassportProps extends Omit<BoxProps, 'className'> {
+export interface EmptyPassportProps extends Omit<BoxProps, 'className'> {
   /** Object containing the props of an avatar. */
   avatar?: AvatarProps;
   /** The class names for the wrapper to apply custom styling. */

--- a/src/components/passport/index.ts
+++ b/src/components/passport/index.ts
@@ -1,5 +1,6 @@
-import EmptyPassport from './EmptyPassport';
-import Passport from './Passport';
+import EmptyPassport, { EmptyPassportProps } from './EmptyPassport';
+import Passport, { PassportProps } from './Passport';
 
 export default Passport;
 export { EmptyPassport, Passport };
+export type { EmptyPassportProps, PassportProps };

--- a/src/components/popover/index.ts
+++ b/src/components/popover/index.ts
@@ -1,3 +1,4 @@
-import Popover from './Popover';
+import Popover, { PopoverProps } from './Popover';
 
 export default Popover;
+export type { PopoverProps };

--- a/src/components/poweredByButton/PoweredByButton.tsx
+++ b/src/components/poweredByButton/PoweredByButton.tsx
@@ -8,7 +8,7 @@ import { BoxProps } from '../box/Box';
 import { GenericComponent } from '../../@types/types';
 import { COLORS, TINTS } from '../../constants';
 
-interface PoweredByButtonProps extends Omit<BoxProps, 'className' | 'children' | 'ref'> {
+export interface PoweredByButtonProps extends Omit<BoxProps, 'className' | 'children' | 'ref'> {
   /** A class name for the wrapper to give custom styles. */
   className?: string;
   /** Overwrite the default label. */

--- a/src/components/poweredByButton/index.ts
+++ b/src/components/poweredByButton/index.ts
@@ -1,4 +1,5 @@
-import PoweredByButton from './PoweredByButton';
+import PoweredByButton, { PoweredByButtonProps } from './PoweredByButton';
 
 export default PoweredByButton;
 export { PoweredByButton };
+export type { PoweredByButtonProps };

--- a/src/components/select/AsyncSelect.tsx
+++ b/src/components/select/AsyncSelect.tsx
@@ -1,7 +1,7 @@
 import omit from 'lodash.omit';
 import React, { useEffect, useState } from 'react';
 import { InputActionMeta } from 'react-select';
-import Select, { BaseSelectProps, SelectProps } from './Select';
+import Select, { SelectProps } from './Select';
 import { Option as OptionType } from './types';
 
 const DEFAULT_PAGE_NUMBER = 1;
@@ -12,7 +12,7 @@ export interface AsyncSelectProps<
   Option extends OptionType = OptionType,
   IsMulti extends boolean = false,
   IsClearable extends boolean = false,
-> extends BaseSelectProps<Option, IsMulti, IsClearable> {
+> extends SelectProps<Option, IsMulti, IsClearable> {
   loadOptions: (searchTerm: string, ...props: any) => Promise<any>;
   paginate?: boolean;
   pageSize?: number;

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -33,7 +33,18 @@ const minHeightBySizeMap: Record<string, number> = {
   medium: 36,
   large: 48,
 };
+
 export interface SelectProps<
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  Option extends OptionType = OptionType,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  IsMulti extends boolean = false,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  IsClearable extends boolean = false,
+> {
+  [key: string]: any;
+}
+export interface SelectPropsFull<
   Option extends OptionType = OptionType,
   IsMulti extends boolean = false,
   IsClearable extends boolean = false,

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -3,12 +3,14 @@ import uiUtilities from '@teamleader/ui-utilities';
 import cx from 'classnames';
 import React, { ForwardedRef, forwardRef, ReactNode, useEffect } from 'react';
 import ReactSelect, {
+  ActionMeta,
   ClearIndicatorProps,
   ControlProps,
   CSSObjectWithLabel,
   DropdownIndicatorProps,
   GroupBase,
   OptionProps,
+  OptionsOrGroups,
   PlaceholderProps,
   Props,
   StylesConfig,
@@ -16,7 +18,6 @@ import ReactSelect, {
 } from 'react-select';
 import ReactCreatableSelect from 'react-select/creatable';
 import SelectType from 'react-select/dist/declarations/src/Select';
-import { ActionMeta, OptionsOrGroups } from '../../../node_modules/react-select/dist/declarations/src/types';
 import { GenericComponent } from '../../@types/types';
 import { COLOR, SIZES } from '../../constants';
 import Box, { omitBoxProps, pickBoxProps } from '../box';

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -27,18 +27,13 @@ import ValidationText from '../validationText';
 import theme from './theme.css';
 import { Option as OptionType } from './types';
 
-const minHeightBySizeMap = {
+const minHeightBySizeMap: Record<string, number> = {
   tiny: 24,
   small: 30,
   medium: 36,
   large: 48,
 };
-
-/* *
- * We have to define BaseSelectProps with optional options, so we can then set them required in Select and never in AsyncSelect.
- * Unfortunately because of BoxProps having index of unknown, Omiting of these props causes all props to become unknown, we cannot Omit options in AsyncSelect.
- * */
-export interface BaseSelectProps<
+export interface SelectProps<
   Option extends OptionType = OptionType,
   IsMulti extends boolean = false,
   IsClearable extends boolean = false,
@@ -83,14 +78,6 @@ export interface BaseSelectProps<
   isMulti?: IsMulti;
 }
 
-export interface SelectProps<
-  Option extends OptionType = OptionType,
-  IsMulti extends boolean = false,
-  IsClearable extends boolean = false,
-> extends BaseSelectProps<Option, IsMulti, IsClearable> {
-  options: OptionsOrGroups<Option, GroupBase<Option>>;
-}
-
 const DropdownIndicator = <Option extends OptionType, IsMulti extends boolean>(
   dropdownIndicatorProps: DropdownIndicatorProps<Option, IsMulti>,
 ) => {
@@ -109,7 +96,7 @@ const DropdownIndicator = <Option extends OptionType, IsMulti extends boolean>(
     </Icon>
   );
 };
-//
+
 const ClearIndicator = <Option extends OptionType, IsMulti extends boolean>(
   clearIndicatorProps: ClearIndicatorProps<Option, IsMulti>,
 ) => {
@@ -475,7 +462,7 @@ function Select<Option extends OptionType, IsMulti extends boolean, IsClearable 
         menuPortalTarget={selectOverlayNode}
         menuShouldBlockScroll
         styles={getStyles()}
-        options={options}
+        options={options || []}
         {...restProps}
       />
       <ValidationText error={error} help={helpText} inverse={inverse} success={success} warning={warning} />

--- a/src/components/select/index.tsx
+++ b/src/components/select/index.tsx
@@ -1,7 +1,7 @@
 import AsyncSelect, { AsyncSelectProps } from './AsyncSelect';
 import Select, { SelectProps } from './Select';
-import { Option, SelectComponentsProps } from './types';
+import { GroupOption, Option, SelectComponentsProps } from './types';
 
 export { Select, AsyncSelect };
-export type { SelectProps, AsyncSelectProps, Option, SelectComponentsProps };
+export type { SelectProps, AsyncSelectProps, Option, SelectComponentsProps, GroupOption };
 export default Select;

--- a/src/components/select/index.tsx
+++ b/src/components/select/index.tsx
@@ -1,7 +1,7 @@
 import AsyncSelect, { AsyncSelectProps } from './AsyncSelect';
 import Select, { SelectProps } from './Select';
-import { Option } from './types';
+import { Option, SelectComponentsProps } from './types';
 
 export { Select, AsyncSelect };
-export type { SelectProps, AsyncSelectProps, Option };
+export type { SelectProps, AsyncSelectProps, Option, SelectComponentsProps };
 export default Select;

--- a/src/components/select/types.ts
+++ b/src/components/select/types.ts
@@ -1,7 +1,65 @@
+import {
+  ClearIndicatorProps,
+  ContainerProps,
+  ControlProps,
+  DropdownIndicatorProps,
+  GroupBase,
+  GroupHeadingProps,
+  GroupProps,
+  IndicatorsContainerProps,
+  IndicatorSeparatorProps,
+  InputProps,
+  LoadingIndicatorProps,
+  MenuListProps,
+  MenuProps,
+  MultiValueGenericProps,
+  MultiValueProps,
+  MultiValueRemoveProps,
+  NoticeProps,
+  OptionProps,
+  PlaceholderProps,
+  SingleValueProps,
+  ValueContainerProps,
+} from 'react-select';
+import { CrossIconProps, DownChevronProps } from 'react-select/dist/declarations/src/components/indicators';
+import { MenuPortalProps } from 'react-select/dist/declarations/src/components/Menu';
+
 export type Value = any;
 
 export interface Option<V = Value> {
   label: string;
   value: V;
   [key: string]: any;
+}
+
+export interface SelectComponentsProps<
+  OptionType extends Option = Option,
+  IsMulti extends boolean = false,
+  Group extends GroupBase<OptionType> = GroupBase<OptionType>,
+> {
+  ClearIndicator: ClearIndicatorProps<OptionType, IsMulti, Group>;
+  Control: ControlProps<OptionType, IsMulti, Group>;
+  DropdownIndicator: DropdownIndicatorProps<OptionType, IsMulti, Group> | null;
+  DownChevron: DownChevronProps;
+  CrossIcon: CrossIconProps;
+  Group: GroupProps<OptionType, IsMulti, Group>;
+  GroupHeading: GroupHeadingProps<OptionType, IsMulti, Group>;
+  IndicatorsContainer: IndicatorsContainerProps<OptionType, IsMulti, Group>;
+  IndicatorSeparator: IndicatorSeparatorProps<OptionType, IsMulti, Group> | null;
+  Input: InputProps<OptionType, IsMulti, Group>;
+  LoadingIndicator: LoadingIndicatorProps<OptionType, IsMulti, Group>;
+  Menu: MenuProps<OptionType, IsMulti, Group>;
+  MenuList: MenuListProps<OptionType, IsMulti, Group>;
+  MenuPortal: MenuPortalProps<OptionType, IsMulti, Group>;
+  LoadingMessage: NoticeProps<OptionType, IsMulti, Group>;
+  NoOptionsMessage: NoticeProps<OptionType, IsMulti, Group>;
+  MultiValue: MultiValueProps<OptionType, IsMulti, Group>;
+  MultiValueContainer: MultiValueGenericProps<OptionType, IsMulti, Group>;
+  MultiValueLabel: MultiValueGenericProps<OptionType, IsMulti, Group>;
+  MultiValueRemove: MultiValueRemoveProps<OptionType, IsMulti, Group>;
+  Option: OptionProps<OptionType, IsMulti, Group>;
+  Placeholder: PlaceholderProps<OptionType, IsMulti, Group>;
+  SelectContainer: ContainerProps<OptionType, IsMulti, Group>;
+  SingleValue: SingleValueProps<OptionType, IsMulti, Group>;
+  ValueContainer: ValueContainerProps<OptionType, IsMulti, Group>;
 }

--- a/src/components/select/types.ts
+++ b/src/components/select/types.ts
@@ -32,6 +32,7 @@ export interface Option<V = Value> {
   [key: string]: any;
 }
 
+export interface GroupOption<O = Option> extends GroupBase<O> {}
 export interface SelectComponentsProps<
   OptionType extends Option = Option,
   IsMulti extends boolean = false,

--- a/src/components/splitButton/SplitButton.tsx
+++ b/src/components/splitButton/SplitButton.tsx
@@ -11,7 +11,7 @@ import isReactElement from '../utils/is-react-element';
 import { SIZES } from '../../constants';
 import theme from './theme.css';
 
-interface SplitButtonProps extends Omit<BoxProps, 'children' | 'size'> {
+export interface SplitButtonProps extends Omit<BoxProps, 'children' | 'size'> {
   /** The MenuItems we pass to our component. */
   children: ReactNode;
   /** Determines which kind of button to be rendered. */

--- a/src/components/splitButton/index.ts
+++ b/src/components/splitButton/index.ts
@@ -1,4 +1,5 @@
-import SplitButton from './SplitButton';
+import SplitButton, { SplitButtonProps } from './SplitButton';
 
 export default SplitButton;
 export { SplitButton };
+export type { SplitButtonProps };

--- a/src/components/statusLabel/StatusLabel.tsx
+++ b/src/components/statusLabel/StatusLabel.tsx
@@ -6,7 +6,7 @@ import { BoxProps } from '../box/Box';
 import { UITextBody, UITextSmall } from '../typography';
 import theme from './theme.css';
 
-interface StatusLabelProps extends Omit<BoxProps, 'size'> {
+export interface StatusLabelProps extends Omit<BoxProps, 'size'> {
   children: ReactNode;
   className?: string;
   color?: Exclude<typeof COLORS[number], 'teal'>;

--- a/src/components/statusLabel/index.tsx
+++ b/src/components/statusLabel/index.tsx
@@ -1,3 +1,4 @@
-import StatusLabel from './StatusLabel';
+import StatusLabel, { StatusLabelProps } from './StatusLabel';
 
 export default StatusLabel;
+export type { StatusLabelProps };

--- a/src/components/tab/TabGroup.tsx
+++ b/src/components/tab/TabGroup.tsx
@@ -13,7 +13,7 @@ import theme from './theme.css';
 const SCROLL_BUTTON_WIDTH = 48;
 const SCROLL_DISTANCE = 200;
 
-interface TabGroupProps extends Omit<BoxProps, 'children'> {
+export interface TabGroupProps extends Omit<BoxProps, 'children'> {
   children: ReactNode;
   className?: string;
   size?: Exclude<typeof SIZES[number], 'tiny' | 'large' | 'fullscreen' | 'smallest' | 'hero'>;

--- a/src/components/tab/TitleTab.tsx
+++ b/src/components/tab/TitleTab.tsx
@@ -8,7 +8,7 @@ import { Heading4, Heading5 } from '../typography';
 import { GenericComponent } from '../../@types/types';
 import { SIZES } from '../../constants';
 
-interface TitleTabProps extends Omit<BoxProps, 'size' | 'element'> {
+export interface TitleTabProps extends Omit<BoxProps, 'size' | 'element'> {
   active?: boolean;
   children: ReactNode;
   element?: React.ElementType;

--- a/src/components/tab/index.tsx
+++ b/src/components/tab/index.tsx
@@ -1,4 +1,5 @@
-import TabGroup from './TabGroup';
-import TitleTab from './TitleTab';
+import TabGroup, { TabGroupProps } from './TabGroup';
+import TitleTab, { TitleTabProps } from './TitleTab';
 
 export { TabGroup, TitleTab };
+export type { TabGroupProps, TitleTabProps };

--- a/src/components/tag/index.tsx
+++ b/src/components/tag/index.tsx
@@ -1,3 +1,4 @@
-import Tag from './Tag';
+import Tag, { TagProps } from './Tag';
 
 export default Tag;
+export type { TagProps };

--- a/src/components/timer/Timer.tsx
+++ b/src/components/timer/Timer.tsx
@@ -9,7 +9,7 @@ import LoadingSpinner from '../loadingSpinner';
 import { Monospaced, UITextBody } from '../typography';
 import theme from './theme.css';
 
-interface TimerProps extends Omit<BoxProps, 'children' | 'className'> {
+export interface TimerProps extends Omit<BoxProps, 'children' | 'className'> {
   className?: string;
   children: ReactNode;
   loading?: boolean;

--- a/src/components/timer/index.tsx
+++ b/src/components/timer/index.tsx
@@ -1,4 +1,5 @@
-import Timer from './Timer';
+import Timer, { TimerProps } from './Timer';
 
 export default Timer;
 export { Timer };
+export type { TimerProps };

--- a/src/components/toast/ToastContainer.tsx
+++ b/src/components/toast/ToastContainer.tsx
@@ -4,7 +4,7 @@ import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { GenericComponent } from '../../@types/types';
 import theme from './theme.css';
 
-interface ToastContainerProps {
+export interface ToastContainerProps {
   /** The content to display inside the ToastContainer */
   children: ReactNode;
   /** A custom class name for custom styling */

--- a/src/components/toast/index.tsx
+++ b/src/components/toast/index.tsx
@@ -1,5 +1,6 @@
-import Toast from './Toast';
-import ToastContainer from './ToastContainer';
+import Toast, { ToastProps } from './Toast';
+import ToastContainer, { ToastContainerProps } from './ToastContainer';
 
 export default Toast;
 export { Toast, ToastContainer };
+export type { ToastProps, ToastContainerProps };

--- a/src/components/toggle/index.ts
+++ b/src/components/toggle/index.ts
@@ -1,2 +1,3 @@
-import Toggle from './Toggle';
+import Toggle, { ToggleProps } from './Toggle';
 export default Toggle;
+export type { ToggleProps };

--- a/src/components/widget/Widget.tsx
+++ b/src/components/widget/Widget.tsx
@@ -7,7 +7,7 @@ import { SIZES } from '../../constants';
 import { BoxProps } from '../box/Box';
 import { GenericComponent } from '../../@types/types';
 
-interface WidgetProps extends Omit<BoxProps, 'children' | 'ref'> {
+export interface WidgetProps extends Omit<BoxProps, 'children' | 'ref'> {
   /** The content to display inside the widget. */
   children?: ReactNode;
   /** The size which controls the padding of the children. */

--- a/src/components/widget/index.ts
+++ b/src/components/widget/index.ts
@@ -1,2 +1,3 @@
-import Widget from './Widget';
+import Widget, { WidgetProps } from './Widget';
 export default Widget;
+export type { WidgetProps };

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,14 @@ import PoweredByButton from './components/poweredByButton';
 import ProgressTracker, { ProgressTrackerProps } from './components/progressTracker';
 import { RadioButton, RadioButtonProps, RadioGroup, RadioGroupProps } from './components/radio';
 import Section, { SectionProps } from './components/section';
-import Select, { AsyncSelect, AsyncSelectProps, Option, SelectComponentsProps, SelectProps } from './components/select';
+import Select, {
+  AsyncSelect,
+  AsyncSelectProps,
+  GroupOption,
+  Option,
+  SelectComponentsProps,
+  SelectProps,
+} from './components/select';
 import SplitButton from './components/splitButton';
 import StatusLabel from './components/statusLabel';
 import { TabGroup, TitleTab } from './components/tab';
@@ -252,4 +259,5 @@ export type {
   BannerProps,
   WysiwygEditorProps,
   SelectComponentsProps,
+  GroupOption,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import Avatar, { AvatarStack } from './components/avatar';
 import Badge from './components/badge';
 import BadgedLink from './components/badgedLink';
 import Banner, { BannerProps } from './components/banner';
-import type { Margin, Padding } from './components/box';
+import type { Margin, Padding, BoxProps } from './components/box';
 import Box from './components/box';
 import Bullet from './components/bullet';
 import Button from './components/button';
@@ -260,4 +260,5 @@ export type {
   WysiwygEditorProps,
   SelectComponentsProps,
   GroupOption,
+  BoxProps,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ import PoweredByButton from './components/poweredByButton';
 import ProgressTracker, { ProgressTrackerProps } from './components/progressTracker';
 import { RadioButton, RadioButtonProps, RadioGroup, RadioGroupProps } from './components/radio';
 import Section, { SectionProps } from './components/section';
-import Select, { AsyncSelect, AsyncSelectProps, Option, SelectProps } from './components/select';
+import Select, { AsyncSelect, AsyncSelectProps, Option, SelectComponentsProps, SelectProps } from './components/select';
 import SplitButton from './components/splitButton';
 import StatusLabel from './components/statusLabel';
 import { TabGroup, TitleTab } from './components/tab';
@@ -251,4 +251,5 @@ export type {
   SectionProps,
   BannerProps,
   WysiwygEditorProps,
+  SelectComponentsProps,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,52 +1,90 @@
-import AdvancedCollapsible from './components/advancedCollapsible';
-import Alert from './components/alert';
-import Avatar, { AvatarStack } from './components/avatar';
-import Badge from './components/badge';
-import BadgedLink from './components/badgedLink';
+import AdvancedCollapsible, { AdvancedCollapsibleProps } from './components/advancedCollapsible';
+import Alert, { AlertProps } from './components/alert';
+import Avatar, { AvatarProps, AvatarStack, AvatarStackProps } from './components/avatar';
+import Badge, { BadgeProps } from './components/badge';
+import BadgedLink, { BadgedLinkProps } from './components/badgedLink';
 import Banner, { BannerProps } from './components/banner';
-import type { Margin, Padding, BoxProps } from './components/box';
+import type { BoxProps, Margin, Padding } from './components/box';
 import Box from './components/box';
-import Bullet from './components/bullet';
-import Button from './components/button';
-import ButtonGroup from './components/buttonGroup';
-import Checkbox from './components/checkbox';
-import Container from './components/container';
-import Counter from './components/counter';
+import Bullet, { BulletProps } from './components/bullet';
+import Button, { ButtonProps } from './components/button';
+import ButtonGroup, { ButtonGroupProps } from './components/buttonGroup';
+import Checkbox, { CheckboxProps } from './components/checkbox';
+import Container, { ContainerProps } from './components/container';
+import Counter, { CounterProps } from './components/counter';
 import DataGrid, { DataGridProps } from './components/datagrid';
-import { DatePicker, DatePickerInput } from './components/datepicker';
-import DetailPage, { DetailPageBody, DetailPageHeader } from './components/detailPage';
-import Dialog, { DialogBase } from './components/dialog';
-import EmailSelector from './components/emailSelector';
-import EmptyState from './components/emptyState';
-import FilterSelection from './components/filterSelection';
-import Flex from './components/flex';
-import Grid from './components/grid';
-import Icon from './components/icon';
-import IconButton from './components/iconButton';
-import Input, { DurationInput, InputBase, NumericInput, Textarea, TimeInput } from './components/input';
+import { DatePicker, DatePickerInput, DatePickerInputProps, DatePickerProps } from './components/datepicker';
+import DetailPage, {
+  DetailPageBody,
+  DetailPageBodyProps,
+  DetailPageHeader,
+  DetailPageHeaderProps,
+  DetailPageProps,
+} from './components/detailPage';
+import Dialog, { DialogBase, DialogBaseProps, DialogProps } from './components/dialog';
+import EmailSelector, { EmailSelectorProps } from './components/emailSelector';
+import EmptyState, { EmptyStateProps } from './components/emptyState';
+import FilterSelection, { FilterSelectionProps } from './components/filterSelection';
+import Flex, { FlexProps } from './components/flex';
+import Grid, { GridProps } from './components/grid';
+import Icon, { IconProps } from './components/icon';
+import IconButton, { IconButtonProps } from './components/iconButton';
+import Input, {
+  DurationInput,
+  DurationInputProps,
+  InputBase,
+  InputBaseProps,
+  InputProps,
+  NumericInput,
+  NumericInputProps,
+  Textarea,
+  TextareaProps,
+  TimeInput,
+  TimeInputProps,
+} from './components/input';
 import { Island, IslandGroup, IslandGroupProps, IslandProps } from './components/island';
-import Label from './components/label';
-import { LabelValuePair, LabelValuePairGroup } from './components/labelValuePair';
-import Link from './components/link';
-import LoadingBar from './components/loadingBar';
-import LoadingSpinner from './components/loadingSpinner';
-import MarketingButton from './components/marketingButton';
-import MarketingButtonGroup from './components/marketingButtonGroup';
-import MarketingDialog from './components/marketingDialog';
-import MarketingLink from './components/marketingLink';
-import MarketingLockBadge from './components/marketingLockBadge';
-import MarketingMarker from './components/marketingMarker';
-import MarketingStatusLabel from './components/marketingStatusLabel';
-import MarketingTab from './components/marketingTab';
-import { MarketingHeading1, MarketingHeading2 } from './components/marketingTypography';
-import Menu, { IconMenu, MenuDivider, MenuItem, MenuTitle } from './components/menu';
-import Message from './components/message';
+import Label, { LabelProps } from './components/label';
+import {
+  LabelValuePair,
+  LabelValuePairGroup,
+  LabelValuePairGroupProps,
+  LabelValuePairProps,
+} from './components/labelValuePair';
+import Link, { LinkProps } from './components/link';
+import LoadingBar, { LoadingBarProps } from './components/loadingBar';
+import LoadingSpinner, { LoadingSpinnerProps } from './components/loadingSpinner';
+import MarketingButton, { MarketingButtonProps } from './components/marketingButton';
+import MarketingButtonGroup, { MarketingButtonGroupProps } from './components/marketingButtonGroup';
+import MarketingDialog, { MarketingDialogProps } from './components/marketingDialog';
+import MarketingLink, { MarketingLinkProps } from './components/marketingLink';
+import MarketingLockBadge, { MarketingLockBadgeProps } from './components/marketingLockBadge';
+import MarketingMarker, { MarketingMarkerProps } from './components/marketingMarker';
+import MarketingStatusLabel, { MarketingStatusLabelProps } from './components/marketingStatusLabel';
+import MarketingTab, { MarketingTabProps } from './components/marketingTab';
+import { MarketingHeading1, MarketingHeading2, MarketingHeadingProps } from './components/marketingTypography';
+import Menu, {
+  IconMenu,
+  IconMenuProps,
+  MenuDivider,
+  MenuItem,
+  MenuItemProps,
+  MenuProps,
+  MenuTitle,
+  MenuTitleProps,
+} from './components/menu';
+import Message, { MessageProps } from './components/message';
 import Overlay, { OverlayProps } from './components/overlay';
-import OverviewPage, { OverviewPageBody, OverviewPageHeader } from './components/overviewPage';
-import Pagination from './components/pagination';
-import Passport, { EmptyPassport } from './components/passport';
-import Popover from './components/popover';
-import PoweredByButton from './components/poweredByButton';
+import OverviewPage, {
+  OverviewPageBody,
+  OverviewPageBodyProps,
+  OverviewPageHeader,
+  OverviewPageHeaderProps,
+  OverviewPageProps,
+} from './components/overviewPage';
+import Pagination, { PaginationProps } from './components/pagination';
+import Passport, { EmptyPassport, EmptyPassportProps, PassportProps } from './components/passport';
+import Popover, { PopoverProps } from './components/popover';
+import PoweredByButton, { PoweredByButtonProps } from './components/poweredByButton';
 import ProgressTracker, { ProgressTrackerProps } from './components/progressTracker';
 import { RadioButton, RadioButtonProps, RadioGroup, RadioGroupProps } from './components/radio';
 import Section, { SectionProps } from './components/section';
@@ -58,13 +96,13 @@ import Select, {
   SelectComponentsProps,
   SelectProps,
 } from './components/select';
-import SplitButton from './components/splitButton';
-import StatusLabel from './components/statusLabel';
-import { TabGroup, TitleTab } from './components/tab';
-import Tag from './components/tag';
-import Timer from './components/timer';
-import { Toast, ToastContainer } from './components/toast';
-import Toggle from './components/toggle';
+import SplitButton, { SplitButtonProps } from './components/splitButton';
+import StatusLabel, { StatusLabelProps } from './components/statusLabel';
+import { TabGroup, TabGroupProps, TitleTab, TitleTabProps } from './components/tab';
+import Tag, { TagProps } from './components/tag';
+import Timer, { TimerProps } from './components/timer';
+import { Toast, ToastContainer, ToastContainerProps, ToastProps } from './components/toast';
+import Toggle, { ToggleProps } from './components/toggle';
 import Tooltip, { TooltipProps } from './components/tooltip';
 import {
   Heading1,
@@ -96,7 +134,7 @@ import ValidationText, {
   WarningText,
   WarningTextProps,
 } from './components/validationText';
-import Widget from './components/widget';
+import Widget, { WidgetProps } from './components/widget';
 import WysiwygEditor, { WysiwygEditorProps } from './components/wysiwygEditor';
 
 import {
@@ -236,14 +274,84 @@ export {
   MarketingDialog,
 };
 export type {
+  AdvancedCollapsibleProps,
+  AlertProps,
+  AvatarProps,
+  AvatarStackProps,
+  PoweredByButtonProps,
   AsyncSelectProps,
+  BadgeProps,
+  BadgedLinkProps,
+  ToggleProps,
+  BulletProps,
+  StatusLabelProps,
+  ButtonProps,
+  ToastProps,
+  ToastContainerProps,
+  CheckboxProps,
+  LinkProps,
+  PaginationProps,
+  ContainerProps,
+  TimerProps,
+  SplitButtonProps,
+  MarketingLinkProps,
+  CounterProps,
+  WidgetProps,
+  PassportProps,
+  EmptyPassportProps,
+  TagProps,
+  IconProps,
+  TabGroupProps,
+  TitleTabProps,
+  DatePickerProps,
+  MessageProps,
+  DatePickerInputProps,
+  MarketingDialogProps,
+  DetailPageProps,
+  GridProps,
+  MenuProps,
+  IconMenuProps,
+  MenuItemProps,
+  MenuTitleProps,
+  DialogProps,
+  PopoverProps,
+  InputProps,
+  LabelProps,
+  DurationInputProps,
+  LabelValuePairProps,
+  LabelValuePairGroupProps,
+  LoadingBarProps,
+  MarketingTabProps,
+  MarketingButtonGroupProps,
+  MarketingLockBadgeProps,
+  MarketingButtonProps,
+  OverviewPageProps,
+  OverviewPageBodyProps,
+  OverviewPageHeaderProps,
+  InputBaseProps,
+  NumericInputProps,
+  TextareaProps,
+  TimeInputProps,
+  IconButtonProps,
+  MarketingHeadingProps,
+  EmailSelectorProps,
+  MarketingStatusLabelProps,
+  EmptyStateProps,
+  FilterSelectionProps,
+  DialogBaseProps,
+  MarketingMarkerProps,
+  DetailPageHeaderProps,
+  DetailPageBodyProps,
+  ButtonGroupProps,
   DataGridProps,
   ErrorTextProps,
   HelpTextProps,
   SuccessTextProps,
   ValidationTextProps,
   WarningTextProps,
+  LoadingSpinnerProps,
   MarkerProps,
+  FlexProps,
   MonospacedProps,
   TextProps,
   OverlayProps,


### PR DESCRIPTION
### Description

- all components have exported their interfaces
- Select props are temporary set as `any`, until adaptation to core is ready (there is around 40 TS errors with proper TS prop of Select). This is for case if there is need for releasing UI library until PR for adapting those changes is ready.
- Updated Select props to be easier to use 

### Manual Check 
Smoke test stories
