### PR TITLE
[Removed] Tiny label size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@
 
 ### Dependency updates
 
-## [20.0.0] - 2023-02-10
+## [20.0.0] - 2023-02-13
 
-### Deprecated
+### Removed
 
 - `Label`: Remove option for 'tiny' label size ([@JorenSaeyTL](https://github.com/JorenSaeyTL)) in ([#2560](https://github.com/teamleadercrm/ui/pull/2560))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Deprecated
 
-- `Label`: Remove option for 'tiny' label size ([@JorenSaeyTL](https://github.com/JorenSaeyTL)) in([#2552](https://github.com/teamleadercrm/ui/pull/2552))
+- `Label`: Remove option for 'tiny' label size ([@JorenSaeyTL](https://github.com/JorenSaeyTL)) in ([#2560](https://github.com/teamleadercrm/ui/pull/2560))
 
 ## [19.1.1] - 2023-02-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [20.0.0] - 2023-02-10
+
+### Deprecated
+
+- `Label`: Remove option for 'tiny' label size ([@JorenSaeyTL](https://github.com/JorenSaeyTL)) in([#2552](https://github.com/teamleadercrm/ui/pull/2552))
+
 ## [19.1.1] - 2023-02-03
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "19.1.1",
+  "version": "20.0.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/src/components/label/Label.tsx
+++ b/src/components/label/Label.tsx
@@ -14,7 +14,7 @@ export interface LabelProps extends Omit<BoxProps, 'children'> {
   children: ReactNode;
   inverse?: boolean;
   required?: boolean;
-  size?: Exclude<typeof SIZES[number], 'fullscreen' | 'smallest' | 'hero'>;
+  size?: Exclude<typeof SIZES[number], 'tiny' | 'fullscreen' | 'smallest' | 'hero'>;
   tooltip?: ReactNode;
   tooltipProps?: Record<string, any>;
 }
@@ -35,7 +35,6 @@ const Label: GenericComponent<LabelProps> = ({
   };
 
   const Element = {
-    tiny: TextSmall,
     small: TextBodyCompact,
     medium: TextBodyCompact,
     large: TextDisplay,


### PR DESCRIPTION
### Removed

- `Label`: Remove option for 'tiny' label size ([@JorenSaeyTL](https://github.com/JorenSaeyTL)) in ([#2560](https://github.com/teamleadercrm/ui/pull/2560))

### Breaking changes

- 'tiny' is not supported anymore as option for Label size