### PR TITLE
Revert back tabIndex on Overlay

### DIFF
--- a/src/components/overlay/Overlay.tsx
+++ b/src/components/overlay/Overlay.tsx
@@ -82,7 +82,6 @@ export const Overlay: GenericComponent<OverlayProps> = ({
             onKeyDown={handleEscKey}
             onMouseDown={handleMouseDown}
             onMouseUp={handleMouseUp}
-            tabIndex={0}
             className={cx(
               theme['overlay'],
               theme[backdrop],


### PR DESCRIPTION
### Description

This brings a bug where you can't click anymore on the emailSelector suggestions.

### Manual check

- Link ui with core, and don't forget to run build
- go to an invoice detail, click send -> send via email, you see an email Selector with label `To:`. Click it, you now can see the suggestions 
