### PR TITLE
`NumericInput` - stepper blurring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [19.1.1] - 2023-02-03
+
+### Fixed
+
+- `NumericInput`: Fix input blurring when using the stepper buttons ([@BeirlaenAaron](https://github.com/BeirlaenAaron)) in([#2552](https://github.com/teamleadercrm/ui/pull/2552))
+
 ## [19.1.0] - 2023-02-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "19.1.0",
+  "version": "19.1.1",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/src/components/input/NumericInput.tsx
+++ b/src/components/input/NumericInput.tsx
@@ -1,4 +1,13 @@
-import React, { ChangeEvent, FocusEvent, forwardRef, KeyboardEvent, ReactElement, useEffect, useRef } from 'react';
+import React, {
+  ChangeEvent,
+  FocusEvent,
+  forwardRef,
+  KeyboardEvent,
+  MouseEvent,
+  ReactElement,
+  useEffect,
+  useRef,
+} from 'react';
 import Icon from '../icon';
 import {
   IconAddSmallOutline,
@@ -16,7 +25,7 @@ import { GenericComponent } from '../../@types/types';
 interface StepperProps {
   disabled: boolean;
   onBlur: (event: FocusEvent<HTMLInputElement>) => void;
-  onMouseDown: () => void;
+  onMouseDown: (event: MouseEvent<HTMLButtonElement>) => void;
   onMouseUp: () => void;
   onMouseLeave: () => void;
 }
@@ -202,7 +211,9 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
       handleClearStepperDecreaseTimer();
     }, [decreaseDisabled]);
 
-    const handleDecreaseMouseDown = () => {
+    const handleDecreaseMouseDown = (event: MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+
       if (onDecreaseMouseDown) {
         onDecreaseMouseDown();
 
@@ -228,7 +239,9 @@ const NumericInput: GenericComponent<NumericInputProps> = forwardRef<HTMLElement
       }, 300);
     };
 
-    const handleIncreaseMouseDown = () => {
+    const handleIncreaseMouseDown = (event: MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+
       if (onIncreaseMouseDown) {
         onIncreaseMouseDown();
 


### PR DESCRIPTION
### Description

Prevent NumericInput from blurring when increasing/decreasing using the stepper buttons
This is causing an issue with the inline inputs for projects

[Screencast from 03-02-23 11:27:06.webm](https://user-images.githubusercontent.com/55881661/216576964-e8ce4bcf-5423-4028-9e8e-84a431b5946a.webm)

#### Before this PR

[Screencast from 03-02-23 11:31:05.webm](https://user-images.githubusercontent.com/55881661/216578662-2e2b1131-70d9-4d56-a9d9-63fd8820f910.webm)

#### After this PR

[Screencast from 03-02-23 11:29:02.webm](https://user-images.githubusercontent.com/55881661/216577571-9973f4d8-9f40-45a5-8939-0ed0b589bbc5.webm)

