### PR TITLE
MarketingMenuItem: Add color unconditionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,18 @@
 
 ### Dependency updates
 
+## [17.0.4] - 2022-11-22
+
+### Fixed
+
+- `MarketingMenuItem`: Ensure color is correct for both links and buttons ([@lorgan3](https://github.com/lorgan3)) in ([#2456](https://github.com/teamleadercrm/ui/pull/2456))
+
 ## [17.0.3] - 2022-11-21
 
 ### Added
 
 - `MarketingMenuItem`: Added new component ([@lorgan3](https://github.com/lorgan3)) in ([#2452](https://github.com/teamleadercrm/ui/pull/2452))
+
 ### Fixed
 
 - `NumericInput`: Make sure the stepper `onMouseDown` loops stop when the minimum or maximum value is reached ([@kristofcolpaert](https://github.com/kristofcolpaert)) in ([#2451](https://github.com/teamleadercrm/ui/pull/2451))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "17.0.3",
+  "version": "17.0.4",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/src/components/marketingMenuItem/MarketingMenuItem.tsx
+++ b/src/components/marketingMenuItem/MarketingMenuItem.tsx
@@ -65,8 +65,8 @@ const MarketingMenuItem: GenericComponent<MarketingMenuItemProps> = ({
         <Box
           marginHorizontal={3}
           flex="1 1 auto"
-          className={cx({
-            [theme['marketing-menu-item-text-container']]: element === 'a',
+          className={cx(theme['marketing-menu-item-text-container'], {
+            [theme['marketing-menu-item-link-container']]: element === 'a',
           })}
         >
           <TextBodyCompact>{label}</TextBodyCompact>

--- a/src/components/marketingMenuItem/marketingMenuItem.stories.tsx
+++ b/src/components/marketingMenuItem/marketingMenuItem.stories.tsx
@@ -21,16 +21,12 @@ export const MenuWithMenuUpsell: ComponentStory<typeof MarketingMenuItem> = (arg
   <Menu>
     <MenuItem label="Foo label" caption="This is foo's caption" />
     <MenuItem label="Bar label" caption="Caption of bar" />
-    <MarketingMenuItem {...args} />
+    <MarketingMenuItem {...args} onClick={() => console.log('onClick: upsell')} />
   </Menu>
 );
 
 MenuWithMenuUpsell.args = {
   label: 'Unlock baz',
-  icon: <IconExternalLinkSmallOutline />,
-  element: 'a',
-  href: 'https://www.teamleader.be',
-  target: '_blank',
 };
 
 const options = [

--- a/src/components/marketingMenuItem/theme.css
+++ b/src/components/marketingMenuItem/theme.css
@@ -47,8 +47,11 @@
     background-color: var(--menu-item-selected-background);
   }
 
-  &-text-container {
+  &-link-container {
     pointer-events: none;
+  }
+
+  &-text-container {
     color: var(--color-marketing-violet);
   }
 


### PR DESCRIPTION
### Description

The marketing color was not added for button MarketingMenuItems. I've fixed it and updated the story so we can see both examples

#### Screenshot before this PR

<img width="189" alt="image" src="https://user-images.githubusercontent.com/1833617/203090266-0c2971fc-4e36-40a6-91db-4b655a97695e.png">

#### Screenshot after this PR

<img width="172" alt="image" src="https://user-images.githubusercontent.com/1833617/203090305-cadac5dd-b408-43a1-b94e-65d4147cc554.png">


### Breaking changes
/
