### PR TITLE
Release/16.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [16.4.4] - 2022-11-07
+
+### Fixed
+
+- `Tabindex on overlay`: Revert back ([@eniskraasniqi1](https://github.com/eniskraasniqi1)) in [#2431](https://github.com/teamleadercrm/ui/pull/2431)
+
 ## [16.4.3] - 22-10-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Fixed
 
-- `Tabindex on overlay`: Revert back ([@eniskraasniqi1](https://github.com/eniskraasniqi1)) in [#2431](https://github.com/teamleadercrm/ui/pull/2431)
+- `Overlay`: Revert back "set tabIndex to fix onKeyDown events no longer registering after clicking inside the overlay" ([@eniskraasniqi1](https://github.com/eniskraasniqi1)) in [#2431](https://github.com/teamleadercrm/ui/pull/2431)
 
 ## [16.4.3] - 22-10-31
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "16.4.3",
+  "version": "16.4.4",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [16.4.4] - 2022-11-07

### Fixed

- `Overlay`: Revert back "set tabIndex to fix onKeyDown events no longer registering after clicking inside the overlay" ([@eniskraasniqi1](https://github.com/eniskraasniqi1)) in [#2431](https://github.com/teamleadercrm/ui/pull/2431)