### PR TITLE
[FRONT-441] fix the focus state for the Link and MarketingLink component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Fixed
 
 - `Toggle`: the component is now focusable. ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2575](https://github.com/teamleadercrm/ui/pull/2575)
+- `Link` and `MarketingLink`: fixed the focus state styling.  ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2576](https://github.com/teamleadercrm/ui/pull/2576)
 
 ### Removed
 

--- a/src/components/link/theme.css
+++ b/src/components/link/theme.css
@@ -25,7 +25,7 @@
   }
 
   &:focus-visible {
-    outline: var(--color-aqua-dark) auto 3px;
+    outline: 2px solid var(--color-aqua-dark);
   }
 
   &:active {

--- a/src/components/marketingLink/theme.css
+++ b/src/components/marketingLink/theme.css
@@ -19,7 +19,7 @@
   }
 
   &:focus-visible {
-    outline: var(--color-marketing-violet-light) auto 3px;
+    outline: 2px solid var(--color-marketing-violet);
   }
 
   &:active {


### PR DESCRIPTION
### Description

 Fix the focus state for the `Link` and `MarketingLink` component. The css was incorrect. Checked with design what the focus state should be (we thought 3px was a bit too much).
