### PR TITLE
[MarketingStatusLabel] Hide margin when no Icon is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [19.0.1] - 2023-01-27
+
+### Fixed
+
+- `MarketingStatusLabel`: TextElement should not have a margin when no icon is provided ([@kristofcolpaert](https://github.com/KristofColpaert)) in ([#2545](https://github.com/teamleadercrm/ui/pull/2545))
+
 ## [19.0.0] - 2023-01-27
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "19.0.0",
+  "version": "19.0.1",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/src/components/marketingStatusLabel/MarketingStatusLabel.tsx
+++ b/src/components/marketingStatusLabel/MarketingStatusLabel.tsx
@@ -38,10 +38,12 @@ const MarketingStatusLabel: GenericComponent<MarketingStatusLabelProps> = ({
       className={classNames}
       paddingHorizontal={2}
     >
-      <TextElement className={theme['text']} marginRight={2}>
-        {children}
-      </TextElement>
-      {icon && <Icon className={theme['icon']}>{icon}</Icon>}
+      <TextElement className={theme['text']}>{children}</TextElement>
+      {icon && (
+        <Icon className={theme['icon']} marginLeft={2}>
+          {icon}
+        </Icon>
+      )}
     </Box>
   );
 };

--- a/src/components/marketingStatusLabel/__tests__/__snapshots__/MarketingStatusLabel.spec.tsx.snap
+++ b/src/components/marketingStatusLabel/__tests__/__snapshots__/MarketingStatusLabel.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`Component - MarketingStatusLabel renders 1`] = `
     data-teamleader-ui="marketing-status-label"
   >
     <p
-      class="box margin-right-2 ui-text ui-text-body darkest text"
+      class="box ui-text ui-text-body darkest text"
       data-teamleader-ui="ui-text"
     >
       Upgrade now
@@ -23,13 +23,13 @@ exports[`Component - MarketingStatusLabel renders with an icon 1`] = `
     data-teamleader-ui="marketing-status-label"
   >
     <p
-      class="box margin-right-2 ui-text ui-text-body darkest text"
+      class="box ui-text ui-text-body darkest text"
       data-teamleader-ui="ui-text"
     >
       Upgrade now
     </p>
     <span
-      class="box align-items-center display-flex teal normal icon"
+      class="box align-items-center display-flex margin-left-2 teal normal icon"
       data-teamleader-ui="icon"
     >
       <span


### PR DESCRIPTION
### Description

`MarketingStatusLabel`: 
- TextElement shouldn't have a margin when no Icon is provided. Margin has been moved to the Icon.

#### Screenshot before this PR

![Screenshot 2023-01-27 at 13 05 51](https://user-images.githubusercontent.com/4469441/215082714-3dab8bb7-149f-48a0-8dbb-b9e603113ec0.png)

#### Screenshot after this PR

![Screenshot 2023-01-27 at 13 06 19](https://user-images.githubusercontent.com/4469441/215082799-64a3624f-3295-4184-bafd-dbeacd347e37.png)
