### PR TITLE
Release/16.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,24 @@
 
 ### Changed
 
-- `Label`: `marginBottom` size is same for all sizes and further customisable ([@qubis741](https://github.com/qubis741)) in [#2408](https://github.com/teamleadercrm/ui/pull/2408))
-
 ### Deprecated
 
 ### Removed
 
 ### Fixed
 
-- `Overlay`: set tabIndex to fix onKeyDown events no longer registering after clicking inside the overlay ([@BeirlaenAaron](https://github.com/BeirlaenAaron)) in [#2394](https://github.com/teamleadercrm/ui/pull/2394))
-
 ### Dependency updates
+
+## [16.4.1] - 2022-10-27
+
+### Changed
+
+- `Label`: `marginBottom` size is same for all sizes and further customisable ([@qubis741](https://github.com/qubis741)) in [#2408](https://github.com/teamleadercrm/ui/pull/2408))
+
+### Fixed
+
+- `Overlay`: set tabIndex to fix onKeyDown events no longer registering after clicking inside the overlay ([@BeirlaenAaron](https://github.com/BeirlaenAaron)) in [#2394](https://github.com/teamleadercrm/ui/pull/2394))
+- `Dialog`: Dialog size update on Safari ([@stefaandevylder](https://github.com/stefaandevylder)) in [#2412](https://github.com/teamleadercrm/ui/pull/2412)
 
 ## [16.4.0] - 2022-09-29
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "16.4.0",
+  "version": "16.4.1",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [16.4.1] - 2022-10-27

### Changed

- `Label`: `marginBottom` size is same for all sizes and further customisable ([@qubis741](https://github.com/qubis741)) in [#2408](https://github.com/teamleadercrm/ui/pull/2408))

### Fixed

- `Overlay`: set tabIndex to fix onKeyDown events no longer registering after clicking inside the overlay ([@BeirlaenAaron](https://github.com/BeirlaenAaron)) in [#2394](https://github.com/teamleadercrm/ui/pull/2394))
- `Dialog`: Dialog size update on Safari ([@stefaandevylder](https://github.com/stefaandevylder)) in [#2412](https://github.com/teamleadercrm/ui/pull/2412)