### PR TITLE
`Dialog`: add the event parameter to the `Dialog` `onSubmit` type

### DIFF
--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -35,7 +35,7 @@ export interface DialogProps extends Omit<DialogBaseProps, 'ref'> {
   /** If true the dialog will render as a form element. */
   form?: boolean;
   /** Optional callback if the dialog is a form and is being submitted */
-  onSubmit?: () => void;
+  onSubmit?: (event: React.FormEvent<HTMLFormElement>) => void;
 }
 
 const Dialog: GenericComponent<DialogProps> = ({

--- a/src/components/dialog/DialogBase.tsx
+++ b/src/components/dialog/DialogBase.tsx
@@ -39,7 +39,7 @@ export interface DialogBaseProps extends Omit<BoxProps, 'form' | 'size'> {
   /** If true the dialog will render as a form element. */
   form?: boolean;
   /** Optional callback if the dialog is a form and is being submitted */
-  onSubmit?: () => void;
+  onSubmit?: (event: React.FormEvent<HTMLFormElement>) => void;
 }
 interface DialogBaseComponent extends GenericComponent<DialogBaseProps> {
   Header: GenericComponent<DialogHeader.HeaderProps>;


### PR DESCRIPTION
### Description

The `onSubmit` handler can have an `event` parameter.
