### PR TITLE
Add `tooltipProps` to `Avatar` to allow a custom tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [18.2.0] - 2022-12-08
+
+### Added
+
+- `Avatar`: Add a prop `tooltipProps` to allow a custom tooltip ([@BeirlaenAaron](https://github.com/BeirlaenAaron)) in ([#2483](https://github.com/teamleadercrm/ui/pull/2483))
+
 ## [18.1.2] - 2022-12-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "18.1.2",
+  "version": "18.2.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -48,6 +48,8 @@ export interface AvatarProps extends Omit<BoxProps, 'size' | 'ref'> {
   team?: boolean;
   /** If true, the name will be shown in a tooltip on hover. */
   tooltip?: boolean;
+  /** The tooltip props for the avatar */
+  tooltipProps?: TooltipProps;
 }
 
 type AvatarInternalComponentProps = { size: Exclude<typeof SIZES[number], 'fullscreen' | 'smallest'> } & Pick<
@@ -138,6 +140,7 @@ const Avatar = ({
   id,
   onImageChange,
   team,
+  tooltipProps,
   ...others
 }: AvatarProps) => {
   const avatarClassNames = cx(
@@ -151,10 +154,10 @@ const Avatar = ({
     className,
   );
 
-  const enableTooltip = tooltip && typeof fullName === 'string' && fullName.length > 0;
+  const enableTooltip = tooltip && ((typeof fullName === 'string' && fullName.length > 0) || tooltipProps);
 
   const Component = enableTooltip ? TooltippedBox : Box;
-  const tooltipProps = enableTooltip
+  const defaultToolTipProps = enableTooltip
     ? {
         tooltip: <TextBodyCompact>{fullName}</TextBodyCompact>,
         tooltipColor: 'white',
@@ -167,7 +170,7 @@ const Avatar = ({
     <Component
       {...others}
       {...(selectable && { boxSizing: 'content-box', padding: size === 'hero' ? 2 : 1 })}
-      {...(tooltipProps as TooltipProps)}
+      {...((tooltipProps ?? defaultToolTipProps) as TooltipProps)}
       className={avatarClassNames}
     >
       <AvatarInternalComponent

--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -154,7 +154,7 @@ const Avatar = ({
     className,
   );
 
-  const enableTooltip = tooltip && ((typeof fullName === 'string' && fullName.length > 0) || tooltipProps);
+  const enableTooltip = tooltip && ((typeof fullName === 'string' && fullName.length > 0) || tooltipProps?.tooltip);
 
   const Component = enableTooltip ? TooltippedBox : Box;
   const defaultToolTipProps = enableTooltip

--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -163,6 +163,7 @@ const Avatar = ({
         tooltipColor: 'white',
         tooltipPosition: 'top',
         tooltipSize: 'small',
+        ...tooltipProps,
       }
     : {};
 
@@ -170,7 +171,7 @@ const Avatar = ({
     <Component
       {...others}
       {...(selectable && { boxSizing: 'content-box', padding: size === 'hero' ? 2 : 1 })}
-      {...((tooltipProps ?? defaultToolTipProps) as TooltipProps)}
+      {...(defaultToolTipProps as TooltipProps)}
       className={avatarClassNames}
     >
       <AvatarInternalComponent

--- a/src/components/avatar/avatar.stories.tsx
+++ b/src/components/avatar/avatar.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { Avatar, Bullet } from '../../index';
+import { Avatar, Bullet, TextBodyCompact } from '../../index';
 import avatars from '../../static/data/avatar';
 import { addStoryInGroup, MID_LEVEL_BLOCKS } from '../../../.storybook/utils';
 
@@ -29,3 +29,13 @@ export const WithBullet = () => (
     <Bullet borderColor="neutral" borderTint="lightest" color="ruby" />
   </Avatar>
 );
+
+export const WithCustomTooltip: ComponentStory<typeof Avatar> = (args) => <Avatar {...args} />;
+
+WithCustomTooltip.args = {
+  tooltip: true,
+  tooltipProps: {
+    tooltip: <TextBodyCompact>Unassigned</TextBodyCompact>,
+    tooltipSize: 'small',
+  },
+};


### PR DESCRIPTION
### Description

We would like to add a custom tooltip to the avatars, which is "Unassigned" in our case
Added a prop `tooltipProps` to Avatar

![image](https://user-images.githubusercontent.com/55881661/206494361-6901466c-93f4-4bec-a37f-47b070b41aa6.png)
