### PR TITLE
[FRONT-482] remove padding on xl screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Container`: remove 72px on xl viewport ([@farazatarodi](https://https://github.com/farazatarodi) in [#2615](https://github.com/teamleadercrm/ui/pull/2615))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/container/theme.css
+++ b/src/components/container/theme.css
@@ -10,10 +10,3 @@
   margin: 0 auto;
   max-width: 1056px;
 }
-
-@media (--larger-than-xl-viewport) {
-  .container {
-    padding-left: var(--spacer-biggest);
-    padding-right: var(--spacer-biggest);
-  }
-}


### PR DESCRIPTION
### Description

#### Changed
- `Container`: remove 72px padding on xl viewport

#### Screenshot before this PR

![image](https://user-images.githubusercontent.com/78449551/229812357-57301b83-ed66-4fc5-83df-6260c070946f.png)


#### Screenshot after this PR

![image](https://user-images.githubusercontent.com/78449551/229812471-d69bb2ba-4e3e-4cc7-b3d6-da355bd76043.png)


### Breaking changes

NA
