### PR TITLE
[FRONT-439] Fix failing Chromatic GitHub action

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,6 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Install dependencies
         run: yarn
       - name: Publish to Chromatic


### PR DESCRIPTION
Using node v16 because it's currently failing on node v18. Seems to be something with node v18 and open-ssl. Not sure why this suddenly starts happening, I'm assuming some change in the latest ubuntu version.

(can't use node 17 because it's not supported by one of the installed packages)

