### PR TITLE
Make `MessageProps` extend `BoxProps`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Message`: Make `MessageProps` extend the `BoxProps` and make `title` property optional ([@kristofcolpaert](https://github.com/kristofcolpaert)) in [#2465](https://github.com/teamleadercrm/ui/pull/2465))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/message/Message.tsx
+++ b/src/components/message/Message.tsx
@@ -68,7 +68,7 @@ export interface MessageProps extends Omit<BoxProps, 'children'> {
   /** A status type to determine color and icon */
   status?: Status;
   /** The message title */
-  title: React.ReactNode;
+  title?: React.ReactNode;
 }
 
 const Message: GenericComponent<MessageProps> = ({

--- a/src/components/message/Message.tsx
+++ b/src/components/message/Message.tsx
@@ -5,7 +5,7 @@ import {
   IconCloseMediumOutline,
   IconWarningBadgedMediumFilled,
 } from '@teamleader/ui-icons';
-import Box from '../box';
+import Box, { BoxProps } from '../box';
 import Button from '../button';
 import ButtonGroup from '../buttonGroup';
 import Icon from '../icon';
@@ -52,7 +52,7 @@ const iconMap = {
   warning: IconWarningBadgedMediumFilled,
 };
 
-export interface MessageProps {
+export interface MessageProps extends Omit<BoxProps, 'children'> {
   /** The content to display inside the message. */
   children: React.ReactNode;
   /** If true, the message will be rendered inline instead of taking full width. */

--- a/src/components/message/message.stories.tsx
+++ b/src/components/message/message.stories.tsx
@@ -85,3 +85,12 @@ export const WithStatus = () => (
     </TextBody>
   </Message>
 );
+
+export const WithoutTitle = () => (
+  <Message status="info">
+    <TextBody color="teal">
+      Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam <Link inherit={false}>nonumy eirmod</Link>{' '}
+      tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+    </TextBody>
+  </Message>
+);


### PR DESCRIPTION
### Description

- Make `MessageProps` extend `BoxProps`
- Make the `title` property optional (null/undefined check already in place)

### Manual check

- [ ] Assert that `Message` stories still work
