### PR TITLE
Call `onChange` prop  in input blur of DatePickerInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [17.0.2] - 2022-11-16
+
+### Fixed
+
+- `DatePickerInput`: call `onChange` prop in input blur ([@qubis741](https://github.com/qubis741)) in [#2447](https://github.com/teamleadercrm/ui/pull/2447))
+
 ## [17.0.1] - 2022-11-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Fixed
 
-- `DatePickerInput`: call `onChange` prop in input blur ([@qubis741](https://github.com/qubis741)) in [#2447](https://github.com/teamleadercrm/ui/pull/2447))
+- `DatePickerInput`: call `onChange` prop on input blur ([@qubis741](https://github.com/qubis741)) in [#2447](https://github.com/teamleadercrm/ui/pull/2447))
 
 ## [17.0.1] - 2022-11-16
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "17.0.1",
+  "version": "17.0.2",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/src/components/datepicker/DatePickerInput.tsx
+++ b/src/components/datepicker/DatePickerInput.tsx
@@ -143,6 +143,7 @@ function DatePickerInput<IsTypeable extends boolean = true>({
       const date = parseMultiFormatsDate(inputValue, ALLOWED_DATE_FORMATS, locale);
       if (date && isAllowedDate(date, dayPickerProps?.disabledDays)) {
         handleInputValueChange(getFormattedDateString(date));
+        onChange && onChange(date);
       } else {
         setDisplayError(true);
       }


### PR DESCRIPTION
### Fixed

- `DatePickerInput`: call `onChange` prop in input blur ([@qubis741](https://github.com/qubis741)) in [#2447](https://github.com/teamleadercrm/ui/pull/2447))

### Manual check
Link to core, submitting of dialogs works. PM me for over shoulder