### PR TITLE
Make sure to stop the NumericInput `mouseDown` loops when max value or min value is reached

### DIFF
--- a/.storybook/stories/playground/numericInput.stories.tsx
+++ b/.storybook/stories/playground/numericInput.stories.tsx
@@ -14,7 +14,28 @@ export default {
   },
 };
 
-export const numericInput = () => {
+export const numericInputWithStepper = () => {
+  const [value, setValue] = useState(1);
+
+  const min = 1;
+  const max = 10;
+
+  const handleChange = (event) => {
+    const newValue = (event as ChangeEvent<HTMLInputElement>).currentTarget.valueAsNumber;
+
+    setValue(newValue);
+  };
+
+  return (
+    <Box style={{ maxWidth: '300px', gap: '12px' }} display="flex" flexDirection="column">
+      <NumericInput stepper="connected" min={min} max={max} value={value} onChange={handleChange} />
+    </Box>
+  );
+};
+
+numericInputWithStepper.storyName = 'Numeric Input stepper control';
+
+export const numericInputWithStepperAndCustomStepperStates = () => {
   const [value, setValue] = useState<number>(3);
   const [hasMinErrorVisible, setMinErrorVisible] = useState<boolean>(false);
   const [hasMaxErrorVisible, setMaxErrorVisible] = useState<boolean>(false);
@@ -68,4 +89,4 @@ export const numericInput = () => {
   );
 };
 
-numericInput.storyName = 'Numeric input stepper control';
+numericInputWithStepperAndCustomStepperStates.storyName = 'Numeric Input stepper control with custom stepper states';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Fixed
 
-- `NumericInput`: Make sure the stepper `onMouseDown` loops stop when the minimum or maximum value is reached ([@kristofcolpaert](https://github.com/kristofcolpaert)) in )[#2451](https://github.com/teamleadercrm/ui/pull/2451))
+- `NumericInput`: Make sure the stepper `onMouseDown` loops stop when the minimum or maximum value is reached ([@kristofcolpaert](https://github.com/kristofcolpaert)) in ([#2451](https://github.com/teamleadercrm/ui/pull/2451))
 
 ## [17.0.2] - 2022-11-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [17.0.3] - 2022-11-18
+
+### Fixed
+
+- `NumericInput`: Make sure the stepper `onMouseDown` loops stop when the minimum or maximum value is reached ([@kristofcolpaert](https://github.com/kristofcolpaert)) in )[#2451](https://github.com/teamleadercrm/ui/pull/2451))
+
 ## [17.0.2] - 2022-11-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,9 @@
 
 ### Fixed
 
-### Dependency updates
-
-## [17.0.3] - 2022-11-18
-
-### Fixed
-
 - `NumericInput`: Make sure the stepper `onMouseDown` loops stop when the minimum or maximum value is reached ([@kristofcolpaert](https://github.com/kristofcolpaert)) in ([#2451](https://github.com/teamleadercrm/ui/pull/2451))
+
+### Dependency updates
 
 ## [17.0.2] - 2022-11-16
 

--- a/src/components/input/NumericInput.tsx
+++ b/src/components/input/NumericInput.tsx
@@ -135,15 +135,19 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
       valueRef.current = value;
     }, [value]);
 
-    const isMinReached = () => toNumber(value || 0) <= min;
+    const isMinValue = (value: number) => value <= min;
 
-    const isMaxReached = () => toNumber(value || 0) >= max;
+    const isMinReached = () => isMinValue(toNumber(value || 0));
+
+    const isMaxValue = (value: number) => value >= max;
+
+    const isMaxReached = () => isMaxValue(toNumber(value || 0));
 
     const handleChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       onChange && onChange(event, event.currentTarget.value);
     };
 
-    const updateStep = (n: number) => {
+    const updateStep = (n: number): number | undefined => {
       const currentValue = toNumber(valueRef.current || 0);
       const stepN = step * n;
 
@@ -168,14 +172,16 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
 
       prototypeValueSetter.call(currentInputElement, newValueBoundToMinMax);
       currentInputElement.dispatchEvent(new Event('change', { bubbles: true }));
+
+      return newValueBoundToMinMax;
     };
 
-    const handleIncreaseValue = () => {
-      updateStep(1);
+    const handleIncreaseValue = (): number | undefined => {
+      return updateStep(1);
     };
 
-    const handleDecreaseValue = () => {
-      updateStep(-1);
+    const handleDecreaseValue = (): number | undefined => {
+      return updateStep(-1);
     };
 
     const handleClearStepperIncreaseTimer = () => {
@@ -205,14 +211,18 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
         }
       }
 
-      handleDecreaseValue();
+      let newValue = handleDecreaseValue();
 
       decreaseTimeoutRef.current = setTimeout(() => {
         decreaseTimerRef.current = setInterval(() => {
-          if (isMinReached()) {
+          if (!newValue) {
+            return;
+          }
+
+          if (isMinValue(newValue)) {
             handleClearStepperDecreaseTimer();
           } else {
-            handleDecreaseValue();
+            newValue = handleDecreaseValue();
           }
         }, 75);
       }, 300);
@@ -227,14 +237,18 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
         }
       }
 
-      handleIncreaseValue();
+      let newValue = handleIncreaseValue();
 
       increaseTimeoutRef.current = setTimeout(() => {
         increaseTimerRef.current = setInterval(() => {
-          if (isMaxReached()) {
+          if (!newValue) {
+            return;
+          }
+
+          if (isMaxValue(newValue)) {
             handleClearStepperIncreaseTimer();
           } else {
-            handleIncreaseValue();
+            newValue = handleIncreaseValue();
           }
         }, 75);
       }, 300);


### PR DESCRIPTION
### Description

- `NumericInput`: Make sure the stepper `onMouseDown` loops stop when the minimum or maximum value is reached

#### Screenshot before this PR

https://user-images.githubusercontent.com/4469441/202491718-c4a7ad89-dd13-407a-8e76-fec794374e14.mov

#### Screenshot after this PR

https://user-images.githubusercontent.com/4469441/202491760-dd850a16-a8e5-4baf-aa9a-c58e33f7b27f.mov
