### PR TITLE
[FRONT-123] remove automatic blurring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,21 @@
 
 ## [20.0.0] - 2023-02-13
 
+### Changed
+
+- Focus states are now styled through `:focus-visible` instead of `:focus`. ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2575](https://github.com/teamleadercrm/ui/pull/2575)
+
+### Fixed
+
+- `Toggle`: the component is now focusable. ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2575](https://github.com/teamleadercrm/ui/pull/2575)
+
 ### Removed
 
 - `Label`: Remove option for 'tiny' label size ([@JorenSaeyTL](https://github.com/JorenSaeyTL)) in ([#2560](https://github.com/teamleadercrm/ui/pull/2560))
+
+### Dependency updates
+
+- `postcss-preset-env`: bump peer dependency expectation to `^8.0.0`, otherwise the `:focus-visible` styling will not be included. ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2575](https://github.com/teamleadercrm/ui/pull/2575)
 
 ## [19.1.1] - 2023-02-03
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "postcss-each": "^0.10.0",
     "postcss-import": "^15.0.0",
     "postcss-nested": "^6.0.0",
-    "postcss-preset-env": "^6.7.0",
+    "postcss-preset-env": "^8.0.0",
     "postcss-pseudoelements": "^5.0.0",
     "postcss-reporter": "^7.0.2",
     "react": "^16 || ^17",

--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -42,7 +42,7 @@
       cursor: pointer;
     }
 
-    &:focus {
+    &:focus-visible {
       background-color: hsl(var(--color-neutral-darkest-hsl), 12%);
       border-color: hsl(var(--color-neutral-darkest-hsl), 24%);
       box-shadow: 0 0 0 var(--badge-border-width) hsl(var(--color-neutral-darkest-hsl), 24%);

--- a/src/components/badgedLink/theme.css
+++ b/src/components/badgedLink/theme.css
@@ -21,7 +21,7 @@
     background: hsl(var(--color-neutral-darkest-hsl), 18%);
   }
 
-  &:focus {
+  &:focus-visible {
     box-shadow: 0 0 0 2px hsl(var(--color-neutral-darkest-hsl), 24%);
     outline: 0;
   }

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -48,10 +48,6 @@ export interface ButtonProps extends Omit<BoxProps, 'size'> {
   label?: string;
   /** Determines which kind of button to be rendered. */
   level?: `${BUTTON_LEVELS}`;
-  /** Callback function that is fired when mouse leaves the component. */
-  onMouseLeave?: (event: React.MouseEvent) => void;
-  /** Callback function that is fired when the mouse button is released. */
-  onMouseUp?: (event: React.MouseEvent) => void;
   /** If true, component will show a loading spinner instead of label or children. */
   processing?: boolean;
   /** Size of the button. */
@@ -78,8 +74,6 @@ const Button: GenericComponent<ButtonProps> = forwardRef<HTMLElement, ButtonProp
       level = BUTTON_LEVELS.secondary,
       size = 'medium',
       type = 'button',
-      onMouseUp,
-      onMouseLeave,
       processing = false,
       ...others
     },
@@ -87,27 +81,6 @@ const Button: GenericComponent<ButtonProps> = forwardRef<HTMLElement, ButtonProp
   ) => {
     const buttonRef = useRef<HTMLElement>(null);
     useImperativeHandle<HTMLElement | null, HTMLElement | null>(ref, () => buttonRef.current);
-
-    const blur = () => {
-      const currentButtonRef = buttonRef.current;
-      if (currentButtonRef?.blur) {
-        currentButtonRef.blur();
-      }
-    };
-
-    const handleMouseUp = (event: React.MouseEvent) => {
-      blur();
-      if (onMouseUp) {
-        onMouseUp(event);
-      }
-    };
-
-    const handleMouseLeave = (event: React.MouseEvent) => {
-      blur();
-      if (onMouseLeave) {
-        onMouseLeave(event);
-      }
-    };
 
     const getSpinnerColor = () => {
       switch (level) {
@@ -174,8 +147,6 @@ const Button: GenericComponent<ButtonProps> = forwardRef<HTMLElement, ButtonProp
         element={element}
         ref={buttonRef}
         type={element === 'button' ? type : undefined}
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseLeave}
       >
         {icon && iconPlacement === 'left' && icon}
         {(label || children) && (

--- a/src/components/button/theme.css
+++ b/src/components/button/theme.css
@@ -97,7 +97,7 @@
           border: 1px solid var(--color-$(color)-darkest);
         }
 
-        &:focus {
+        &:focus-visible {
           border: 1px solid var(--color-$(color)-darkest);
           box-shadow: 0 0 0 1px var(--color-$(color)-darkest);
         }
@@ -123,7 +123,7 @@
         border: 1px solid var(--color-neutral-lightest);
       }
 
-      &:focus {
+      &:focus-visible {
         border: 1px solid var(--color-neutral-lightest);
         box-shadow: 0 0 0 1px var(--color-neutral-lightest);
       }
@@ -157,7 +157,7 @@
       border: 1px solid var(--color-neutral-darkest);
     }
 
-    &:focus {
+    &:focus-visible {
       background-color: var(--color-neutral-light);
       border: 1px solid var(--color-neutral-darkest);
       box-shadow: 0 0 0 1px var(--color-neutral-darkest);
@@ -192,7 +192,7 @@
       border: 1px solid var(--color-mint-darkest);
     }
 
-    &:focus {
+    &:focus-visible {
       background-color: var(--color-mint);
       border: 1px solid var(--color-mint-dark);
       box-shadow: 0 0 0 1px var(--color-mint-dark);
@@ -223,7 +223,7 @@
       border: 1px solid var(--color-violet-darkest);
     }
 
-    &:focus {
+    &:focus-visible {
       background-color: var(--color-violet);
       border: 1px solid var(--color-violet-dark);
       box-shadow: 0 0 0 1px var(--color-violet-dark);
@@ -255,7 +255,7 @@
       border: 1px solid var(--color-ruby-darkest);
     }
 
-    &:focus {
+    &:focus-visible {
       background-color: var(--color-ruby);
       border: 1px solid var(--color-ruby-darkest);
       box-shadow: 0 0 0 1px var(--color-ruby-darkest);
@@ -278,7 +278,7 @@
   color: var(--color-aqua-dark);
 
   &:not(.is-disabled) {
-    &:focus {
+    &:focus-visible {
       box-shadow: 0 0 0 2px var(--color-aqua-light);
     }
 

--- a/src/components/emailSelector/theme.css
+++ b/src/components/emailSelector/theme.css
@@ -69,7 +69,7 @@
           background-color: hsl(var(--color-ruby-dark-hsl), 18%);
         }
 
-        &:focus {
+        &:focus-visible {
           box-shadow: 0 0 0 2px hsl(var(--color-ruby-dark-hsl), 24%);
         }
 

--- a/src/components/iconButton/IconButton.tsx
+++ b/src/components/iconButton/IconButton.tsx
@@ -47,8 +47,6 @@ const IconButton: GenericComponent<IconButtonProps> = forwardRef<HTMLElement, Ic
       tint = 'darkest',
       selected,
       type = 'button',
-      onMouseUp,
-      onMouseLeave,
       processing = false,
       ...others
     }: IconButtonProps,

--- a/src/components/iconButton/IconButton.tsx
+++ b/src/components/iconButton/IconButton.tsx
@@ -30,10 +30,6 @@ export interface IconButtonProps extends Omit<BoxProps, 'ref' | 'children' | 'cl
   selected?: boolean;
   /** Type of the button element. */
   type?: string;
-  /** Callback function that is fired when the mouse button is released. */
-  onMouseUp?: (e: React.MouseEvent) => void;
-  /** Callback function that is fired when mouse leaves the component. */
-  onMouseLeave?: (e: React.MouseEvent) => void;
   /** If true, component will show a loading spinner instead of icon or children. */
   processing?: boolean;
 }
@@ -61,27 +57,6 @@ const IconButton: GenericComponent<IconButtonProps> = forwardRef<HTMLElement, Ic
     const buttonRef = useRef<HTMLElement>(null);
     useImperativeHandle<HTMLElement | null, HTMLElement | null>(ref, () => buttonRef.current);
 
-    const blur = () => {
-      const currentButtonRef = buttonRef.current;
-      if (currentButtonRef?.blur) {
-        currentButtonRef.blur();
-      }
-    };
-
-    const handleMouseUp = (event: React.MouseEvent) => {
-      blur();
-      if (onMouseUp) {
-        onMouseUp(event);
-      }
-    };
-
-    const handleMouseLeave = (event: React.MouseEvent) => {
-      blur();
-      if (onMouseLeave) {
-        onMouseLeave(event);
-      }
-    };
-
     const classNames = cx(
       buttonTheme['button-base'],
       theme['icon-button'],
@@ -100,8 +75,6 @@ const IconButton: GenericComponent<IconButtonProps> = forwardRef<HTMLElement, Ic
       className: classNames,
       disabled: element === 'button' ? disabled : undefined,
       element,
-      onMouseUp: handleMouseUp,
-      onMouseLeave: handleMouseLeave,
       type: element === 'button' ? type : undefined,
       'data-teamleader-ui': 'icon-button',
     };

--- a/src/components/iconButton/theme.css
+++ b/src/components/iconButton/theme.css
@@ -16,7 +16,7 @@
       background-color: hsl(var(--color-neutral-darkest-hsl), 18%);
     }
 
-    &:focus {
+    &:focus-visible {
       box-shadow: 0 0 0 2px hsl(var(--color-neutral-darkest-hsl), 24%);
     }
 

--- a/src/components/link/Link.tsx
+++ b/src/components/link/Link.tsx
@@ -19,49 +19,17 @@ export interface LinkProps extends Omit<BoxProps, 'ref'> {
   inverse?: boolean;
   /** A custom element to be rendered */
   element?: React.ElementType;
-  /** Callback function that is fired when mouse leaves the component. */
-  onMouseLeave?: (event: React.MouseEvent) => void;
-  /** Callback function that is fired when the mouse button is released. */
-  onMouseUp?: (event: React.MouseEvent) => void;
   /** If true, component will be shown in a selected state */
   selected?: boolean;
 }
 
 const Link: GenericComponent<LinkProps> = forwardRef<HTMLElement, LinkProps>(
   (
-    {
-      children,
-      className = '',
-      disabled = false,
-      element = 'a',
-      inherit = true,
-      inverse = false,
-      selected,
-      onMouseUp,
-      onMouseLeave,
-      ...others
-    },
+    { children, className = '', disabled = false, element = 'a', inherit = true, inverse = false, selected, ...others },
     ref,
   ) => {
     const linkRef = useRef<HTMLElement>(null);
     useImperativeHandle<HTMLElement | null, HTMLElement | null>(ref, () => linkRef.current);
-
-    const blur = () => {
-      const currentLinkRef = linkRef.current;
-      if (currentLinkRef?.blur) {
-        currentLinkRef.blur();
-      }
-    };
-
-    const handleMouseUp = (event: React.MouseEvent) => {
-      blur();
-      onMouseUp && onMouseUp(event);
-    };
-
-    const handleMouseLeave = (event: React.MouseEvent) => {
-      blur();
-      onMouseLeave && onMouseLeave(event);
-    };
 
     const classNames = cx(
       uiUtilities['reset-font-smoothing'],
@@ -76,15 +44,7 @@ const Link: GenericComponent<LinkProps> = forwardRef<HTMLElement, LinkProps>(
     );
 
     return (
-      <Box
-        element={element}
-        ref={linkRef}
-        className={classNames}
-        data-teamleader-ui="link"
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseLeave}
-        {...others}
-      >
+      <Box element={element} ref={linkRef} className={classNames} data-teamleader-ui="link" {...others}>
         {children}
       </Box>
     );

--- a/src/components/link/theme.css
+++ b/src/components/link/theme.css
@@ -24,8 +24,8 @@
     pointer-events: none;
   }
 
-    outline: var(--color-aqua-dark) auto 3px;
   &:focus-visible {
+    outline: var(--color-aqua-dark) auto 3px;
   }
 
   &:active {

--- a/src/components/link/theme.css
+++ b/src/components/link/theme.css
@@ -24,8 +24,8 @@
     pointer-events: none;
   }
 
-  &:focus {
     outline: var(--color-aqua-dark) auto 3px;
+  &:focus-visible {
   }
 
   &:active {

--- a/src/components/marketingButton/MarketingButton.tsx
+++ b/src/components/marketingButton/MarketingButton.tsx
@@ -25,10 +25,6 @@ export interface MarketingButtonProps extends Omit<BoxProps, 'ref' | 'element'> 
   icon?: ReactNode;
   /** The position of the icon inside the button. */
   iconPlacement?: 'left' | 'right';
-  /** Callback function that is fired when mouse leaves the component. */
-  onMouseLeave?: (event: React.MouseEvent) => void;
-  /** Callback function that is fired when the mouse button is released. */
-  onMouseUp?: (event: React.MouseEvent) => void;
   /** If true, component will show a loading spinner instead of label or children. */
   processing?: boolean;
   /** Size of the button. */
@@ -58,35 +54,12 @@ const MarketingButton: GenericComponent<MarketingButtonProps> = forwardRef<HTMLE
       size = 'medium',
       type = 'button',
       processing = false,
-      onMouseUp,
-      onMouseLeave,
       ...others
     },
     ref,
   ) => {
     const buttonRef = useRef<HTMLElement>(null);
     useImperativeHandle<HTMLElement | null, HTMLElement | null>(ref, () => buttonRef.current);
-
-    const blur = () => {
-      const currentButtonRef = buttonRef.current;
-      if (currentButtonRef?.blur) {
-        currentButtonRef.blur();
-      }
-    };
-
-    const handleMouseUp = (event: React.MouseEvent) => {
-      blur();
-      if (onMouseUp) {
-        onMouseUp(event);
-      }
-    };
-
-    const handleMouseLeave = (event: React.MouseEvent) => {
-      blur();
-      if (onMouseLeave) {
-        onMouseLeave(event);
-      }
-    };
 
     const classNames = cx(
       theme['reset-box-sizing'],
@@ -110,8 +83,6 @@ const MarketingButton: GenericComponent<MarketingButtonProps> = forwardRef<HTMLE
       className: classNames,
       disabled: element === 'button' ? disabled : undefined,
       element,
-      onMouseUp: handleMouseUp,
-      onMouseLeave: handleMouseLeave,
       type: element === 'button' ? type : undefined,
       'data-teamleader-ui': 'button',
     };

--- a/src/components/marketingButton/theme.css
+++ b/src/components/marketingButton/theme.css
@@ -71,7 +71,7 @@
       border: 1px solid var(--color-marketing-violet-dark);
     }
 
-    &:focus {
+    &:focus-visible {
       background-color: var(--color-marketing-violet-dark);
       border: 1px solid var(--color-neutral-lightest);
       box-shadow: 0 0 0 2px var(--color-marketing-violet-light);
@@ -107,7 +107,7 @@
       color: var(--color-marketing-violet-dark);
     }
 
-    &:focus {
+    &:focus-visible {
       background-color: var(--color-marketing-violet-lightest);
       box-shadow: 0 0 0 2px var(--color-marketing-violet-lightest);
     }
@@ -138,7 +138,7 @@
       background-color: var(--color-marketing-violet-lightest);
     }
 
-    &:focus {
+    &:focus-visible {
       box-shadow: 0 0 0 2px var(--color-marketing-violet-light);
     }
 

--- a/src/components/marketingButtonGroup/Button.tsx
+++ b/src/components/marketingButtonGroup/Button.tsx
@@ -15,39 +15,14 @@ export interface ButtonProps extends Omit<BoxProps, 'ref'> {
   active?: boolean;
   /** The textual label displayed inside the button. */
   label?: number | string;
-  /** Callback function that is fired when mouse leaves the component. */
-  onMouseLeave?: (event: React.MouseEvent) => void;
-  /** Callback function that is fired when the mouse button is released. */
-  onMouseUp?: (event: React.MouseEvent) => void;
   /** Button value in case it's being in a button group. */
   value?: string;
 }
 
 const Button: GenericComponent<ButtonProps> = forwardRef<HTMLElement, ButtonProps>(
-  ({ onMouseUp, onMouseLeave, children, className = '', active, label, ...others }, ref) => {
+  ({ children, className = '', active, label, ...others }, ref) => {
     const buttonRef = useRef<HTMLElement>(null);
     useImperativeHandle<HTMLElement | null, HTMLElement | null>(ref, () => buttonRef.current);
-
-    const blur = () => {
-      const currentButtonRef = buttonRef.current;
-      if (currentButtonRef) {
-        currentButtonRef.blur();
-      }
-    };
-
-    const handleMouseUp = (event: React.MouseEvent) => {
-      blur();
-      if (onMouseUp) {
-        onMouseUp(event);
-      }
-    };
-
-    const handleMouseLeave = (event: React.MouseEvent) => {
-      blur();
-      if (onMouseLeave) {
-        onMouseLeave(event);
-      }
-    };
 
     const classNames = cx(
       theme['reset-box-sizing'],
@@ -65,8 +40,6 @@ const Button: GenericComponent<ButtonProps> = forwardRef<HTMLElement, ButtonProp
       ref: buttonRef,
       className: classNames,
       element: 'button' as React.ElementType,
-      onMouseUp: handleMouseUp,
-      onMouseLeave: handleMouseLeave,
       'data-teamleader-ui': 'button',
     };
 

--- a/src/components/marketingButtonGroup/theme.css
+++ b/src/components/marketingButtonGroup/theme.css
@@ -54,7 +54,7 @@
     border: 1px solid var(--color-neutral-darkest);
   }
 
-  &:focus {
+  &:focus-visible {
     background-color: var(--color-neutral-light);
     border: 1px solid var(--color-neutral-darkest);
     box-shadow: 0 0 0 1px var(--color-neutral-darkest);

--- a/src/components/marketingLink/MarketingLink.tsx
+++ b/src/components/marketingLink/MarketingLink.tsx
@@ -20,39 +20,14 @@ export interface MarketingLinkProps extends Omit<BoxProps, 'ref'> {
 }
 
 const MarketingLink: GenericComponent<MarketingLinkProps> = forwardRef<HTMLElement, MarketingLinkProps>(
-  ({ children, className = '', element = 'a', onMouseUp, onMouseLeave, ...others }, ref) => {
+  ({ children, className = '', element = 'a', ...others }, ref) => {
     const linkRef = useRef<HTMLElement>(null);
     useImperativeHandle<HTMLElement | null, HTMLElement | null>(ref, () => linkRef.current);
-
-    const blur = () => {
-      const currentLinkRef = linkRef.current;
-      if (currentLinkRef?.blur) {
-        currentLinkRef.blur();
-      }
-    };
-
-    const handleMouseUp = (event: React.MouseEvent) => {
-      blur();
-      onMouseUp && onMouseUp(event);
-    };
-
-    const handleMouseLeave = (event: React.MouseEvent) => {
-      blur();
-      onMouseLeave && onMouseLeave(event);
-    };
 
     const classNames = cx(uiUtilities['reset-font-smoothing'], theme['link'], className);
 
     return (
-      <Box
-        element={element}
-        ref={linkRef}
-        className={classNames}
-        data-teamleader-ui="marketing-link"
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseLeave}
-        {...others}
-      >
+      <Box element={element} ref={linkRef} className={classNames} data-teamleader-ui="marketing-link" {...others}>
         {children}
       </Box>
     );

--- a/src/components/marketingLink/MarketingLink.tsx
+++ b/src/components/marketingLink/MarketingLink.tsx
@@ -13,10 +13,6 @@ export interface MarketingLinkProps extends Omit<BoxProps, 'ref'> {
   className?: string;
   /** A custom element to be rendered */
   element?: React.ElementType;
-  /** Callback function that is fired when mouse leaves the component. */
-  onMouseLeave?: (event: React.MouseEvent) => void;
-  /** Callback function that is fired when the mouse button is released. */
-  onMouseUp?: (event: React.MouseEvent) => void;
 }
 
 const MarketingLink: GenericComponent<MarketingLinkProps> = forwardRef<HTMLElement, MarketingLinkProps>(

--- a/src/components/marketingLink/marketingLink.stories.tsx
+++ b/src/components/marketingLink/marketingLink.stories.tsx
@@ -24,4 +24,5 @@ export const Basic: ComponentStory<typeof MarketingLink> = (args) => (
 
 Basic.args = {
   children: 'a link for marketing purposes',
+  href: 'https://www.teamleader.eu',
 };

--- a/src/components/marketingLink/theme.css
+++ b/src/components/marketingLink/theme.css
@@ -18,8 +18,8 @@
     text-decoration: none;
   }
 
-  &:focus {
     outline: var(--color-marketing-violet-light) auto 3px;
+  &:focus-visible {
   }
 
   &:active {

--- a/src/components/marketingLink/theme.css
+++ b/src/components/marketingLink/theme.css
@@ -18,8 +18,8 @@
     text-decoration: none;
   }
 
-    outline: var(--color-marketing-violet-light) auto 3px;
   &:focus-visible {
+    outline: var(--color-marketing-violet-light) auto 3px;
   }
 
   &:active {

--- a/src/components/marketingMenuItem/theme.css
+++ b/src/components/marketingMenuItem/theme.css
@@ -26,7 +26,7 @@
     cursor: pointer;
   }
 
-  &:not(.is-disabled):not(.is-selected):focus {
+  &:not(.is-disabled):not(.is-selected):focus-visible {
     background-color: var(--menu-item-hover-background);
   }
 

--- a/src/components/marketingTab/MarketingTab.tsx
+++ b/src/components/marketingTab/MarketingTab.tsx
@@ -21,19 +21,9 @@ const MarketingTab: GenericComponent<MarketingTabProps> = forwardRef<HTMLElement
     const tabRef = useRef<HTMLElement>(null);
     useImperativeHandle<HTMLElement | null, HTMLElement | null>(ref, () => tabRef.current);
 
-    const blur = () => {
-      const currentTabRef = tabRef.current;
-      if (currentTabRef?.blur) {
-        currentTabRef.blur();
-      }
-    };
-
     const handleClick = (event: React.MouseEvent) => {
       if (onClick) {
         onClick(event);
-      }
-      if (event.pageX !== 0 && event.pageY !== 0) {
-        blur();
       }
     };
 

--- a/src/components/marketingTab/marketingTab.stories.tsx
+++ b/src/components/marketingTab/marketingTab.stories.tsx
@@ -32,4 +32,5 @@ Basic.args = {
   active: false,
   children: 'Marketing tab',
   href: 'https://www.teamleader.eu',
+  element: 'a',
 };

--- a/src/components/marketingTab/theme.css
+++ b/src/components/marketingTab/theme.css
@@ -21,7 +21,7 @@
   flex-shrink: 0;
   height: 48px;
 
-  &:focus {
+  &:focus-visible {
     box-shadow: inset 0 0 0 2px var(--color-neutral);
   }
 

--- a/src/components/menu/theme.css
+++ b/src/components/menu/theme.css
@@ -152,7 +152,7 @@
     cursor: pointer;
   }
 
-  &:not(.is-disabled):not(.is-selected):focus {
+  &:not(.is-disabled):not(.is-selected):focus-visible {
     background-color: var(--menu-item-hover-background);
   }
 

--- a/src/components/poweredByButton/PoweredByButton.tsx
+++ b/src/components/poweredByButton/PoweredByButton.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, forwardRef, useImperativeHandle, ReactNode, MouseEvent } from 'react';
+import React, { useRef, forwardRef, useImperativeHandle, ReactNode } from 'react';
 import cx from 'classnames';
 import Box from '../box';
 import { TextSmall } from '../typography';

--- a/src/components/poweredByButton/PoweredByButton.tsx
+++ b/src/components/poweredByButton/PoweredByButton.tsx
@@ -21,10 +21,6 @@ export interface PoweredByButtonProps extends Omit<BoxProps, 'className' | 'chil
   shape?: 'pill' | 'box';
   /** Button tint. Light for dark backgrounds and dark for light backgrounds. */
   tint?: 'dark' | 'light';
-  /** Callback function that is fired when mouse leaves the component. */
-  onMouseLeave?: (event: MouseEvent<HTMLElement>) => void;
-  /** Callback function that is fired when the mouse button is released. */
-  onMouseUp?: (event: MouseEvent<HTMLElement>) => void;
 }
 
 const PoweredByButton: GenericComponent<PoweredByButtonProps> = forwardRef<HTMLElement, PoweredByButtonProps>(
@@ -35,8 +31,6 @@ const PoweredByButton: GenericComponent<PoweredByButtonProps> = forwardRef<HTMLE
       tint = 'dark',
       shape = 'pill',
       label = 'text-and-logo',
-      onMouseUp,
-      onMouseLeave,
       className,
       ...rest
     },
@@ -44,27 +38,6 @@ const PoweredByButton: GenericComponent<PoweredByButtonProps> = forwardRef<HTMLE
   ) => {
     const buttonRef = useRef<HTMLElement>(null);
     useImperativeHandle<HTMLElement | null, HTMLElement | null>(ref, () => buttonRef.current);
-
-    const blur = () => {
-      const currentButtonRef = buttonRef.current;
-      if (currentButtonRef?.blur) {
-        currentButtonRef.blur();
-      }
-    };
-
-    const handleMouseUp = (event: MouseEvent<HTMLElement>) => {
-      blur();
-      if (onMouseUp) {
-        onMouseUp(event);
-      }
-    };
-
-    const handleMouseLeave = (event: MouseEvent<HTMLElement>) => {
-      blur();
-      if (onMouseLeave) {
-        onMouseLeave(event);
-      }
-    };
 
     const classNames = cx(
       theme['reset-box-sizing'],
@@ -86,8 +59,6 @@ const PoweredByButton: GenericComponent<PoweredByButtonProps> = forwardRef<HTMLE
         target="_blank"
         rel="noopener noreferrer"
         className={classNames}
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseLeave}
         ref={buttonRef}
         {...rest}
       >

--- a/src/components/poweredByButton/theme.css
+++ b/src/components/poweredByButton/theme.css
@@ -54,7 +54,7 @@
   }
 
   &:active,
-  &:focus {
+  &:focus-visible {
     box-shadow: inset 0px 2px 3px hsl(var(--color-black-hsl), 24%);
   }
 

--- a/src/components/radio/RadioButton.tsx
+++ b/src/components/radio/RadioButton.tsx
@@ -52,17 +52,7 @@ const RadioButton: GenericComponent<RadioButtonProps> = ({
     className,
   );
 
-  const blur = () => {
-    if (inputNode.current) {
-      inputNode.current.blur();
-    }
-  };
-
   const handleToggle = (event: React.MouseEvent) => {
-    if (event.pageX !== 0 && event.pageY !== 0) {
-      blur();
-    }
-
     if (!disabled && onChange) {
       onChange(!checked, event);
     }

--- a/src/components/radio/theme.css
+++ b/src/components/radio/theme.css
@@ -82,7 +82,7 @@
       border-color: var(--color-mint-darkest);
     }
 
-    input:focus + .shape {
+    input:focus-visible + .shape {
       box-shadow: inset 0 0 0 1px var(--color-mint-darkest);
       border-color: var(--color-mint-darkest);
     }
@@ -106,7 +106,7 @@
     }
   }
 
-  input:focus + .shape {
+  input:focus-visible + .shape {
     border-color: var(--color-neutral-darkest);
     box-shadow: inset 0 0 0 1px var(--color-neutral-darkest);
   }

--- a/src/components/tab/TitleTab.tsx
+++ b/src/components/tab/TitleTab.tsx
@@ -26,19 +26,9 @@ const TitleTab: GenericComponent<TitleTabProps> = forwardRef<HTMLElement, TitleT
     const tabRef = useRef<HTMLElement>(null);
     useImperativeHandle(ref, () => tabRef.current!);
 
-    const blur = () => {
-      const currentTabRef = tabRef.current;
-      if (currentTabRef?.blur) {
-        currentTabRef.blur();
-      }
-    };
-
     const handleClick = (event: React.MouseEvent<HTMLElement>) => {
       if (onClick) {
         onClick(event);
-      }
-      if (event.pageX !== 0 && event.pageY !== 0) {
-        blur();
       }
     };
 

--- a/src/components/tab/theme.css
+++ b/src/components/tab/theme.css
@@ -26,7 +26,7 @@
   flex-shrink: 0;
   height: 48px;
 
-  &:focus {
+  &:focus-visible {
     box-shadow: inset 0 0 0 2px var(--color-neutral);
 
     .counter {

--- a/src/components/timer/theme.css
+++ b/src/components/timer/theme.css
@@ -15,7 +15,7 @@
     background-color: hsl(var(--color-neutral-darkest-hsl), 12%);
     border: 1px solid hsl(var(--color-neutral-darkest-hsl), 12%);
 
-    &:focus {
+    &:focus-visible {
       background-color: hsl(var(--color-neutral-darkest-hsl), 12%);
       border-color: hsl(var(--color-neutral-darkest-hsl), 24%);
       box-shadow: 0 0 0 1px hsl(var(--color-neutral-darkest-hsl), 24%);
@@ -35,7 +35,7 @@
     background-color: hsl(var(--color-violet-darkest-hsl), 12%);
     border: 1px solid hsl(var(--color-violet-darkest-hsl), 12%);
 
-    &:focus {
+    &:focus-visible {
       background-color: hsl(var(--color-violet-darkest-hsl), 12%);
       border-color: hsl(var(--color-violet-darkest-hsl), 24%);
       box-shadow: 0 0 0 1px hsl(var(--color-violet-darkest-hsl), 24%);

--- a/src/components/toggle/Toggle.tsx
+++ b/src/components/toggle/Toggle.tsx
@@ -44,14 +44,7 @@ const Toggle: GenericComponent<ToggleProps> = ({
   const boxProps = pickBoxProps(others);
   const inputProps = omitBoxProps(others);
 
-  const blur = () => {
-    if (ref.current) {
-      ref.current.blur();
-    }
-  };
-
   const handleToggle = (event: ChangeEvent<HTMLInputElement>) => {
-    blur();
     if (!disabled && onChange) {
       onChange(event);
     }

--- a/src/components/toggle/Toggle.tsx
+++ b/src/components/toggle/Toggle.tsx
@@ -66,7 +66,6 @@ const Toggle: GenericComponent<ToggleProps> = ({
       <input
         className={theme['input']}
         type="checkbox"
-        hidden
         checked={checked}
         disabled={disabled}
         onChange={handleToggle}

--- a/src/components/toggle/__tests__/__snapshots__/Toggle.spec.tsx.snap
+++ b/src/components/toggle/__tests__/__snapshots__/Toggle.spec.tsx.snap
@@ -8,7 +8,6 @@ exports[`Component - Toggle renders 1`] = `
   >
     <input
       class="input"
-      hidden=""
       type="checkbox"
     />
     <span

--- a/src/components/toggle/theme.css
+++ b/src/components/toggle/theme.css
@@ -82,7 +82,7 @@
       border-color: var(--color-mint-darkest);
     }
 
-    input:focus + .track {
+    input:focus-visible + .track {
       box-shadow: 0 0 0 1px var(--color-mint-darkest);
       border-color: var(--color-mint-darkest);
     }
@@ -116,7 +116,7 @@
     }
   }
 
-  input:focus + .track {
+  input:focus-visible + .track {
     border-color: var(--color-neutral-darkest);
     box-shadow: 0 0 0 1px var(--color-neutral-darkest);
   }


### PR DESCRIPTION
### Description

Some of our components contain automatic blurring when clicking them, to avoid having a focus state after clicking. This is not necessary anymore these days, because we now just style the focus state via `:focus-visible` which is only used when focus state is reached via keyboard (kind of, in reality it's a bit more complicated than that).

The automatic blurring was also causing some issues because the focus completely resets when doing the blur.

---

### Changed

- Focus states are now styled through `:focus-visible` instead of `:focus`. ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2575](https://github.com/teamleadercrm/ui/pull/2575)

### Fixed

- `Toggle`: the component is now focusable. ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2575](https://github.com/teamleadercrm/ui/pull/2575)

### Dependency updates

- `postcss-preset-env`: bump peer dependency expectation to `^8.0.0`, otherwise the `:focus-visible` styling will not be included. ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2575](https://github.com/teamleadercrm/ui/pull/2575)

---

### Manual check

Check focus states in storybook. Clicking on them shouldn't show a focus state, but navigating with keyboard 

- [ ] in storybook
- [ ] linking it into your local project (I tested on `service-auth-frontend`. Couldn't get the linking working on `core`, even after linking react)



