### PR TITLE
[FRONT-443] Avoid DataGrid error when hovering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [20.0.1] - 2023-02-28
+
+### Changed
+
+- `DataGrid` Avoid error when hovering over a row. ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2582](https://github.com/teamleadercrm/ui/pull/2582)
+
 ## [20.0.0] - 2023-02-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ## [20.0.1] - 2023-02-28
 
-### Changed
+### Fixed
 
 - `DataGrid` Avoid error when hovering over a row. ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2582](https://github.com/teamleadercrm/ui/pull/2582)
 

--- a/src/components/datagrid/DataGrid.tsx
+++ b/src/components/datagrid/DataGrid.tsx
@@ -212,7 +212,7 @@ export const DataGrid: DatagridComponent = ({
                 return React.cloneElement(child, {
                   sliceFrom: stickyFromLeft > 0 ? stickyFromLeft : 0,
                   sliceTo: stickyFromRight > 0 ? -stickyFromRight : undefined,
-                  ref: (rowNode: HTMLElement) => setRowNodes(rowNodes.set(key, rowNode)),
+                  ref: (rowNode: HTMLElement | null) => rowNode && setRowNodes(rowNodes.set(key, rowNode)),
                   style: isOverflowing
                     ? {
                         minWidth: `${totalRowChildrenWidth - 10}px`,
@@ -226,7 +226,7 @@ export const DataGrid: DatagridComponent = ({
                   onMouseLeave: (event: MouseEvent) => handleBodyRowMouseLeave(child, event),
                   sliceFrom: stickyFromLeft > 0 ? stickyFromLeft : 0,
                   sliceTo: stickyFromRight > 0 ? -stickyFromRight : undefined,
-                  ref: (rowNode: HTMLElement) => setRowNodes(rowNodes.set(key, rowNode)),
+                  ref: (rowNode: HTMLElement | null) => rowNode && setRowNodes(rowNodes.set(key, rowNode)),
                   style: isOverflowing
                     ? {
                         minWidth: `${totalRowChildrenWidth - 10}px`,


### PR DESCRIPTION
### Description

DataGrid can crash under certain circumstances and then hovering over a DataGrid row. It seems to be a weird occasion when the amount of rows changes, but I can't reproduce it inside storybook (but I'm consistently having the issue in workorders-frontend when updated to v20). 

The issue is caused by storing a ref as null, but in a calculation we don't expect it to be null. The ref is stored as null, because it's an inline function, which means it gets called with null, and then with the DOM element.

From the [react docs](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs): 

> If the ref callback is defined as an inline function, it will get called twice during updates, first with null and then again with the DOM element. This is because a new instance of the function is created with each render, so React needs to clear the old ref and set up the new one.

![Screenshot 2023-02-28 at 14 18 51](https://user-images.githubusercontent.com/330765/221770434-3fb851d5-19fb-4e16-91bb-5af9843642c9.png)
