### PR TITLE
Single menu item split button

### DIFF
--- a/src/components/splitButton/SplitButton.tsx
+++ b/src/components/splitButton/SplitButton.tsx
@@ -82,7 +82,11 @@ const SplitButton: GenericComponent<SplitButtonProps> = ({
     | undefined;
   const buttonLabel = firstItem?.props.label;
 
-  return (
+  return childrenArray.length === 1 ? (
+    <Box display="flex" justifyContent="center" {...boxProps} data-teamleader-ui="split-menu">
+      <Button label={buttonLabel} level={level} size={size} disabled={disabled} onClick={handleMainButtonClick} />
+    </Box>
+  ) : (
     <Box display="flex" justifyContent="center" {...boxProps} data-teamleader-ui="split-menu">
       {processing ? (
         <Button

--- a/src/components/splitButton/SplitButton.tsx
+++ b/src/components/splitButton/SplitButton.tsx
@@ -7,7 +7,6 @@ import Popover from '../popover';
 import { IconChevronDownSmallOutline } from '@teamleader/ui-icons';
 import { BoxProps } from '../box/Box';
 import { GenericComponent } from '../../@types/types';
-import isReactElement from '../utils/is-react-element';
 import { SIZES } from '../../constants';
 import theme from './theme.css';
 import isComponentOfType from '../utils/is-component-of-type';

--- a/src/components/splitButton/SplitButton.tsx
+++ b/src/components/splitButton/SplitButton.tsx
@@ -76,14 +76,11 @@ const SplitButton: GenericComponent<SplitButtonProps> = ({
     ...pickBoxProps(others),
   };
 
-  let buttonLabel: string | undefined;
-  if (Array.isArray(children)) {
-    const childrenArray: Array<any> = children;
-
-    if (childrenArray.length && isReactElement(childrenArray[0])) {
-      buttonLabel = childrenArray[0].props.label;
-    }
-  }
+  const childrenArray = React.Children.toArray(children);
+  const firstItem = childrenArray.find((item) => React.isValidElement(item) && isComponentOfType(MenuItem, item)) as
+    | ReactElement
+    | undefined;
+  const buttonLabel = firstItem?.props.label;
 
   return (
     <Box display="flex" justifyContent="center" {...boxProps} data-teamleader-ui="split-menu">

--- a/src/components/splitButton/splitButton.stories.tsx
+++ b/src/components/splitButton/splitButton.stories.tsx
@@ -34,7 +34,7 @@ export const WithPopoverOverrides: ComponentStory<typeof SplitButton> = (args) =
   </SplitButton>
 );
 
-export const WithoutExtraMenuItems: ComponentStory<typeof SplitButton> = (args) => (
+export const WithSingleMenuItem: ComponentStory<typeof SplitButton> = (args) => (
   <SplitButton {...args} popoverProps={{ direction: 'north' }} onButtonClick={handleButtonClick}>
     <MenuItem onClick={handleMenuItemClick} label="Main action" />
   </SplitButton>

--- a/src/components/splitButton/splitButton.stories.tsx
+++ b/src/components/splitButton/splitButton.stories.tsx
@@ -33,3 +33,9 @@ export const WithPopoverOverrides: ComponentStory<typeof SplitButton> = (args) =
     <MenuItem onClick={handleMenuItemClick} label="I appear above the button" />
   </SplitButton>
 );
+
+export const WithoutExtraMenuItems: ComponentStory<typeof SplitButton> = (args) => (
+  <SplitButton {...args} popoverProps={{ direction: 'north' }} onButtonClick={handleButtonClick}>
+    <MenuItem onClick={handleMenuItemClick} label="Main action" />
+  </SplitButton>
+);


### PR DESCRIPTION
### Description

When there is only one menu item available (e.g. when certain menu items are not showable because of permissions), render the split button as a normal button, this makes if-else structures a lot easier.

Before:
```javascript
accountHasAccessToTimeTracking ? (
    <SplitButton level="secondary">
      <MenuItem label="Mark as done" />
      <MenuItem label="Track time">
    </SplitButton>
  ) : (
    <Button level="secondary" label="Mark as done"/>
  )
```
After:
```javascript
    <SplitButton level="secondary">
      <MenuItem label="Mark as done" />
      {accountHasAccesstoTimeTracking && <MenuItem label="Track time"/>}
    </SplitButton>
```

#### Screenshot after this PR

![image](https://user-images.githubusercontent.com/8998239/214037316-08bd5afd-2107-4828-8c27-4729b19b7c57.png)
