### PR TITLE
[FIX] Break long words in order to prevent text overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Fixed
 
-- `Toast.tsx`: Break long words to prevent text overflow ([@JorenSaeyTL](https://github.com/JorenSaeyTL)) in ([#2492](https://github.com/teamleadercrm/ui/pull/2492))
+- `Toast`: Break long words to prevent text overflow ([@JorenSaeyTL](https://github.com/JorenSaeyTL)) in ([#2492](https://github.com/teamleadercrm/ui/pull/2492))
 
 ## [18.2.1] - 2022-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [18.2.2]
+
+### Fixed
+
+- `Toast.tsx`: Break long words to prevent text overflow ([@JorenSaeyTL](https://github.com/JorenSaeyTL)) in ([#2492](https://github.com/teamleadercrm/ui/pull/2492))
+
 ## [18.2.1] - 2022-12-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "18.2.1",
+  "version": "18.2.2",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/src/components/toast/theme.css
+++ b/src/components/toast/theme.css
@@ -28,6 +28,7 @@
   display: flex;
   align-items: center;
   position: relative;
+  word-break: break-word;
 
   .action-link {
     font-family: var(--font-family-inter);


### PR DESCRIPTION
## [18.2.2]

### Fixed

- `Toast.tsx`: Break long words to prevent text overflow ([@JorenSaeyTL](https://github.com/JorenSaeyTL)) in ([#2492](https://github.com/teamleadercrm/ui/pull/2492))

### Description

|Before|After|
|--|--|
|![Schermafbeelding 2022-12-16 om 10 04 58](https://user-images.githubusercontent.com/78364524/208063292-3f84e1d8-60e0-43e5-83b0-a0759f3e7068.png)|![Schermafbeelding 2022-12-16 om 10 05 13](https://user-images.githubusercontent.com/78364524/208063321-d1c193af-0990-4afa-aabc-10d2bea11ab5.png)|

