### PR TITLE
Tweak select menu margins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Select`: Adjust margins in dropdown when option groups are used ([@lorgan3](https://github.com/lorgan3)) in [#2440](https://github.com/teamleadercrm/ui/pull/2440))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -9,6 +9,9 @@ import ReactSelect, {
   CSSObjectWithLabel,
   DropdownIndicatorProps,
   GroupBase,
+  GroupHeadingProps,
+  GroupProps,
+  MenuListProps,
   OptionProps,
   OptionsOrGroups,
   PlaceholderProps,
@@ -246,9 +249,14 @@ function Select<Option extends OptionType, IsMulti extends boolean, IsClearable 
     };
   };
 
-  const getGroupStyles = (base: CSSObjectWithLabel): CSSObjectWithLabel => {
+  const getGroupStyles = (
+    base: CSSObjectWithLabel,
+    props: GroupProps<Option, boolean, GroupBase<Option>>,
+  ): CSSObjectWithLabel => {
     return {
       ...base,
+      paddingTop: props.data.label ? 3 : 0,
+      paddingBottom: 3,
       borderBottomColor: inverse ? COLOR.TEAL.LIGHT : COLOR.NEUTRAL.NORMAL,
       borderBottomStyle: 'solid',
       borderBottomWidth: '1px',
@@ -258,13 +266,25 @@ function Select<Option extends OptionType, IsMulti extends boolean, IsClearable 
     };
   };
 
-  const getGroupHeadingStyles = (base: CSSObjectWithLabel) => {
+  const getGroupHeadingStyles = (
+    base: CSSObjectWithLabel,
+    props: GroupHeadingProps<Option, boolean, GroupBase<Option>>,
+  ) => {
     return {
       ...base,
       color: inverse ? COLOR.NEUTRAL.LIGHTEST : COLOR.TEAL.DARKEST,
       fontSize: '12px',
       fontWeight: 700,
       letterSpacing: '0.6px',
+      ...(props.data.label
+        ? {
+            marginBottom: 9,
+            marginTop: 9,
+          }
+        : {
+            marginBottom: 3,
+            marginTop: 3,
+          }),
     };
   };
 
@@ -288,6 +308,16 @@ function Select<Option extends OptionType, IsMulti extends boolean, IsClearable 
             position: 'absolute',
           }
         : {}),
+    };
+  };
+
+  const getMenuListStyles = (
+    base: CSSObjectWithLabel,
+    props: MenuListProps<Option, boolean, GroupBase<Option>>,
+  ): CSSObjectWithLabel => {
+    return {
+      ...base,
+      ...(props.options[0]?.options ? { paddingTop: 1, paddingBottom: 1 } : {}),
     };
   };
 
@@ -435,6 +465,7 @@ function Select<Option extends OptionType, IsMulti extends boolean, IsClearable 
     groupHeading: getGroupHeadingStyles,
     input: getInput,
     menu: getMenuStyles,
+    menuList: getMenuListStyles,
     menuPortal: getMenuPortalStyles,
     multiValue: getMultiValueStyles,
     multiValueLabel: getMultiValueLabelStyles,

--- a/src/components/select/select.stories.tsx
+++ b/src/components/select/select.stories.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { OptionProps } from 'react-select';
 import { addStoryInGroup, LOW_LEVEL_BLOCKS } from '../../../.storybook/utils';
 import { AsyncSelect, Avatar, Box, Label, Select, TextBody } from '../../index';
-import { customOptions, groupedOptions, options } from '../../static/data/select';
+import { customOptions, groupedOptions, groupedOptionsWithoutLabels, options } from '../../static/data/select';
 import { Option } from './types';
 
 export default {
@@ -95,6 +95,12 @@ export const grouped: ComponentStory<typeof Select> = () => {
   const [value, setValue] = useState<Option | null>(null);
   const handleChange = (option: Option) => setValue(option);
   return <Select value={value} options={groupedOptions} onChange={handleChange} />;
+};
+
+export const groupedWithoutLabels: ComponentStory<typeof Select> = () => {
+  const [value, setValue] = useState<Option | null>(null);
+  const handleChange = (option: Option) => setValue(option);
+  return <Select value={value} options={groupedOptionsWithoutLabels} onChange={handleChange} />;
 };
 
 export const customOption: ComponentStory<typeof Select> = () => {

--- a/src/static/data/select.ts
+++ b/src/static/data/select.ts
@@ -40,5 +40,22 @@ const groupedOptions: GroupBase<Option>[] = [
   },
 ];
 
+const groupedOptionsWithoutLabels: GroupBase<Option>[] = [
+  {
+    options: [
+      { label: 'Chocolate', value: 'chocolate' },
+      { label: 'Vanilla', value: 'vanilla', isDisabled: true },
+      { label: 'Strawberry', value: 'strawberry' },
+    ],
+  },
+  {
+    options: [
+      { label: 'Red', value: 'red' },
+      { label: 'Green', value: 'green' },
+      { label: 'Blue', value: 'blue' },
+    ],
+  },
+];
+
 export default options;
-export { customOptions, groupedOptions, options };
+export { customOptions, groupedOptions, groupedOptionsWithoutLabels, options };


### PR DESCRIPTION
### Description

Adjust the margins on the select dropdown with grouped options to more closely match our designs

#### Screenshot before this PR

<img width="958" alt="image" src="https://user-images.githubusercontent.com/1833617/201134157-4b5b01c6-612b-4a17-b20a-966aec5b9f75.png">

<img width="957" alt="image" src="https://user-images.githubusercontent.com/1833617/201134214-c0a61e32-d3ca-4fa7-8e8c-dc13f5301aae.png">

#### Screenshot after this PR

<img width="957" alt="image" src="https://user-images.githubusercontent.com/1833617/201133866-63b0e185-2b72-446e-9c37-31836e4a131b.png">

<img width="955" alt="image" src="https://user-images.githubusercontent.com/1833617/201133996-8685ae1b-b808-4221-99a2-544716250cc0.png">


### Breaking changes

/