### PR TITLE
Use typed SelectProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@
 
 ### Dependency updates
 
-## [17.2.0] - 2022-11-29
+## [18.0.0] - 2022-11-29
 
 ### Changed
 
-- `Typescript`: All components and their props are typescript ([@qubis741](https://github.com/qubis741)) in [#2467](https://github.com/teamleadercrm/ui/pull/2467))
+- [BREAKING] `Typescript`: All components and their props are typescript ([@qubis741](https://github.com/qubis741)) in [#2467](https://github.com/teamleadercrm/ui/pull/2467))
 
 ## [17.1.1] - 2022-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Changed
 
-- `Typescript`: All components and their props are typescript ([@qubis741](https://github.com/kristofcolpaert)) in [#qubis741](https://github.com/teamleadercrm/ui/pull/2465))
+- `Typescript`: All components and their props are typescript ([@qubis741](https://github.com/qubis741)) in [#2467](https://github.com/teamleadercrm/ui/pull/2467))
 
 ## [17.1.1] - 2022-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [17.2.0] - 2022-11-29
+
+### Changed
+
+- `Typescript`: All components and their props are typescript ([@qubis741](https://github.com/kristofcolpaert)) in [#qubis741](https://github.com/teamleadercrm/ui/pull/2465))
+
 ## [17.1.1] - 2022-11-23
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "17.2.0",
+  "version": "18.0.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "17.1.1",
+  "version": "17.2.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/src/components/marketingMenuItem/marketingMenuItem.stories.tsx
+++ b/src/components/marketingMenuItem/marketingMenuItem.stories.tsx
@@ -6,8 +6,7 @@ import MarketingMenuItem from './MarketingMenuItem';
 import { IconExternalLinkSmallOutline } from '@teamleader/ui-icons';
 import Menu, { MenuDivider, MenuItem } from '../menu';
 import Box, { BoxProps } from '../box';
-import { MenuListProps } from 'react-select';
-import Select from '../select';
+import Select, { Option, SelectComponentsProps } from '../select';
 import { useCallback } from '@storybook/addons';
 
 export default {
@@ -36,7 +35,7 @@ const options = [
 
 export const DropdownWithUpsell: ComponentStory<typeof MarketingMenuItem> = (args) => {
   const MenuList = useCallback(
-    (props: MenuListProps) => {
+    (props: SelectComponentsProps['MenuList']) => {
       const { children, getStyles, innerRef, innerProps } = props;
 
       return (
@@ -57,8 +56,9 @@ export const DropdownWithUpsell: ComponentStory<typeof MarketingMenuItem> = (arg
     },
     [args],
   );
+  const handleChange = (option: Option) => console.log(option);
 
-  return <Select options={options} components={{ MenuList }} />;
+  return <Select options={options} onChange={handleChange} components={{ MenuList }} />;
 };
 
 DropdownWithUpsell.args = {

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -38,17 +38,8 @@ const minHeightBySizeMap: Record<string, number> = {
 
 export interface SelectRef<Option extends OptionType = OptionType, IsMulti extends boolean = false>
   extends SelectType<Option, IsMulti> {}
+
 export interface SelectProps<
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  Option extends OptionType = OptionType,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  IsMulti extends boolean = false,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  IsClearable extends boolean = false,
-> {
-  [key: string]: any;
-}
-export interface SelectPropsFull<
   Option extends OptionType = OptionType,
   IsMulti extends boolean = false,
   IsClearable extends boolean = false,

--- a/src/components/select/types.ts
+++ b/src/components/select/types.ts
@@ -32,7 +32,10 @@ export interface Option<V = Value> {
   [key: string]: any;
 }
 
-export interface GroupOption<O = Option> extends GroupBase<O> {}
+export interface GroupOption<O = Option> {
+  options: O[];
+  label?: string;
+}
 export interface SelectComponentsProps<
   OptionType extends Option = Option,
   IsMulti extends boolean = false,


### PR DESCRIPTION
## [17.2.0] - 2022-11-29

### Changed

- `Typescript`: All components and their props are typescript 


### Manual Check

N/A, I have connected it to `core`, all fixed is here: https://github.com/teamleadercrm/core/pull/29569 and its only type changes


Since now everything is in TS, I think we should start mentioning it in `CHANGELOG.MD`, but I am not sure if to release as major or minor version. Your thoughts?