### PR TITLE
Make sure Dialog scroll shadow appears above inner elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Dialog`: Added z-index to scroll shadow to make sure it appears above inner elements ([@BeirlaenAaron](https://github.com/BeirlaenAaron)) in ([#2463](https://github.com/teamleadercrm/ui/pull/2463))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/dialog/theme.css
+++ b/src/components/dialog/theme.css
@@ -97,4 +97,5 @@
 .scroll-shadow {
   box-shadow: 0px 0px 1px rgba(130, 130, 140, 0.09), 0px 0px 0px rgba(130, 130, 140, 0.09),
     0px -4px 8px rgba(130, 130, 140, 0.09);
+  z-index: 2;
 }


### PR DESCRIPTION
### Description

The scroll shadow of dialogs wasn't appearing above inner elements like inputs
Just adding a z-index seems to fix this

This was a problem with elements in the dialog taking it's full width (f.e. DataGrid), the scroll shadow wouldn't be visible at all because it's under it

#### Screenshot before this PR

![image](https://user-images.githubusercontent.com/55881661/203524025-172c0bbc-7f9c-4944-8217-faaa5aae67a2.png)
![image](https://user-images.githubusercontent.com/55881661/203525850-d99b3ff6-7334-4a01-8d1a-1f769446424c.png)


#### Screenshot after this PR

![image](https://user-images.githubusercontent.com/55881661/203523983-03623871-a27e-4a72-ae51-d3efb76cdfcc.png)
![image](https://user-images.githubusercontent.com/55881661/203525921-d7d156ee-a7ff-4f37-b086-ac09bf970aa0.png)


### Breaking changes

N/A
