### PR TITLE
Fix dialog being to big on Safari

### DIFF
--- a/src/components/dialog/theme.css
+++ b/src/components/dialog/theme.css
@@ -20,7 +20,7 @@
   border-radius: var(--dialog-border-radius);
   display: flex;
   flex-direction: column;
-  max-height: 96vh;
+  max-height: calc(96vh - 20px);
   max-width: 90vw;
   opacity: 0;
   transform: translateY(var(--dialog-initial-translate-y));

--- a/src/components/overlay/theme.css
+++ b/src/components/overlay/theme.css
@@ -3,12 +3,12 @@
 
 .overlay {
   bottom: 0;
-  height: 100vh;
+  height: 100%;
   left: 0;
   position: fixed;
   top: 0;
   transition: background var(--animation-duration) var(--animation-curve-default);
-  width: 100vw;
+  width: 100%;
 }
 
 .is-entered {


### PR DESCRIPTION
### Description

Bug: When multiple tabs are open in safari, the save button of the new modal company add isn't visible.
This was semi-reproducible on Safari Macbook. It indeed cut off a part of the screen when opening a new tab.

The cause of the bug is because we are using `vh` and `vw` as a measurelent in CSS. This type of measurement is differently calculated on WebKit.

#### Screenshot before this PR

<img width="1010" alt="Screenshot 2022-10-26 at 16 37 52" src="https://user-images.githubusercontent.com/10358801/198056277-3f4a60ff-4800-426e-82e0-2fb4625a77be.png">

#### Screenshot after this PR

<img width="1021" alt="Screenshot 2022-10-26 at 16 38 30" src="https://user-images.githubusercontent.com/10358801/198056311-792fafa0-ca2a-4a7a-9216-b326f7edc675.png">
