### PR TITLE
Fix menu onSelect type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Changed
 
-- Changed some color calculations from using the color function (from the postcss-color plugin) to native color calculations with hsl. ([@lowiebenoot](https://github.com/lowiebenoot)) in ([#2518](https://github.com/teamleadercrm/ui/pull/2518))
-
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Fix menu onSelect type ([@lorgan3](https://github.com/lorgan3)) in ([#2521](https://github.com/teamleadercrm/ui/pull/2521))
+
 ### Dependency updates
 
 ## [18.6.0] - 2023-01-09

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -29,7 +29,7 @@ const POSITION: Record<string, 'auto' | 'static' | 'top-left' | 'top-right' | 'b
   BOTTOM_RIGHT: 'bottom-right',
 };
 
-export interface MenuProps extends Omit<BoxProps, 'children' | 'className'> {
+export interface MenuProps<S = any> extends Omit<BoxProps, 'children' | 'className'> {
   /** If true, the menu will be active. */
   active?: boolean;
   /** The content to display inside the menu. */
@@ -39,7 +39,7 @@ export interface MenuProps extends Omit<BoxProps, 'children' | 'className'> {
   /** Callback function that is fired when the menu hides. */
   onHide?: () => void;
   /** Callback function that is fired when a menu item is clicked. */
-  onSelect?: (e: SyntheticEvent) => void;
+  onSelect?: (selected: S) => void;
   /** Callback function that is fired when the menu shows. */
   onShow?: () => void;
   /** If true, a border is rendered around the menu. */
@@ -49,7 +49,7 @@ export interface MenuProps extends Omit<BoxProps, 'children' | 'className'> {
   /** If true, the menu will highlight the selected value. */
   selectable?: boolean;
   /** The value of the menu item that will be highlighted. */
-  selected?: any;
+  selected?: S;
 }
 
 const Menu: GenericComponent<MenuProps> = ({

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -10,7 +10,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { GenericComponent } from '../../@types/types';
+
 import Box, { pickBoxProps } from '../box';
 import { BoxProps } from '../box/Box';
 import MarketingMenuItem from '../marketingMenuItem';
@@ -52,7 +52,7 @@ export interface MenuProps<S = any> extends Omit<BoxProps, 'children' | 'classNa
   selected?: S;
 }
 
-const Menu: GenericComponent<MenuProps> = ({
+const Menu = <S,>({
   active = false,
   children,
   className,
@@ -64,7 +64,7 @@ const Menu: GenericComponent<MenuProps> = ({
   selectable = true,
   selected,
   ...others
-}) => {
+}: MenuProps<S>): ReactElement<any, any> | null => {
   const [stateWidth, setStateWidth] = useState<number | undefined>(0);
   const [stateHeight, setStateHeight] = useState<number | undefined>(0);
   const [statePosition, setPosition] = useState<string | undefined>(position);

--- a/src/components/menu/menu.stories.tsx
+++ b/src/components/menu/menu.stories.tsx
@@ -33,4 +33,5 @@ export const DefaultStory = (args: ComponentStory<typeof Menu>) => (
 DefaultStory.args = {
   selectable: true,
   selected: 'bar',
+  onSelect: (selected: string) => console.log('Selected option', selected),
 };


### PR DESCRIPTION
### Description

Small fix and improvement: The type for `Menu` `onSelect` was incorrect.
I've also updated the type of `selected` so it should be inferred instead of always being `any`.

#### Screenshot before this PR

N/a

#### Screenshot after this PR

N/a

### Breaking changes

N/a
