### PR TITLE
AdvancedCollapsible: children indent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@
 
 ### Dependency updates
 
-## [18.5.0] - 2023-01-03
+## [18.5.0] - 2023-01-04
 
 ### Added
 
 - `AdvancedCollapsible`: Added `defaultIsCollapsed` prop to be able to set it's state ([@BeirlaenAaron](https://github.com/BeirlaenAaron) in [#2511](https://github.com/teamleadercrm/ui/pull/2511))
+
+- `AdvancedCollapsible`: Added `indent` boolean prop ([@BeirlaenAaron](https://github.com/driesd) in [#2515](https://github.com/teamleadercrm/ui/pull/2515))
 
 ## [18.4.0] - 2023-01-02
 

--- a/src/components/advancedCollapsible/AdvancedCollapsible.tsx
+++ b/src/components/advancedCollapsible/AdvancedCollapsible.tsx
@@ -16,6 +16,7 @@ export type AllowedAdvancedCollapsibleColor = Exclude<
 export interface AdvancedCollapsibleProps extends Omit<BoxProps, 'size'> {
   color?: AllowedAdvancedCollapsibleColor;
   children: ReactNode;
+  indent?: boolean;
   title: string;
   size?: AllowedAdvancedCollapsibleSize;
   defaultIsCollapsed?: boolean;
@@ -24,6 +25,7 @@ export interface AdvancedCollapsibleProps extends Omit<BoxProps, 'size'> {
 const AdvancedCollapsible: GenericComponent<AdvancedCollapsibleProps> = ({
   children,
   color = 'teal',
+  indent = true,
   size = 'medium',
   title,
   defaultIsCollapsed = true,
@@ -49,7 +51,7 @@ const AdvancedCollapsible: GenericComponent<AdvancedCollapsibleProps> = ({
         </TitleElement>
       </Box>
       {!collapsed && (
-        <Box className={theme['children']} marginTop={2}>
+        <Box {...(indent && { className: theme['children'] })} marginTop={2}>
           {children}
         </Box>
       )}

--- a/src/components/advancedCollapsible/AdvancedCollapsible.tsx
+++ b/src/components/advancedCollapsible/AdvancedCollapsible.tsx
@@ -51,7 +51,7 @@ const AdvancedCollapsible: GenericComponent<AdvancedCollapsibleProps> = ({
         </TitleElement>
       </Box>
       {!collapsed && (
-        <Box {...(indent && { className: theme['children'] })} marginTop={2}>
+        <Box {...(indent && { className: theme['children-indent'] })} marginTop={2}>
           {children}
         </Box>
       )}

--- a/src/components/advancedCollapsible/theme.css
+++ b/src/components/advancedCollapsible/theme.css
@@ -2,6 +2,6 @@
   cursor: pointer;
 }
 
-.children {
+.children-indent {
   padding-left: 20px;
 }


### PR DESCRIPTION
### Description

This PR adds the `indent` boolean prop to our `AdvancedCollapsible` component. By default, it's `true` and can be set to `false` to remove the indentation of the children's wrapper.

#### Screenshot with indent (default)

<img width="417" alt="Screenshot 2023-01-04 at 10 30 49" src="https://user-images.githubusercontent.com/5336831/210525250-5f794093-4163-4b7d-b157-2786fe4dc4ef.png">

#### Screenshot without indent

<img width="359" alt="Screenshot 2023-01-04 at 10 30 41" src="https://user-images.githubusercontent.com/5336831/210525228-ed5b6218-889e-425d-ba08-e83d17eaf1e5.png">

### Breaking changes

None
