### PR TITLE
[FRONT-481] Fix multiple variable imports

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import { addDecorator, addParameters } from '@storybook/react';
 import { withDesign } from 'storybook-addon-designs';
 import { COLOR } from '../src/constants';
+import '../src/index.css';
 
 import theme from './theme';
 import {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `Container`: Removed 72px padding on xl viewport ([@farazatarodi](https://https://github.com/farazatarodi) in [#2618](https://github.com/teamleadercrm/ui/pull/2618))
 - [BREAKING] `Menu`: State management now should happen in the parent component ([@farazatarodi](https://https://github.com/farazatarodi) in [#2618](https://github.com/teamleadercrm/ui/pull/2618)).
 - `Menu`: Shadow and border now use the values from the design system ([@farazatarodi](https://https://github.com/farazatarodi) in [#2618](https://github.com/teamleadercrm/ui/pull/2618)).
+- [BREAKING]: CSS custom properties are not transpiled anymore. Before, the custom properties were replaced with the actual values in the built CSS, but now they are not replaced as we want to actually use custom properties natively. So you need to make sure that you import the variables into your project (e.g. `import '@teamleader/ui/es/index.css';` in JS or `@import url('@teamleader/ui/es/index.css)` in css). ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2620](https://github.com/teamleadercrm/ui/pull/2620))
 
 ### Deprecated
 
@@ -21,6 +22,9 @@
 - [BREAKING] `Menu`: It now requires an anchor element for positioning when it is not static. Previously it was based on the parent element, which caused layout bugs in `flex` elements ([@farazatarodi](https://https://github.com/farazatarodi) in [#2618](https://github.com/teamleadercrm/ui/pull/2618)).
 
 ### Dependency updates
+
+- [BREAKING] `@teamleader/ui-colors` has been updated to version 2.0.0 which uses the newer comma-free syntax for hsl colors. This means that you need to update the syntax where you use the hsl value in combination with alhpa (e.g. `hsl(var(--color-teal), 50%)` should be changed to `hsl(var(--color-teal) /50%)`). ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2620](https://github.com/teamleadercrm/ui/pull/2620))
+
 
 ## [20.1.0] - 2023-03-17
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ import { Button } from '@teamleader/ui';
 ReactDOM.render(<Button label="Hello World!" />, document.getElementById('app'));
 ```
 
+Import the CSS into your project via JS or CSS.
+
+JS
+```js
+import '@teamleader/ui/es/index.css';
+```
+
+or CSS
+```css
+@import url('@teamleader/ui/es/index.css');
+```
+
 ## Browser support
 
 This library officially supports the last two versions of the major browsers. This is mainly because of dependencies and ease of mind.

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,8 +4,8 @@ module.exports = {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/tests/__mocks__/filemock.js',
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
-    '^@teamleader/ui-utilities': '<rootDir>/tests/__mocks__/filemock.js',
-    '^@teamleader/ui-typography': '<rootDir>/tests/__mocks__/filemock.js',
+    '^@teamleader/ui-utilities': 'identity-obj-proxy',
+    '^@teamleader/ui-typography': 'identity-obj-proxy',
   },
   testMatch: ['<rootDir>/src/**/__tests__/**/*.spec.(ts|tsx)'],
   testPathIgnorePatterns: ['stories.spec.tsx'],

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "cjs/**/*.css",
     "es/**/*.css"
   ],
-  "browserslist": ">0.5%, ie 11, not op_mini all",
+  "browserslist": ">0.5%, not op_mini all",
   "scripts": {
     "build:css": "postcss ./src/**/*.css --base src --dir ./es && cp -R ./es ./cjs",
     "build:js": "yarn build:es; yarn build:cjs",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@babel/preset-env": "^7.18.2",
     "@babel/preset-react": "^7.12.5",
     "@babel/preset-typescript": "^7.16.7",
+    "@csstools/postcss-global-data": "^1.0.3",
     "@storybook/addon-backgrounds": "6.5.10",
     "@storybook/addon-controls": "^6.5.10",
     "@storybook/addon-docs": "^6.5.10",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@babel/runtime": "^7.18.3",
     "@teamleader/ui-animations": "^0.0.3",
-    "@teamleader/ui-colors": "^1.1.0",
+    "@teamleader/ui-colors": "^2.0.0",
     "@teamleader/ui-icons": "^2.1.0",
     "@teamleader/ui-illustrations": "^1.10.0",
     "@teamleader/ui-typography": "^2.0.2",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -14,6 +14,9 @@ module.exports = ({ file, options, env }) => {
       'postcss-reporter': {},
       'postcss-preset-env': {
         preserve: false,
+        features: {
+          'custom-properties': false,
+        },
       },
     },
   };

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -7,6 +7,9 @@ module.exports = ({ file, options, env }) => {
         root: './',
         path: [path.join(__dirname, './src/components')],
       },
+      '@csstools/postcss-global-data': {
+        files: ['./node_modules/@teamleader/ui-utilities/index.css'],
+      },
       'postcss-pseudoelements': {},
       'postcss-each': {},
       'postcss-nested': {},

--- a/src/components/alert/__tests__/__snapshots__/Alert.spec.tsx.snap
+++ b/src/components/alert/__tests__/__snapshots__/Alert.spec.tsx.snap
@@ -15,7 +15,7 @@ exports[`Component - Alert renders 1`] = `
           tabindex="0"
         />
         <div
-          class="box dialog-base is-small is-entering"
+          class="box box-shadow-300 dialog-base is-small is-entering"
           data-teamleader-ui="dialog"
         >
           <div

--- a/src/components/avatar/__tests__/__snapshots__/AvatarStack.spec.tsx.snap
+++ b/src/components/avatar/__tests__/__snapshots__/AvatarStack.spec.tsx.snap
@@ -52,7 +52,7 @@ exports[`Component - AvatarStack renders 1`] = `
       </div>
     </div>
     <div
-      class="box align-items-center display-flex justify-content-center overflow"
+      class="box align-items-center display-flex justify-content-center reset-font-smoothing overflow"
     >
       +2
     </div>

--- a/src/components/avatar/__tests__/__snapshots__/AvatarStackOverflow.spec.tsx.snap
+++ b/src/components/avatar/__tests__/__snapshots__/AvatarStackOverflow.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Component - AvatarStackOverflow renders 1`] = `
 <DocumentFragment>
   <div
-    class="box align-items-center display-flex justify-content-center overflow"
+    class="box align-items-center display-flex justify-content-center reset-font-smoothing overflow"
   >
     +2
   </div>

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -1,7 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-typography';
-@import '@teamleader/ui-utilities';
-
 :root {
   --overflow-padding-horizontal: 8px;
   --stacked-avatars-spacing: 12px;

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -72,25 +72,25 @@
 }
 
 .default-height {
-  background-color: hsl(var(--color-teal-darkest-hsl), 0.84);
+  background-color: hsl(var(--color-teal-darkest-hsl) / 0.84);
   height: 24px;
 }
 
 .full-height {
-  background-color: hsl(var(--color-teal-darkest-hsl), 0.48);
+  background-color: hsl(var(--color-teal-darkest-hsl) / 0.48);
   height: 100%;
 }
 
 .dark {
   .overflow {
-    background: hsl(var(--color-teal-darkest-hsl), 10%);
+    background: hsl(var(--color-teal-darkest-hsl) / 10%);
     color: var(--color-neutral-darkest);
   }
 }
 
 .light {
   .overflow {
-    background: hsl(var(--color-white-hsl), 10%);
+    background: hsl(var(--color-white-hsl) / 10%);
     color: var(--color-white);
   }
 }

--- a/src/components/avatar/theme.css
+++ b/src/components/avatar/theme.css
@@ -1,24 +1,17 @@
-:root {
-  --overflow-padding-horizontal: 8px;
-  --stacked-avatars-spacing: 12px;
-
-  --tiny-size: 24px;
-  --small-size: 30px;
-  --medium-size: 48px;
-  --large-size: 72px;
-  --hero-size: 144px;
-
-  --shape-circle-image-border-radius: 50%;
-  --shape-rounded-image-border-radius: 4px;
-}
-
 .wrapper {
   position: relative;
   text-decoration: none;
+  height: var(--size);
+  width: var(--size);
 
   &:hover {
     text-decoration: none;
   }
+}
+
+.avatar {
+  height: var(--size);
+  width: var(--size);
 }
 
 .children {
@@ -50,8 +43,11 @@
   font-family: var(--font-family-inter);
   font-weight: 500;
   line-height: 1;
-  padding: 0 var(--overflow-padding-horizontal);
+  padding: 0 8px;
   user-select: none;
+  border-radius: var(--size);
+  height: var(--size);
+  min-width: var(--size);
 }
 
 .overlay {
@@ -114,11 +110,7 @@
 }
 
 .is-tiny {
-  &.wrapper,
-  .avatar {
-    height: var(--tiny-size);
-    width: var(--tiny-size);
-  }
+  --size: 24px;
 
   .initials {
     font-size: 8px;
@@ -130,19 +122,12 @@
   }
 
   .overflow {
-    border-radius: var(--tiny-size);
     font-size: calc(1.2 * var(--unit));
-    height: var(--tiny-size);
-    min-width: var(--tiny-size);
   }
 }
 
 .is-small {
-  &.wrapper,
-  .avatar {
-    height: var(--small-size);
-    width: var(--small-size);
-  }
+  --size: 30px;
 
   .children {
     bottom: 60%;
@@ -150,19 +135,12 @@
   }
 
   .overflow {
-    border-radius: var(--small-size);
     font-size: calc(1.4 * var(--unit));
-    height: var(--small-size);
-    min-width: var(--small-size);
   }
 }
 
 .is-medium {
-  &.wrapper,
-  .avatar {
-    height: var(--medium-size);
-    width: var(--medium-size);
-  }
+  --size: 48px;
 
   .children {
     bottom: 65%;
@@ -170,19 +148,12 @@
   }
 
   .overflow {
-    border-radius: var(--medium-size);
     font-size: calc(1.6 * var(--unit));
-    height: var(--medium-size);
-    min-width: var(--medium-size);
   }
 }
 
 .is-large {
-  &.wrapper,
-  .avatar {
-    height: var(--large-size);
-    width: var(--large-size);
-  }
+  --size: 72px;
 
   .initials {
     font-size: 18px;
@@ -194,19 +165,12 @@
   }
 
   .overflow {
-    border-radius: var(--large-size);
     font-size: calc(1.8 * var(--unit));
-    height: var(--large-size);
-    min-width: var(--large-size);
   }
 }
 
 .is-hero {
-  &.wrapper,
-  .avatar {
-    height: var(--hero-size);
-    width: var(--hero-size);
-  }
+  --size: 144px;
 
   .initials {
     font-size: 36px;
@@ -218,32 +182,31 @@
   }
 
   .overflow {
-    border-radius: var(--hero-size);
     font-size: calc(3.6 * var(--unit));
-    height: var(--hero-size);
-    min-width: var(--hero-size);
   }
 }
 
 .is-circle {
   .avatar,
   .overlay {
-    border-radius: var(--shape-circle-image-border-radius);
+    border-radius: 50%;
   }
 }
 
 .is-rounded {
+  --rounded-border-radius: 4px;
+
   .avatar {
-    border-radius: var(--shape-rounded-image-border-radius);
+    border-radius: var(--rounded-border-radius);
   }
 
   .overlay {
     .default-height {
-      border-radius: 0 0 var(--shape-rounded-image-border-radius) var(--shape-rounded-image-border-radius);
+      border-radius: 0 0 var(--rounded-border-radius) var(--rounded-border-radius);
     }
 
     .full-height {
-      border-radius: var(--shape-rounded-image-border-radius);
+      border-radius: var(--rounded-border-radius);
     }
   }
 }

--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -4,8 +4,8 @@
 }
 
 .badge {
-  background-color: hsl(var(--color-neutral-darkest-hsl), 12%);
-  border: var(--badge-border-width) solid hsl(var(--color-neutral-darkest-hsl), 12%);
+  background-color: hsl(var(--color-neutral-darkest-hsl) / 12%);
+  border: var(--badge-border-width) solid hsl(var(--color-neutral-darkest-hsl) / 12%);
   border-radius: var(--badge-border-radius);
   color: var(--color-teal-darkest);
   display: inline-flex;
@@ -33,19 +33,19 @@
 
   &.is-clickable:not(.is-disabled) {
     &:hover {
-      background-color: hsl(var(--color-neutral-darkest-hsl), 18%);
+      background-color: hsl(var(--color-neutral-darkest-hsl) / 18%);
       cursor: pointer;
     }
 
     &:focus-visible {
-      background-color: hsl(var(--color-neutral-darkest-hsl), 12%);
-      border-color: hsl(var(--color-neutral-darkest-hsl), 24%);
-      box-shadow: 0 0 0 var(--badge-border-width) hsl(var(--color-neutral-darkest-hsl), 24%);
+      background-color: hsl(var(--color-neutral-darkest-hsl) / 12%);
+      border-color: hsl(var(--color-neutral-darkest-hsl) / 24%);
+      box-shadow: 0 0 0 var(--badge-border-width) hsl(var(--color-neutral-darkest-hsl) / 24%);
     }
 
     &:active {
-      box-shadow: inset 0 2px 3px hsl(var(--color-neutral-darkest-hsl), 12%);
-      background-color: hsl(var(--color-neutral-darkest-hsl), 18%);
+      box-shadow: inset 0 2px 3px hsl(var(--color-neutral-darkest-hsl) / 12%);
+      background-color: hsl(var(--color-neutral-darkest-hsl) / 18%);
     }
   }
 
@@ -55,7 +55,7 @@
   }
 
   &.is-selected {
-    background-color: hsl(var(--color-neutral-darkest-hsl), 24%) !important;
+    background-color: hsl(var(--color-neutral-darkest-hsl) / 24%) !important;
   }
 }
 

--- a/src/components/badge/theme.css
+++ b/src/components/badge/theme.css
@@ -1,8 +1,3 @@
-@import '@teamleader/ui-animations';
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-@import '@teamleader/ui-typography';
-
 :root {
   --badge-border-radius: calc(0.4 * var(--unit));
   --badge-border-width: 1px;

--- a/src/components/badgedLink/__tests__/__snapshots__/BadgedLink.spec.tsx.snap
+++ b/src/components/badgedLink/__tests__/__snapshots__/BadgedLink.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Component - BadgedLink renders 1`] = `
 <DocumentFragment>
   <a
-    class="box badged-link is-inherit is-left-icon-placed"
+    class="box reset-font-smoothing ui-text-body badged-link is-inherit is-left-icon-placed"
     data-teamleader-ui="badgedLink"
     href="https://foobar.com"
     target="_blank"

--- a/src/components/badgedLink/theme.css
+++ b/src/components/badgedLink/theme.css
@@ -1,8 +1,3 @@
-@import '@teamleader/ui-animations';
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-typography';
-@import '@teamleader/ui-utilities';
-
 .badged-link {
   display: inline-flex;
   align-items: center;

--- a/src/components/badgedLink/theme.css
+++ b/src/components/badgedLink/theme.css
@@ -13,22 +13,22 @@
   text-decoration: none !important;
 
   &:hover {
-    background: hsl(var(--color-neutral-darkest-hsl), 18%);
+    background: hsl(var(--color-neutral-darkest-hsl) / 18%);
   }
 
   &:focus-visible {
-    box-shadow: 0 0 0 2px hsl(var(--color-neutral-darkest-hsl), 24%);
+    box-shadow: 0 0 0 2px hsl(var(--color-neutral-darkest-hsl) / 24%);
     outline: 0;
   }
 
   &:active {
-    box-shadow: inset 0 2px 3px hsl(var(--color-neutral-darkest-hsl), 12%);
-    background-color: hsl(var(--color-neutral-darkest-hsl), 18%);
+    box-shadow: inset 0 2px 3px hsl(var(--color-neutral-darkest-hsl) / 12%);
+    background-color: hsl(var(--color-neutral-darkest-hsl) / 18%);
     outline: 0;
   }
 
   &.is-selected {
-    background-color: hsl(var(--color-neutral-darkest-hsl), 24%) !important;
+    background-color: hsl(var(--color-neutral-darkest-hsl) / 24%) !important;
   }
 
   &.is-left-icon-placed :first-child {

--- a/src/components/banner/theme.css
+++ b/src/components/banner/theme.css
@@ -1,6 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-
 .banner {
   border: 1px solid;
 

--- a/src/components/box/theme.css
+++ b/src/components/box/theme.css
@@ -1,6 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-
 .box {
   box-sizing: border-box;
   margin-bottom: 0;

--- a/src/components/bullet/theme.css
+++ b/src/components/bullet/theme.css
@@ -1,28 +1,21 @@
-:root {
-  --large-size: 18px;
-  --medium-size: 12px;
-  --small-size: 9px;
-}
-
 .bullet {
   border-radius: 50%;
   display: inline-block;
   vertical-align: middle;
-}
-
-.medium {
-  height: var(--medium-size);
-  width: var(--medium-size);
+  width: var(--size);
+  height: var(--size);
 }
 
 .small {
-  height: var(--small-size);
-  width: var(--small-size);
+  --size: 9px;
+}
+
+.medium {
+  --size: 12px;
 }
 
 .large {
-  height: var(--large-size);
-  width: var(--large-size);
+  --size: 18px;
 }
 
 .neutral {

--- a/src/components/bullet/theme.css
+++ b/src/components/bullet/theme.css
@@ -1,5 +1,3 @@
-@import '@teamleader/ui-colors';
-
 :root {
   --large-size: 18px;
   --medium-size: 12px;

--- a/src/components/button/theme.css
+++ b/src/components/button/theme.css
@@ -1,8 +1,3 @@
-@import '@teamleader/ui-animations';
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-typography';
-@import '@teamleader/ui-utilities';
-
 :root {
   --button-border-radius: calc(0.4 * var(--unit));
 }

--- a/src/components/button/theme.css
+++ b/src/components/button/theme.css
@@ -78,17 +78,17 @@
       color: var(--color-$(color)-darkest);
 
       &.is-disabled {
-        background-color: hsl(var(--color-$(color)-darkest-hsl), 12%);
-        border: 1px solid hsl(var(--color-$(color)-darkest-hsl), 12%);
-        color: hsl(var(--color-$(color)-darkest-hsl), 36%);
+        background-color: hsl(var(--color-$(color)-darkest-hsl) / 12%);
+        border: 1px solid hsl(var(--color-$(color)-darkest-hsl) / 12%);
+        color: hsl(var(--color-$(color)-darkest-hsl) / 36%);
       }
 
       &:not(.is-disabled) {
         background-color: transparent;
-        border: 1px solid hsl(var(--color-$(color)-darkest-hsl), 72%);
+        border: 1px solid hsl(var(--color-$(color)-darkest-hsl) / 72%);
 
         &:hover {
-          background-color: hsl(var(--color-$(color)-darkest-hsl), 6%);
+          background-color: hsl(var(--color-$(color)-darkest-hsl) / 6%);
           border: 1px solid var(--color-$(color)-darkest);
         }
 
@@ -104,17 +104,17 @@
     color: var(--color-neutral-lightest);
 
     &.is-disabled {
-      border: 1px solid hsl(var(--color-neutral-lightest-hsl), 12%);
-      background-color: hsl(var(--color-neutral-lightest-hsl), 12%);
-      color: hsl(var(--color-neutral-lightest-hsl), 36%);
+      border: 1px solid hsl(var(--color-neutral-lightest-hsl) / 12%);
+      background-color: hsl(var(--color-neutral-lightest-hsl) / 12%);
+      color: hsl(var(--color-neutral-lightest-hsl) / 36%);
     }
 
     &:not(.is-disabled) {
       background-color: transparent;
-      border: 1px solid hsl(var(--color-neutral-lightest-hsl), 72%);
+      border: 1px solid hsl(var(--color-neutral-lightest-hsl) / 72%);
 
       &:hover {
-        background-color: hsl(var(--color-neutral-lightest-hsl), 12%);
+        background-color: hsl(var(--color-neutral-lightest-hsl) / 12%);
         border: 1px solid var(--color-neutral-lightest);
       }
 
@@ -279,7 +279,7 @@
 
     &:hover,
     &:active {
-      background-color: hsl(var(--color-neutral-hsl), 0.48);
+      background-color: hsl(var(--color-neutral-hsl) / 0.48);
     }
   }
 
@@ -288,7 +288,7 @@
   }
 
   &.has-icon-only:hover {
-    background-color: hsl(var(--color-neutral-darkest-hsl), 0.24);
+    background-color: hsl(var(--color-neutral-darkest-hsl) / 0.24);
   }
 
   &.is-processing {

--- a/src/components/buttonGroup/theme.css
+++ b/src/components/buttonGroup/theme.css
@@ -1,6 +1,6 @@
 :root {
-  --button-border-radius: calc(0.4 * var(--unit));
-  --button-margin: calc(0.6 * var(--unit));
+  --button-group-button-border-radius: calc(0.4 * var(--unit));
+  --button-group-button-margin: calc(0.6 * var(--unit));
 }
 
 .group {
@@ -9,8 +9,8 @@
   min-width: 0;
 
   > * {
-    margin-left: var(--button-margin);
-    margin-right: var(--button-margin);
+    margin-left: var(--button-group-button-margin);
+    margin-right: var(--button-group-button-margin);
   }
 
   > *:first-child {
@@ -30,15 +30,15 @@
   }
 
   > *:first-child:not(:only-child) {
-    border-radius: var(--button-border-radius) 0 0 var(--button-border-radius);
+    border-radius: var(--button-group-button-border-radius) 0 0 var(--button-group-button-border-radius);
     margin-left: 0;
   }
 
   > *:last-child:not(:only-child) {
-    border-radius: 0 var(--button-border-radius) var(--button-border-radius) 0;
+    border-radius: 0 var(--button-group-button-border-radius) var(--button-group-button-border-radius) 0;
   }
 
   > *:only-child {
-    border-radius: var(--button-border-radius);
+    border-radius: var(--button-group-button-border-radius);
   }
 }

--- a/src/components/buttonGroup/theme.css
+++ b/src/components/buttonGroup/theme.css
@@ -1,5 +1,3 @@
-@import '@teamleader/ui-utilities';
-
 :root {
   --button-border-radius: calc(0.4 * var(--unit));
   --button-margin: calc(0.6 * var(--unit));

--- a/src/components/checkbox/theme.css
+++ b/src/components/checkbox/theme.css
@@ -1,7 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-@import '@teamleader/ui-animations';
-
 :root {
   --checkbox-border-width: 1px;
 

--- a/src/components/container/theme.css
+++ b/src/components/container/theme.css
@@ -1,5 +1,3 @@
-@import '@teamleader/ui-utilities';
-
 .container {
   min-width: 1056px;
   padding-left: var(--spacer-big);

--- a/src/components/counter/__tests__/__snapshots__/Counter.spec.tsx.snap
+++ b/src/components/counter/__tests__/__snapshots__/Counter.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Component - Counter renders 1`] = `
 <DocumentFragment>
   <span
-    class="box counter neutral medium"
+    class="box reset-font-smoothing counter neutral medium"
     data-teamleader-ui="counter"
   >
     <span

--- a/src/components/counter/theme.css
+++ b/src/components/counter/theme.css
@@ -1,9 +1,5 @@
-:root {
-  --border-radius: 4px;
-}
-
 .counter {
-  border-radius: var(--border-radius);
+  border-radius: 4px;
   color: var(--color-white);
   display: inline-flex;
   align-items: center;

--- a/src/components/counter/theme.css
+++ b/src/components/counter/theme.css
@@ -1,7 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-@import '@teamleader/ui-typography';
-
 :root {
   --border-radius: 4px;
 }

--- a/src/components/counter/theme.css
+++ b/src/components/counter/theme.css
@@ -1,5 +1,5 @@
 .counter {
-  border-radius: 4px;
+  border-radius: var(--border-radius-medium);
   color: var(--color-white);
   display: inline-flex;
   align-items: center;

--- a/src/components/datagrid/HeaderRowOverlay/theme.css
+++ b/src/components/datagrid/HeaderRowOverlay/theme.css
@@ -1,6 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-typography';
-
 .header-row-overlay {
   background: var(--color-neutral-light);
   position: absolute;

--- a/src/components/datagrid/__tests__/__snapshots__/Datagrid.spec.tsx.snap
+++ b/src/components/datagrid/__tests__/__snapshots__/Datagrid.spec.tsx.snap
@@ -17,7 +17,7 @@ exports[`Component - Datagrid renders 1`] = `
           data-teamleader-ui="datagrid-header-row"
         >
           <div
-            class="box cell align-left flex-1 has-background-undefined has-border-undefined header-cell"
+            class="box reset-font-smoothing cell align-left flex-1 has-background-undefined has-border-undefined header-cell"
             data-teamleader-ui="datagrid-cell"
             style="box-sizing: content-box;"
           >
@@ -29,7 +29,7 @@ exports[`Component - Datagrid renders 1`] = `
             </span>
           </div>
           <div
-            class="box cell align-left flex-1 has-background-undefined has-border-undefined header-cell"
+            class="box reset-font-smoothing cell align-left flex-1 has-background-undefined has-border-undefined header-cell"
             data-teamleader-ui="datagrid-cell"
             style="box-sizing: content-box;"
           >
@@ -46,7 +46,7 @@ exports[`Component - Datagrid renders 1`] = `
           data-teamleader-ui="datagrid-body-row"
         >
           <div
-            class="box cell align-left flex-1 has-background-undefined has-border-undefined"
+            class="box reset-font-smoothing cell align-left flex-1 has-background-undefined has-border-undefined"
             data-teamleader-ui="datagrid-cell"
             style="box-sizing: content-box;"
           >
@@ -57,7 +57,7 @@ exports[`Component - Datagrid renders 1`] = `
             </div>
           </div>
           <div
-            class="box cell align-left flex-1 has-background-undefined has-border-undefined"
+            class="box reset-font-smoothing cell align-left flex-1 has-background-undefined has-border-undefined"
             data-teamleader-ui="datagrid-cell"
             style="box-sizing: content-box;"
           >
@@ -73,7 +73,7 @@ exports[`Component - Datagrid renders 1`] = `
           data-teamleader-ui="datagrid-body-row"
         >
           <div
-            class="box cell align-left flex-1 has-background-undefined has-border-undefined"
+            class="box reset-font-smoothing cell align-left flex-1 has-background-undefined has-border-undefined"
             data-teamleader-ui="datagrid-cell"
             style="box-sizing: content-box;"
           >
@@ -84,7 +84,7 @@ exports[`Component - Datagrid renders 1`] = `
             </div>
           </div>
           <div
-            class="box cell align-left flex-1 has-background-undefined has-border-undefined"
+            class="box reset-font-smoothing cell align-left flex-1 has-background-undefined has-border-undefined"
             data-teamleader-ui="datagrid-cell"
             style="box-sizing: content-box;"
           >
@@ -100,7 +100,7 @@ exports[`Component - Datagrid renders 1`] = `
           data-teamleader-ui="datagrid-footer-row"
         >
           <div
-            class="box cell align-left flex-1 has-background-undefined has-border-undefined"
+            class="box reset-font-smoothing cell align-left flex-1 has-background-undefined has-border-undefined"
             data-teamleader-ui="datagrid-cell"
             style="box-sizing: content-box;"
           >

--- a/src/components/datagrid/theme.css
+++ b/src/components/datagrid/theme.css
@@ -1,7 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-@import '@teamleader/ui-typography';
-
 :root {
   --datagrid-blend-width: 6px;
   --datagrid-cell-width-base: 80px;

--- a/src/components/datepicker/__tests__/__snapshots__/DatePicker.spec.tsx.snap
+++ b/src/components/datepicker/__tests__/__snapshots__/DatePicker.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`Component - DatePicker renders 1`] = `
     data-teamleader-ui="date-picker"
   >
     <div
-      class="container date-picker is-medium is-bordered"
+      class="container reset-font-smoothing date-picker is-medium is-bordered"
       lang="en"
     >
       <div

--- a/src/components/datepicker/theme.css
+++ b/src/components/datepicker/theme.css
@@ -1,7 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-typography';
-@import '@teamleader/ui-utilities';
-
 :root {
   --border-radius: calc(0.4 * var(--unit));
   --input-error-border: var(--color-ruby-dark);

--- a/src/components/datepicker/theme.css
+++ b/src/components/datepicker/theme.css
@@ -1,17 +1,6 @@
-:root {
-  --border-radius: calc(0.4 * var(--unit));
-  --input-error-border: var(--color-ruby-dark);
-  --input-error-border-inverse: var(--color-ruby-light);
-  --input-warning-border: var(--color-gold-dark);
-  --input-warning-border-inverse: var(--color-gold-light);
-  --input-height-large: calc(4.6 * var(--unit));
-  --input-height-medium: calc(3.4 * var(--unit));
-  --input-height-small: calc(2.8 * var(--unit));
-  --input-text-size: calc(1.4 * var(--unit));
-  --input-text-size-large: calc(1.6 * var(--unit));
-}
-
 .date-picker {
+  --border-radius: calc(0.4 * var(--unit));
+
   display: flex;
 
   &-input__non-typeable {
@@ -227,63 +216,6 @@
   color: var(--color-violet-darkest);
 }
 
-.input-wrapper {
-  align-items: center;
-  border: 1px solid;
-  border-radius: var(--border-radius);
-  display: flex;
-  transition: 0.3s ease-in-out border, 0.3s ease-in-out box-shadow;
-  white-space: nowrap;
-
-  input {
-    background: transparent;
-    border: 0;
-    border-radius: var(--border-radius);
-    font-family: var(--font-family-inter);
-    font-size: var(--input-text-size);
-    font-weight: 400;
-    outline: 0;
-    padding: 0;
-    width: 100%;
-  }
-}
-
-.has-warning {
-  &:not(.has-focus) {
-    &:not(.is-inverse) {
-      .input-wrapper {
-        border-color: var(--input-warning-border) !important;
-        box-shadow: 0 0 0 1px var(--input-warning-border);
-      }
-    }
-
-    &.is-inverse {
-      .input-wrapper {
-        border-color: var(--input-warning-border-inverse) !important;
-        box-shadow: 0 0 0 1px var(--input-warning-border-inverse);
-      }
-    }
-  }
-}
-
-.has-error {
-  &:not(.has-focus) {
-    &:not(.is-inverse) {
-      .input-wrapper {
-        border-color: var(--input-error-border) !important;
-        box-shadow: 0 0 0 1px var(--input-error-border);
-      }
-    }
-
-    &.is-inverse {
-      .input-wrapper {
-        border-color: var(--input-error-border-inverse) !important;
-        box-shadow: 0 0 0 1px var(--input-error-border-inverse);
-      }
-    }
-  }
-}
-
 .is-small {
   .caption {
     font-size: 12px;
@@ -323,12 +255,6 @@
     font-size: 12px;
     padding: 6px;
   }
-
-  .input-wrapper {
-    input {
-      height: var(--input-height-small);
-    }
-  }
 }
 
 .is-medium {
@@ -363,12 +289,6 @@
   .weekNumber {
     font-size: 12px;
     padding: 9px;
-  }
-
-  .input-wrapper {
-    input {
-      height: var(--input-height-medium);
-    }
   }
 }
 
@@ -406,12 +326,5 @@
   .weekNumber {
     font-size: 16px;
     padding: 12px;
-  }
-
-  .input-wrapper {
-    input {
-      font-size: var(--input-text-size-large);
-      height: var(--input-height-large);
-    }
   }
 }

--- a/src/components/detailPage/theme.css
+++ b/src/components/detailPage/theme.css
@@ -1,5 +1,3 @@
-@import '@teamleader/ui-utilities';
-
 .header-inner {
   position: relative;
 }

--- a/src/components/dialog/__tests__/__snapshots__/Dialog.spec.tsx.snap
+++ b/src/components/dialog/__tests__/__snapshots__/Dialog.spec.tsx.snap
@@ -23,7 +23,7 @@ exports[`Component - Dialog renders 1`] = `
           tabindex="0"
         />
         <div
-          class="box dialog-base is-medium is-entering dialog"
+          class="box box-shadow-300 dialog-base is-medium is-entering dialog"
           data-teamleader-ui="dialog"
         >
           <div

--- a/src/components/dialog/theme.css
+++ b/src/components/dialog/theme.css
@@ -1,7 +1,3 @@
-@import '@teamleader/ui-animations';
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-
 :root {
   --dialog-background-color: var(--color-white);
   --dialog-border-radius: calc(0.4 * var(--unit));

--- a/src/components/emailSelector/__tests__/__snapshots__/EmailSelector.spec.tsx.snap
+++ b/src/components/emailSelector/__tests__/__snapshots__/EmailSelector.spec.tsx.snap
@@ -15,7 +15,7 @@ exports[`Component - EmailSelector renders 1`] = `
         data-teamleader-ui="ui-text"
       >
         <button
-          class="box link label-text"
+          class="box reset-font-smoothing link label-text"
           data-teamleader-ui="link"
         >
           David Brent

--- a/src/components/emailSelector/theme.css
+++ b/src/components/emailSelector/theme.css
@@ -53,8 +53,8 @@
   }
 
   &--error {
-    background-color: hsl(var(--color-ruby-dark-hsl), 12%) !important;
-    box-shadow: inset 0 0 0 1px hsl(var(--color-ruby-dark-hsl), 12%) !important;
+    background-color: hsl(var(--color-ruby-dark-hsl) / 12%) !important;
+    box-shadow: inset 0 0 0 1px hsl(var(--color-ruby-dark-hsl) / 12%) !important;
 
     button {
       color: var(--color-ruby-dark) !important;
@@ -63,16 +63,16 @@
     & > button {
       &:not(.is-disabled) {
         &:hover {
-          background-color: hsl(var(--color-ruby-dark-hsl), 18%);
+          background-color: hsl(var(--color-ruby-dark-hsl) / 18%);
         }
 
         &:focus-visible {
-          box-shadow: 0 0 0 2px hsl(var(--color-ruby-dark-hsl), 24%);
+          box-shadow: 0 0 0 2px hsl(var(--color-ruby-dark-hsl) / 24%);
         }
 
         &:active {
-          box-shadow: inset 0 2px 3px hsl(var(--color-ruby-dark-hsl), 24%);
-          background-color: hsl(var(--color-ruby-dark-hsl), 12%);
+          box-shadow: inset 0 2px 3px hsl(var(--color-ruby-dark-hsl) / 24%);
+          background-color: hsl(var(--color-ruby-dark-hsl) / 12%);
         }
       }
 

--- a/src/components/emailSelector/theme.css
+++ b/src/components/emailSelector/theme.css
@@ -1,6 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-
 :root {
   --overlay-z-index: 500;
   --max-label-width: 300px;

--- a/src/components/emptyState/__tests__/__snapshots__/EmptyState.spec.tsx.snap
+++ b/src/components/emptyState/__tests__/__snapshots__/EmptyState.spec.tsx.snap
@@ -52,7 +52,7 @@ exports[`Component - EmptyState renders 1`] = `
         class="box margin-top-3"
       >
         <a
-          class="box badged-link is-left-icon-placed"
+          class="box reset-font-smoothing ui-text-body badged-link is-left-icon-placed"
           data-teamleader-ui="badgedLink"
         >
           <svg

--- a/src/components/emptyState/theme.css
+++ b/src/components/emptyState/theme.css
@@ -1,5 +1,3 @@
-@import '@teamleader/ui-utilities';
-
 .wrapper {
   position: relative;
 }

--- a/src/components/filterSelection/theme.css
+++ b/src/components/filterSelection/theme.css
@@ -1,5 +1,3 @@
-@import '@teamleader/ui-colors';
-
 .select-control {
   height: 36px;
   width: max-content;

--- a/src/components/flex/theme.css
+++ b/src/components/flex/theme.css
@@ -1,5 +1,3 @@
-@import '@teamleader/ui-utilities';
-
 .flex {
   box-sizing: border-box;
   display: flex;

--- a/src/components/grid/theme.css
+++ b/src/components/grid/theme.css
@@ -1,5 +1,3 @@
-@import '@teamleader/ui-utilities';
-
 .grid {
   box-sizing: border-box;
   display: grid;

--- a/src/components/icon/theme.css
+++ b/src/components/icon/theme.css
@@ -1,5 +1,3 @@
-@import '@teamleader/ui-colors';
-
 .neutral {
   &.lightest {
     color: var(--color-neutral-lightest);

--- a/src/components/iconButton/theme.css
+++ b/src/components/iconButton/theme.css
@@ -10,21 +10,21 @@
 
   &:not(.is-disabled) {
     &:hover {
-      background-color: hsl(var(--color-neutral-darkest-hsl), 18%);
+      background-color: hsl(var(--color-neutral-darkest-hsl) / 18%);
     }
 
     &:focus-visible {
-      box-shadow: 0 0 0 2px hsl(var(--color-neutral-darkest-hsl), 24%);
+      box-shadow: 0 0 0 2px hsl(var(--color-neutral-darkest-hsl) / 24%);
     }
 
     &:active {
-      box-shadow: inset 0 2px 3px hsl(var(--color-neutral-darkest-hsl), 12%);
-      background-color: hsl(var(--color-neutral-darkest-hsl), 18%);
+      box-shadow: inset 0 2px 3px hsl(var(--color-neutral-darkest-hsl) / 12%);
+      background-color: hsl(var(--color-neutral-darkest-hsl) / 18%);
     }
   }
 
   &.is-selected {
-    background-color: hsl(var(--color-neutral-darkest-hsl), 24%) !important;
+    background-color: hsl(var(--color-neutral-darkest-hsl) / 24%) !important;
   }
 
   &.is-processing {

--- a/src/components/iconButton/theme.css
+++ b/src/components/iconButton/theme.css
@@ -1,6 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-
 .icon-button {
   background-color: transparent;
   border: 0;

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -1,7 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-typography';
-@import '@teamleader/ui-animations';
-
 /**
  * Variables
  */

--- a/src/components/input/theme.css
+++ b/src/components/input/theme.css
@@ -115,7 +115,7 @@
 .wrapper.is-inverse:active .input-inner-wrapper,
 .input.is-inverse:active {
   border-color: var(--color-teal-light);
-  box-shadow: inset 0 1px 3px 0 hsl(var(--color-teal-darkest-hsl), 0.48);
+  box-shadow: inset 0 1px 3px 0 hsl(var(--color-teal-darkest-hsl) / 0.48);
 }
 
 /* Disabled and Read-only state */

--- a/src/components/island/theme.css
+++ b/src/components/island/theme.css
@@ -1,5 +1,3 @@
-@import '@teamleader/ui-colors';
-
 .white {
   color: var(--color-teal-darkest);
 }

--- a/src/components/link/__tests__/__snapshots__/Link.spec.tsx.snap
+++ b/src/components/link/__tests__/__snapshots__/Link.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Component - Link renders 1`] = `
 <DocumentFragment>
   <a
-    class="box link is-inherit"
+    class="box reset-font-smoothing link is-inherit"
     data-teamleader-ui="link"
     href="https://foobar.com"
   >

--- a/src/components/link/theme.css
+++ b/src/components/link/theme.css
@@ -1,8 +1,3 @@
-@import '@teamleader/ui-animations';
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-typography';
-@import '@teamleader/ui-utilities';
-
 .link {
   cursor: pointer;
   background: transparent;

--- a/src/components/loadingBar/theme.css
+++ b/src/components/loadingBar/theme.css
@@ -38,7 +38,7 @@
 
 @each $color in (neutral, mint, violet, ruby, gold, aqua, teal) {
   .is-$(color) {
-    background-color: hsl(var(--color-$(color)-hsl), 18%);
+    background-color: hsl(var(--color-$(color)-hsl) / 18%);
 
     & .loading-bar-indicator {
       background-color: var(--color-$(color));
@@ -46,7 +46,7 @@
 
     @each $tint in (darkest, dark, light, lightest) {
       &.is-$(tint) {
-        background-color: hsl(var(--color-$(color)-$(tint)-hsl), 18%);
+        background-color: hsl(var(--color-$(color)-$(tint)-hsl) / 18%);
 
         & .loading-bar-indicator {
           background-color: var(--color-$(color)-$(tint));

--- a/src/components/loadingBar/theme.css
+++ b/src/components/loadingBar/theme.css
@@ -1,7 +1,3 @@
-@import '@teamleader/ui-animations';
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-
 @keyframes slideOut {
   to {
     transform: translate3d(650%, 0, 0);

--- a/src/components/loadingSpinner/theme.css
+++ b/src/components/loadingSpinner/theme.css
@@ -24,189 +24,189 @@
 
 .is-neutral {
   &.is-lightest:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-neutral-lightest-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-neutral-lightest-hsl) / 18%);
     border-top-color: var(--color-neutral-lightest);
   }
 
   &.is-light:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-neutral-light-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-neutral-light-hsl) / 18%);
     border-top-color: var(--color-neutral-light);
   }
 
   &.is-normal:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-neutral-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-neutral-hsl) / 18%);
     border-top-color: var(--color-neutral);
   }
 
   &.is-dark:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-neutral-dark-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-neutral-dark-hsl) / 18%);
     border-top-color: var(--color-neutral-dark);
   }
 
   &.is-darkest:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-neutral-darkest-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-neutral-darkest-hsl) / 18%);
     border-top-color: var(--color-neutral-darkest);
   }
 }
 
 .is-mint {
   &.is-lightest:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-mint-lightest-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-mint-lightest-hsl) / 18%);
     border-top-color: var(--color-mint-lightest);
   }
 
   &.is-light:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-mint-light-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-mint-light-hsl) / 18%);
     border-top-color: var(--color-mint-light);
   }
 
   &.is-normal:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-mint-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-mint-hsl) / 18%);
     border-top-color: var(--color-mint);
   }
 
   &.is-dark:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-mint-dark-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-mint-dark-hsl) / 18%);
     border-top-color: var(--color-mint-dark);
   }
 
   &.is-darkest:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-mint-darkest-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-mint-darkest-hsl) / 18%);
     border-top-color: var(--color-mint-darkest);
   }
 }
 
 .is-violet {
   &.is-lightest:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-violet-lightest-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-violet-lightest-hsl) / 18%);
     border-top-color: var(--color-violet-lightest);
   }
 
   &.is-light:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-violet-light-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-violet-light-hsl) / 18%);
     border-top-color: var(--color-violet-light);
   }
 
   &.is-normal:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-violet-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-violet-hsl) / 18%);
     border-top-color: var(--color-violet);
   }
 
   &.is-dark:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-violet-dark-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-violet-dark-hsl) / 18%);
     border-top-color: var(--color-violet-dark);
   }
 
   &.is-darkest:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-violet-darkest-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-violet-darkest-hsl) / 18%);
     border-top-color: var(--color-violet-darkest);
   }
 }
 
 .is-ruby {
   &.is-lightest:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-ruby-lightest-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-ruby-lightest-hsl) / 18%);
     border-top-color: var(--color-ruby-lightest);
   }
 
   &.is-light:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-ruby-light-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-ruby-light-hsl) / 18%);
     border-top-color: var(--color-ruby-light);
   }
 
   &.is-normal:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-ruby-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-ruby-hsl) / 18%);
     border-top-color: var(--color-ruby);
   }
 
   &.is-dark:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-ruby-dark-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-ruby-dark-hsl) / 18%);
     border-top-color: var(--color-ruby-dark);
   }
 
   &.is-darkest:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-ruby-darkest-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-ruby-darkest-hsl) / 18%);
     border-top-color: var(--color-ruby-darkest);
   }
 }
 
 .is-gold {
   &.is-lightest:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-gold-lightest-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-gold-lightest-hsl) / 18%);
     border-top-color: var(--color-gold-lightest);
   }
 
   &.is-light:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-gold-light-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-gold-light-hsl) / 18%);
     border-top-color: var(--color-gold-light);
   }
 
   &.is-normal:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-gold-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-gold-hsl) / 18%);
     border-top-color: var(--color-gold);
   }
 
   &.is-dark:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-gold-dark-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-gold-dark-hsl) / 18%);
     border-top-color: var(--color-gold-dark);
   }
 
   &.is-darkest:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-gold-darkest-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-gold-darkest-hsl) / 18%);
     border-top-color: var(--color-gold-darkest);
   }
 }
 
 .is-aqua {
   &.is-lightest:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-aqua-lightest-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-aqua-lightest-hsl) / 18%);
     border-top-color: var(--color-aqua-lightest);
   }
 
   &.is-light:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-aqua-light-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-aqua-light-hsl) / 18%);
     border-top-color: var(--color-aqua-light);
   }
 
   &.is-normal:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-aqua-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-aqua-hsl) / 18%);
     border-top-color: var(--color-aqua);
   }
 
   &.is-dark:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-aqua-dark-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-aqua-dark-hsl) / 18%);
     border-top-color: var(--color-aqua-dark);
   }
 
   &.is-darkest:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-aqua-darkest-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-aqua-darkest-hsl) / 18%);
     border-top-color: var(--color-aqua-darkest);
   }
 }
 
 .is-teal {
   &.is-lightest:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-teal-lightest-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-teal-lightest-hsl) / 18%);
     border-top-color: var(--color-teal-lightest);
   }
 
   &.is-light:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-teal-light-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-teal-light-hsl) / 18%);
     border-top-color: var(--color-teal-light);
   }
 
   &.is-normal:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-teal-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-teal-hsl) / 18%);
     border-top-color: var(--color-teal);
   }
 
   &.is-dark:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-teal-dark-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-teal-dark-hsl) / 18%);
     border-top-color: var(--color-teal-dark);
   }
 
   &.is-darkest:before {
-    border: var(--spinner-border-width) solid hsl(var(--color-teal-darkest-hsl), 18%);
+    border: var(--spinner-border-width) solid hsl(var(--color-teal-darkest-hsl) / 18%);
     border-top-color: var(--color-teal-darkest);
   }
 }
@@ -219,4 +219,10 @@
 .is-medium {
   height: var(--medium-spinner-size);
   width: var(--medium-spinner-size);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/src/components/loadingSpinner/theme.css
+++ b/src/components/loadingSpinner/theme.css
@@ -1,7 +1,3 @@
-@import '@teamleader/ui-animations';
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-
 :root {
   --spinner-border-width: 2px;
   --small-spinner-size: calc(1.4 * var(--unit));

--- a/src/components/marketingButton/theme.css
+++ b/src/components/marketingButton/theme.css
@@ -1,8 +1,3 @@
-@import '@teamleader/ui-animations';
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-typography';
-@import '@teamleader/ui-utilities';
-
 :root {
   --color-marketing-violet-lightest: #e9e8ff;
   --color-marketing-violet-light: #d3d1fe;

--- a/src/components/marketingButton/theme.css
+++ b/src/components/marketingButton/theme.css
@@ -1,10 +1,3 @@
-:root {
-  --color-marketing-violet-lightest: #e9e8ff;
-  --color-marketing-violet-light: #d3d1fe;
-  --color-marketing-violet: #4f1fff;
-  --color-marketing-violet-dark: #2800b8;
-}
-
 .button-base {
   align-items: center;
   border-radius: var(--border-radius-medium);

--- a/src/components/marketingButtonGroup/theme.css
+++ b/src/components/marketingButtonGroup/theme.css
@@ -1,8 +1,6 @@
 :root {
   --button-border-radius: calc(0.4 * var(--unit));
   --button-margin: calc(0.6 * var(--unit));
-  --color-marketing-violet: #4f1fff;
-  --color-marketing-violet-dark: #2800b8;
 }
 
 .button-base {

--- a/src/components/marketingButtonGroup/theme.css
+++ b/src/components/marketingButtonGroup/theme.css
@@ -1,11 +1,10 @@
 :root {
-  --button-border-radius: calc(0.4 * var(--unit));
-  --button-margin: calc(0.6 * var(--unit));
+  --marketing-button-group-button-border-radius: calc(0.4 * var(--unit));
 }
 
 .button-base {
   align-items: center;
-  border-radius: var(--button-border-radius);
+  border-radius: var(--marketing-button-group-button-border-radius);
   cursor: pointer;
   display: inline-flex;
   justify-content: center;
@@ -86,7 +85,7 @@
   }
 
   > *:first-child:not(:only-child) {
-    border-radius: var(--button-border-radius) 0 0 var(--button-border-radius);
+    border-radius: var(--marketing-button-group-button-border-radius) 0 0 var(--marketing-button-group-button-border-radius);
     margin-left: 0;
   }
 
@@ -95,10 +94,10 @@
   }
 
   > *:last-child:not(:only-child) {
-    border-radius: 0 var(--button-border-radius) var(--button-border-radius) 0;
+    border-radius: 0 var(--marketing-button-group-button-border-radius) var(--marketing-button-group-button-border-radius) 0;
   }
 
   > *:only-child {
-    border-radius: var(--button-border-radius);
+    border-radius: var(--marketing-button-group-button-border-radius);
   }
 }

--- a/src/components/marketingButtonGroup/theme.css
+++ b/src/components/marketingButtonGroup/theme.css
@@ -1,8 +1,3 @@
-@import '@teamleader/ui-animations';
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-typography';
-@import '@teamleader/ui-utilities';
-
 :root {
   --button-border-radius: calc(0.4 * var(--unit));
   --button-margin: calc(0.6 * var(--unit));

--- a/src/components/marketingDialog/__tests__/__snapshots__/MarketingDialog.spec.tsx.snap
+++ b/src/components/marketingDialog/__tests__/__snapshots__/MarketingDialog.spec.tsx.snap
@@ -15,7 +15,7 @@ exports[`Component - Dialog renders 1`] = `
           tabindex="0"
         />
         <div
-          class="box dialog-base is-medium is-entering marketing-dialog"
+          class="box box-shadow-300 dialog-base is-medium is-entering marketing-dialog"
           data-teamleader-ui="dialog"
         >
           <div

--- a/src/components/marketingLink/__tests__/__snapshots__/MarketingLink.spec.tsx.snap
+++ b/src/components/marketingLink/__tests__/__snapshots__/MarketingLink.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Component - MarketingLink renders 1`] = `
 <DocumentFragment>
   <a
-    class="box link"
+    class="box reset-font-smoothing link"
     data-teamleader-ui="marketing-link"
     href="https://foobar.com"
   >

--- a/src/components/marketingLink/theme.css
+++ b/src/components/marketingLink/theme.css
@@ -1,5 +1,3 @@
-@import '@teamleader/ui-colors';
-
 :root {
   --color-marketing-violet-light: #d3d1fe;
   --color-marketing-violet: #4f1fff;

--- a/src/components/marketingLink/theme.css
+++ b/src/components/marketingLink/theme.css
@@ -1,8 +1,3 @@
-:root {
-  --color-marketing-violet-light: #d3d1fe;
-  --color-marketing-violet: #4f1fff;
-}
-
 .link {
   cursor: pointer;
   color: var(--color-marketing-violet);

--- a/src/components/marketingLockBadge/theme.css
+++ b/src/components/marketingLockBadge/theme.css
@@ -1,11 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-
-:root {
-  --color-marketing-violet-light: #d3d1fe;
-  --color-marketing-violet: #4f1fff;
-}
-
 .wrapper {
   background-color: var(--color-marketing-violet-light);
 }

--- a/src/components/marketingMarker/theme.css
+++ b/src/components/marketingMarker/theme.css
@@ -1,7 +1,3 @@
-:root {
-  --color-marketing-violet-light: #d3d1fe;
-}
-
 .marker {
   background-color: hsl(var(--color-marketing-violet-light-hsl) / 50%);
   color: inherit;

--- a/src/components/marketingMarker/theme.css
+++ b/src/components/marketingMarker/theme.css
@@ -3,6 +3,6 @@
 }
 
 .marker {
-  background-color: hsl(var(--color-marketing-violet-light-hsl), 50%);
+  background-color: hsl(var(--color-marketing-violet-light-hsl) / 50%);
   color: inherit;
 }

--- a/src/components/marketingMenuItem/theme.css
+++ b/src/components/marketingMenuItem/theme.css
@@ -1,6 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-
 :root {
   --menu-item-background: var(--color-neutral-lightest);
   --menu-item-hover-background: var(--color-neutral-light);

--- a/src/components/marketingMenuItem/theme.css
+++ b/src/components/marketingMenuItem/theme.css
@@ -3,7 +3,6 @@
   --menu-item-hover-background: var(--color-neutral-light);
   --menu-item-selected-background: var(--color-aqua-lightest);
   --menu-item-height: calc(3.6 * var(--unit));
-  --color-marketing-violet: #4f1fff;
 }
 
 .marketing-menu-item {

--- a/src/components/marketingMenuItem/theme.css
+++ b/src/components/marketingMenuItem/theme.css
@@ -1,14 +1,14 @@
 :root {
-  --menu-item-background: var(--color-neutral-lightest);
-  --menu-item-hover-background: var(--color-neutral-light);
-  --menu-item-selected-background: var(--color-aqua-lightest);
-  --menu-item-height: calc(3.6 * var(--unit));
+  --marketing-menu-item-background: var(--color-neutral-lightest);
+  --marketing-menu-item-hover-background: var(--color-neutral-light);
+  --marketing-menu-item-selected-background: var(--color-aqua-lightest);
+  --marketing-menu-item-height: calc(3.6 * var(--unit));
 }
 
 .marketing-menu-item {
-  background-color: var(--menu-item-background);
+  background-color: var(--marketing-menu-item-background);
   border: 0;
-  min-height: var(--menu-item-height);
+  min-height: var(--marketing-menu-item-height);
   overflow: hidden;
   position: relative;
   text-decoration: none;
@@ -18,12 +18,12 @@
   user-select: none;
 
   &:not(.is-disabled):not(.is-selected):hover {
-    background-color: var(--menu-item-hover-background);
+    background-color: var(--marketing-menu-item-hover-background);
     cursor: pointer;
   }
 
   &:not(.is-disabled):not(.is-selected):focus-visible {
-    background-color: var(--menu-item-hover-background);
+    background-color: var(--marketing-menu-item-hover-background);
   }
 
   &:hover {
@@ -40,7 +40,7 @@
   }
 
   &.is-selected {
-    background-color: var(--menu-item-selected-background);
+    background-color: var(--marketing-menu-item-selected-background);
   }
 
   &-link-container {

--- a/src/components/marketingStatusLabel/theme.css
+++ b/src/components/marketingStatusLabel/theme.css
@@ -1,9 +1,6 @@
-:root {
-  --size-small: 18px;
-  --size-medium: 24px;
-}
-
 .wrapper {
+  height: var(--size);
+  border-radius: var(--size);
   background-color: var(--color-marketing-violet-lightest);
   box-shadow: inset 0 0 0 1px var(--color-marketing-violet-light);
 }
@@ -14,11 +11,9 @@
 }
 
 .is-small {
-  border-radius: var(--size-small);
-  height: var(--size-small);
+  --size: 18px;
 }
 
 .is-medium {
-  border-radius: var(--size-medium);
-  height: var(--size-medium);
+  --size: 24px;
 }

--- a/src/components/marketingStatusLabel/theme.css
+++ b/src/components/marketingStatusLabel/theme.css
@@ -1,7 +1,4 @@
 :root {
-  --color-marketing-violet-lightest: #e9e8ff;
-  --color-marketing-violet-light: #d3d1fe;
-  --color-marketing-violet: #4f1fff;
   --size-small: 18px;
   --size-medium: 24px;
 }

--- a/src/components/marketingTab/theme.css
+++ b/src/components/marketingTab/theme.css
@@ -1,6 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-animations';
-
 :root {
   --color-marketing-violet-lightest: #e9e8ff;
   --color-marketing-violet: #4f1fff;

--- a/src/components/marketingTab/theme.css
+++ b/src/components/marketingTab/theme.css
@@ -1,8 +1,3 @@
-:root {
-  --color-marketing-violet-lightest: #e9e8ff;
-  --color-marketing-violet: #4f1fff;
-}
-
 .wrapper {
   color: var(--color-neutral-darkest);
   display: flex;

--- a/src/components/marketingTypography/theme.css
+++ b/src/components/marketingTypography/theme.css
@@ -1,6 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-typography';
-
 .heading-1,
 .heading-2 {
   color: var(--color-teal-darkest);

--- a/src/components/menu/theme.css
+++ b/src/components/menu/theme.css
@@ -1,7 +1,3 @@
-@import '@teamleader/ui-animations';
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-
 :root {
   --menu-item-hover-background: var(--color-neutral-light);
   --menu-item-selected-background: var(--color-aqua-lightest);

--- a/src/components/overlay/theme.css
+++ b/src/components/overlay/theme.css
@@ -10,6 +10,6 @@
 
 .is-entered {
   &.dark {
-    background-color: hsl(var(--color-teal-dark-hsl), 50%);
+    background-color: hsl(var(--color-teal-dark-hsl) / 50%);
   }
 }

--- a/src/components/overlay/theme.css
+++ b/src/components/overlay/theme.css
@@ -1,6 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-animations';
-
 .overlay {
   bottom: 0;
   height: 100%;

--- a/src/components/pagination/theme.css
+++ b/src/components/pagination/theme.css
@@ -1,7 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-typography';
-@import '@teamleader/ui-utilities';
-
 :root {
   --ellipsis-min-width: calc(3 * var(--unit));
 }

--- a/src/components/passport/__tests__/__snapshots__/Passport.spec.tsx.snap
+++ b/src/components/passport/__tests__/__snapshots__/Passport.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`Component - Passport renders 1`] = `
             tabindex="0"
           />
           <div
-            class="box popover passport"
+            class="box box-shadow-200 popover passport"
             data-teamleader-ui="popover"
             style="left: 0px; top: 0px; max-width: 50vw; min-width: 180px;"
           >

--- a/src/components/popover/__tests__/__snapshots__/Popover.spec.tsx.snap
+++ b/src/components/popover/__tests__/__snapshots__/Popover.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`Component - Popover renders 1`] = `
             tabindex="0"
           />
           <div
-            class="box popover"
+            class="box box-shadow-200 popover"
             data-teamleader-ui="popover"
             style="left: 0px; top: 0px; max-width: 50vw; min-width: 180px;"
           >

--- a/src/components/popover/theme.css
+++ b/src/components/popover/theme.css
@@ -1,7 +1,3 @@
-@import '@teamleader/ui-animations';
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-
 :root {
   --popover-border-radius: calc(0.4 * var(--unit));
   --popover-box-shadow: 0 0 0 1px hsl(var(--color-teal-dark-hsl), 20%);

--- a/src/components/popover/theme.css
+++ b/src/components/popover/theme.css
@@ -1,6 +1,6 @@
 :root {
   --popover-border-radius: calc(0.4 * var(--unit));
-  --popover-box-shadow: 0 0 0 1px hsl(var(--color-teal-dark-hsl), 20%);
+  --popover-box-shadow: 0 0 0 1px hsl(var(--color-teal-dark-hsl) / 20%);
 }
 
 .wrapper {

--- a/src/components/poweredByButton/theme.css
+++ b/src/components/poweredByButton/theme.css
@@ -1,8 +1,3 @@
-@import '@teamleader/ui-animations';
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-typography';
-@import '@teamleader/ui-utilities';
-
 .button {
   align-items: center;
   border-radius: var(--border-radius-medium);

--- a/src/components/poweredByButton/theme.css
+++ b/src/components/poweredByButton/theme.css
@@ -20,20 +20,20 @@
   }
 
   &-dark {
-    background: hsl(var(--color-black-hsl), 10%);
+    background: hsl(var(--color-black-hsl) / 10%);
     color: var(--color-black);
 
     &:hover {
-      background: hsl(var(--color-black-hsl), 20%);
+      background: hsl(var(--color-black-hsl) / 20%);
     }
   }
 
   &-light {
-    background: hsl(var(--color-white-hsl), 20%);
+    background: hsl(var(--color-white-hsl) / 20%);
     color: var(--color-white);
 
     &:hover {
-      background: hsl(var(--color-white-hsl), 40%);
+      background: hsl(var(--color-white-hsl) / 40%);
     }
   }
 
@@ -50,7 +50,7 @@
 
   &:active,
   &:focus-visible {
-    box-shadow: inset 0px 2px 3px hsl(var(--color-black-hsl), 24%);
+    box-shadow: inset 0px 2px 3px hsl(var(--color-black-hsl) / 24%);
   }
 
   &::-moz-focus-inner {

--- a/src/components/progressTracker/theme.css
+++ b/src/components/progressTracker/theme.css
@@ -1,8 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-typography';
-@import '@teamleader/ui-animations';
-@import '@teamleader/ui-utilities';
-
 :root {
   --bullet-size: 12px;
   --bullet-center-size: calc(var(--bullet-size) / 2);

--- a/src/components/radio/theme.css
+++ b/src/components/radio/theme.css
@@ -1,15 +1,3 @@
-:root {
-  --checkbox-border-width: 1px;
-
-  --checkbox-shape-size-small: 18px;
-  --checkbox-shape-size-medium: 24px;
-  --checkbox-shape-size-large: 30px;
-
-  --checkbox-shape-inner-size-small: 10px;
-  --checkbox-shape-inner-size-medium: 12px;
-  --checkbox-shape-inner-size-large: 18px;
-}
-
 .radiobutton {
   align-items: flex-start;
   display: flex;
@@ -31,7 +19,7 @@
   .shape {
     box-sizing: border-box;
     background: var(--color-neutral-lightest);
-    border: var(--checkbox-border-width) solid var(--color-neutral-dark);
+    border: 1px solid var(--color-neutral-dark);
     border-radius: 100%;
     color: var(--color-white);
     flex-shrink: 0;
@@ -41,6 +29,8 @@
     display: inline-flex;
     justify-content: center;
     align-items: center;
+    width: var(--shape-size);
+    height: var(--shape-size);
 
     &::before {
       box-sizing: border-box;
@@ -52,7 +42,8 @@
       height: 100%;
       transform: scale(0);
       transition: transform var(--animation-duration) var(--animation-curve-default);
-      width: 100%;
+      width: var(--shape-inner-size);
+      height: var(--shape-inner-size);
     }
   }
 
@@ -112,46 +103,25 @@
   }
 
   &.is-small {
-    .shape {
-      width: var(--checkbox-shape-size-small);
-      height: var(--checkbox-shape-size-small);
-
-      &:before {
-        width: var(--checkbox-shape-inner-size-small);
-        height: var(--checkbox-shape-inner-size-small);
-      }
-    }
+    --shape-size: 18px;
+    --shape-inner-size: 10px;
   }
 
   &.is-medium {
+  --shape-size: 24px;
+  --shape-inner-size: 12px;
+
     .label {
       padding-top: var(--spacer-smallest);
-    }
-
-    .shape {
-      width: var(--checkbox-shape-size-medium);
-      height: var(--checkbox-shape-size-medium);
-
-      &:before {
-        width: var(--checkbox-shape-inner-size-medium);
-        height: var(--checkbox-shape-inner-size-medium);
-      }
     }
   }
 
   &.is-large {
+  --shape-size: 30px;
+  --shape-inner-size: 18px;
+
     .label {
       padding-top: var(--spacer-smallest);
-    }
-
-    .shape {
-      width: var(--checkbox-shape-size-large);
-      height: var(--checkbox-shape-size-large);
-
-      &:before {
-        width: var(--checkbox-shape-inner-size-large);
-        height: var(--checkbox-shape-inner-size-large);
-      }
     }
   }
 }

--- a/src/components/radio/theme.css
+++ b/src/components/radio/theme.css
@@ -1,7 +1,3 @@
-@import '@teamleader/ui-animations';
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-
 :root {
   --checkbox-border-width: 1px;
 

--- a/src/components/select/__tests__/__snapshots__/Select.spec.tsx.snap
+++ b/src/components/select/__tests__/__snapshots__/Select.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`Component - Select does not render a clear button when no value is prov
     data-teamleader-ui="select"
   >
     <div
-      class="select css-b62m3t-container"
+      class="reset-font-smoothing select css-b62m3t-container"
     >
       <span
         class="css-1f43avz-a11yText-A11yText"
@@ -91,7 +91,7 @@ exports[`Component - Select renders 1`] = `
     data-teamleader-ui="select"
   >
     <div
-      class="select css-b62m3t-container"
+      class="reset-font-smoothing select css-b62m3t-container"
     >
       <span
         class="css-1f43avz-a11yText-A11yText"
@@ -175,7 +175,7 @@ exports[`Component - Select renders a clear button when a value is provided 1`] 
     data-teamleader-ui="select"
   >
     <div
-      class="select css-b62m3t-container"
+      class="reset-font-smoothing select css-b62m3t-container"
     >
       <span
         class="css-1f43avz-a11yText-A11yText"
@@ -278,7 +278,7 @@ exports[`Component - Select renders a help text 1`] = `
     data-teamleader-ui="select"
   >
     <div
-      class="select css-b62m3t-container"
+      class="reset-font-smoothing select css-b62m3t-container"
     >
       <span
         class="css-1f43avz-a11yText-A11yText"
@@ -368,7 +368,7 @@ exports[`Component - Select renders a success message 1`] = `
     data-teamleader-ui="select"
   >
     <div
-      class="select css-b62m3t-container"
+      class="reset-font-smoothing select css-b62m3t-container"
     >
       <span
         class="css-1f43avz-a11yText-A11yText"
@@ -460,7 +460,7 @@ exports[`Component - Select renders a warning message 1`] = `
     data-teamleader-ui="select"
   >
     <div
-      class="select css-b62m3t-container"
+      class="reset-font-smoothing select css-b62m3t-container"
     >
       <span
         class="css-1f43avz-a11yText-A11yText"
@@ -552,7 +552,7 @@ exports[`Component - Select renders an error message 1`] = `
     data-teamleader-ui="select"
   >
     <div
-      class="select css-b62m3t-container"
+      class="reset-font-smoothing select css-b62m3t-container"
     >
       <span
         class="css-1f43avz-a11yText-A11yText"

--- a/src/components/select/theme.css
+++ b/src/components/select/theme.css
@@ -1,7 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-@import '@teamleader/ui-typography';
-
 .select {
   font-family: var(--font-family-inter);
   font-size: calc(1.4 * var(--unit));

--- a/src/components/tab/theme.css
+++ b/src/components/tab/theme.css
@@ -1,7 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-animations';
-@import '@teamleader/ui-utilities';
-
 :root {
   --scroll-button-size: 48px;
 }

--- a/src/components/tag/theme.css
+++ b/src/components/tag/theme.css
@@ -1,5 +1,3 @@
-@import '@teamleader/ui-colors';
-
 :root {
   --size-small: 18px;
   --size-medium: 24px;

--- a/src/components/tag/theme.css
+++ b/src/components/tag/theme.css
@@ -1,46 +1,26 @@
-:root {
-  --size-small: 18px;
-  --size-medium: 24px;
-  --size-large: 30px;
-}
-
 .wrapper {
   background-color: hsl(var(--color-neutral-darkest-hsl) / 12%);
   box-shadow: inset 0 0 0 1px hsl(var(--color-neutral-darkest-hsl) / 12%);
   max-width: 100%;
+  height: var(--size);
+  border-radius: calc(var(--size) / 2);
 }
 
 .remove-button {
   border-radius: 50%;
   min-width: initial;
+  height: var(--size);
+  width: var(--size);
 }
 
 .is-small {
-  border-radius: calc(var(--size-small) / 2);
-  height: var(--size-small);
-
-  .remove-button {
-    height: var(--size-small);
-    width: var(--size-small);
-  }
+  --size: 18px;
 }
 
 .is-medium {
-  border-radius: calc(var(--size-medium) / 2);
-  height: var(--size-medium);
-
-  .remove-button {
-    height: var(--size-medium);
-    width: var(--size-medium);
-  }
+  --size: 24px;
 }
 
 .is-large {
-  border-radius: calc(var(--size-large) / 2);
-  height: var(--size-large);
-
-  .remove-button {
-    height: var(--size-large);
-    width: var(--size-large);
-  }
+  --size: 30px;
 }

--- a/src/components/tag/theme.css
+++ b/src/components/tag/theme.css
@@ -5,8 +5,8 @@
 }
 
 .wrapper {
-  background-color: hsl(var(--color-neutral-darkest-hsl), 12%);
-  box-shadow: inset 0 0 0 1px hsl(var(--color-neutral-darkest-hsl), 12%);
+  background-color: hsl(var(--color-neutral-darkest-hsl) / 12%);
+  box-shadow: inset 0 0 0 1px hsl(var(--color-neutral-darkest-hsl) / 12%);
   max-width: 100%;
 }
 

--- a/src/components/timer/theme.css
+++ b/src/components/timer/theme.css
@@ -9,42 +9,42 @@
     border-color var(--animation-duration) var(--animation-curve-fast-out-slow-in);
 
   &:not(.is-running) {
-    background-color: hsl(var(--color-neutral-darkest-hsl), 12%);
-    border: 1px solid hsl(var(--color-neutral-darkest-hsl), 12%);
+    background-color: hsl(var(--color-neutral-darkest-hsl) / 12%);
+    border: 1px solid hsl(var(--color-neutral-darkest-hsl) / 12%);
 
     &:focus-visible {
-      background-color: hsl(var(--color-neutral-darkest-hsl), 12%);
-      border-color: hsl(var(--color-neutral-darkest-hsl), 24%);
-      box-shadow: 0 0 0 1px hsl(var(--color-neutral-darkest-hsl), 24%);
+      background-color: hsl(var(--color-neutral-darkest-hsl) / 12%);
+      border-color: hsl(var(--color-neutral-darkest-hsl) / 24%);
+      box-shadow: 0 0 0 1px hsl(var(--color-neutral-darkest-hsl) / 24%);
     }
 
     &:hover {
-      background-color: hsl(var(--color-neutral-darkest-hsl), 18%);
+      background-color: hsl(var(--color-neutral-darkest-hsl) / 18%);
     }
 
     &:active {
-      box-shadow: inset 0 2px 3px hsl(var(--color-neutral-darkest-hsl), 12%);
-      background-color: hsl(var(--color-neutral-darkest-hsl), 18%);
+      box-shadow: inset 0 2px 3px hsl(var(--color-neutral-darkest-hsl) / 12%);
+      background-color: hsl(var(--color-neutral-darkest-hsl) / 18%);
     }
   }
 
   &.is-running {
-    background-color: hsl(var(--color-violet-darkest-hsl), 12%);
-    border: 1px solid hsl(var(--color-violet-darkest-hsl), 12%);
+    background-color: hsl(var(--color-violet-darkest-hsl) / 12%);
+    border: 1px solid hsl(var(--color-violet-darkest-hsl) / 12%);
 
     &:focus-visible {
-      background-color: hsl(var(--color-violet-darkest-hsl), 12%);
-      border-color: hsl(var(--color-violet-darkest-hsl), 24%);
-      box-shadow: 0 0 0 1px hsl(var(--color-violet-darkest-hsl), 24%);
+      background-color: hsl(var(--color-violet-darkest-hsl) / 12%);
+      border-color: hsl(var(--color-violet-darkest-hsl) / 24%);
+      box-shadow: 0 0 0 1px hsl(var(--color-violet-darkest-hsl) / 24%);
     }
 
     &:hover {
-      background-color: hsl(var(--color-violet-darkest-hsl), 18%);
+      background-color: hsl(var(--color-violet-darkest-hsl) / 18%);
     }
 
     &:active {
-      box-shadow: inset 0 2px 3px hsl(var(--color-neutral-darkest-hsl), 12%);
-      background-color: hsl(var(--color-violet-darkest-hsl), 18%);
+      box-shadow: inset 0 2px 3px hsl(var(--color-neutral-darkest-hsl) / 12%);
+      background-color: hsl(var(--color-violet-darkest-hsl) / 18%);
     }
   }
 }

--- a/src/components/timer/theme.css
+++ b/src/components/timer/theme.css
@@ -1,6 +1,3 @@
-@import '@teamleader/ui-animations';
-@import '@teamleader/ui-colors';
-
 .timer {
   cursor: pointer;
   height: 30px;

--- a/src/components/toast/__tests__/__snapshots__/Toast.spec.tsx.snap
+++ b/src/components/toast/__tests__/__snapshots__/Toast.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Component - Toast renders 1`] = `
 <DocumentFragment>
   <div
-    class="toast"
+    class="reset-box-sizing box-shadow-400 toast"
     data-teamleader-ui="toast"
   >
     <div

--- a/src/components/toast/__tests__/__snapshots__/ToastContainer.spec.tsx.snap
+++ b/src/components/toast/__tests__/__snapshots__/ToastContainer.spec.tsx.snap
@@ -8,7 +8,7 @@ exports[`Component - Toast renders 1`] = `
   >
     <li>
       <div
-        class="toast"
+        class="reset-box-sizing box-shadow-400 toast"
         data-teamleader-ui="toast"
       >
         <div
@@ -19,7 +19,7 @@ exports[`Component - Toast renders 1`] = `
         </div>
       </div>
       <div
-        class="toast"
+        class="reset-box-sizing box-shadow-400 toast"
         data-teamleader-ui="toast"
       >
         <div

--- a/src/components/toast/theme.css
+++ b/src/components/toast/theme.css
@@ -1,8 +1,3 @@
-@import '@teamleader/ui-animations';
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-typography';
-@import '@teamleader/ui-utilities';
-
 :root {
   --toast-background-color: var(--color-teal-dark);
   --toast-border-radius: calc(0.4 * var(--unit));

--- a/src/components/toggle/theme.css
+++ b/src/components/toggle/theme.css
@@ -1,7 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-@import '@teamleader/ui-animations';
-
 :root {
   --toggle-border-width: 1px;
 

--- a/src/components/tooltip/theme.css
+++ b/src/components/tooltip/theme.css
@@ -26,7 +26,7 @@
 
   &::after {
     content: '';
-    border-color: hsl(var(--color-teal-dark-hsl), 20%);
+    border-color: hsl(var(--color-teal-dark-hsl) / 20%);
     border-style: solid;
     height: var(--tooltip-arrow-size);
     position: absolute;
@@ -112,7 +112,7 @@
 }
 
 .inner {
-  border: var(--tooltip-border-width) solid hsl(var(--color-teal-dark-hsl), 20%);
+  border: var(--tooltip-border-width) solid hsl(var(--color-teal-dark-hsl) / 20%);
   border-radius: var(--tooltip-border-radius);
   display: block;
 }

--- a/src/components/tooltip/theme.css
+++ b/src/components/tooltip/theme.css
@@ -1,6 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-utilities';
-
 :root {
   --tooltip-arrow-size: calc(0.8 * var(--unit));
   --tooltip-arrow-position-correction: calc(0.45 * var(--unit));

--- a/src/components/typography/Monospaced.tsx
+++ b/src/components/typography/Monospaced.tsx
@@ -1,7 +1,7 @@
 import cx from 'classnames';
 import React, { ElementType, ReactNode } from 'react';
 import { GenericComponent } from '../../@types/types';
-import theme from './theme.css';
+import uiTypography from '@teamleader/ui-typography';
 
 export interface MonospacedProps {
   children?: ReactNode;
@@ -9,7 +9,7 @@ export interface MonospacedProps {
   element?: ElementType;
 }
 const Monospaced: GenericComponent<MonospacedProps> = ({ children, className, element = 'span' }) => {
-  const classNames = cx(theme['monospaced'], className);
+  const classNames = cx(uiTypography['monospaced'], className);
 
   const Element = element;
 

--- a/src/components/typography/Text.tsx
+++ b/src/components/typography/Text.tsx
@@ -1,5 +1,6 @@
 import cx from 'classnames';
 import React, { CSSProperties, ElementType, forwardRef, ReactNode } from 'react';
+import typography from '@teamleader/ui-typography';
 import { GenericComponent } from '../../@types/types';
 import { COLORS, TINTS } from '../../constants';
 import Box from '../box';
@@ -20,8 +21,8 @@ const factory = (baseType: string, type: string, defaultElement: ElementType) =>
   const Text: GenericComponent<TextProps> = forwardRef<HTMLElement, TextProps>(
     ({ children, className, color, element = null, maxLines, style, tint = 'darkest', ...others }, ref) => {
       const classNames = cx(
-        theme[baseType],
-        theme[type],
+        typography[baseType],
+        typography[type],
 
         theme[tint],
         {

--- a/src/components/typography/theme.css
+++ b/src/components/typography/theme.css
@@ -153,7 +153,7 @@
 }
 
 .marker {
-  background-color: hsl(var(--color-mint-light-hsl), 0.3);
+  background-color: hsl(var(--color-mint-light-hsl) / 0.3);
   color: inherit;
 }
 

--- a/src/components/typography/theme.css
+++ b/src/components/typography/theme.css
@@ -1,6 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-typography';
-
 .neutral {
   &.lightest {
     color: var(--color-neutral-lightest);

--- a/src/components/wysiwygEditor/theme.css
+++ b/src/components/wysiwygEditor/theme.css
@@ -2,26 +2,26 @@
  * Variables
  */
 :root {
-  --input-text-size: calc(1.4 * var(--unit));
-  --input-border-radius: calc(0.4 * var(--unit));
-  --input-error-border: var(--color-ruby-dark);
-  --input-success-border: var(--color-mint-dark);
-  --input-warning-border: var(--color-gold-dark);
-  --input-min-height: calc(9.3 * var(--unit));
-  --input-spacing: calc(0.5 * var(--unit));
-  --toolbar-height: 43px;
+  --wysiwyg-input-text-size: calc(1.4 * var(--unit));
+  --wysiwyg-input-border-radius: calc(0.4 * var(--unit));
+  --wysiwyg-input-error-border: var(--color-ruby-dark);
+  --wysiwyg-input-success-border: var(--color-mint-dark);
+  --wysiwyg-input-warning-border: var(--color-gold-dark);
+  --wysiwyg-input-min-height: calc(9.3 * var(--unit));
+  --wysiwyg-input-spacing: calc(0.5 * var(--unit));
+  --wysiwyg-toolbar-height: 43px;
 }
 
 /**
  * Components
  */
 .input {
-  height: calc(100% - var(--toolbar-height) - 2 * var(--input-spacing));
+  height: calc(100% - var(--wysiwyg-toolbar-height) - 2 * var(--wysiwyg-input-spacing));
   overflow: auto;
-  min-height: var(--input-min-height);
-  margin: var(--input-spacing);
+  min-height: var(--wysiwyg-input-min-height);
+  margin: var(--wysiwyg-input-spacing);
   resize: vertical;
-  font-size: var(--input-text-size);
+  font-size: var(--wysiwyg-input-text-size);
   font-family: var(--font-family-inter);
   font-weight: 400;
 
@@ -32,7 +32,7 @@
 
 .wrapper {
   width: 100%;
-  border-radius: var(--input-border-radius);
+  border-radius: var(--wysiwyg-input-border-radius);
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   font-smoothing: antialiased;
@@ -83,7 +83,7 @@
 .toolbar {
   background-color: var(--color-neutral-light);
   border-bottom: solid 1px var(--color-neutral);
-  border-radius: var(--input-border-radius) var(--input-border-radius) 0 0;
+  border-radius: var(--wysiwyg-input-border-radius) var(--wysiwyg-input-border-radius) 0 0;
   display: flex;
   padding: calc(0.6 * var(--unit));
 }
@@ -116,19 +116,19 @@
  * Modifiers
  */
 .wrapper.has-success {
-  border-color: var(--input-success-border);
-  box-shadow: 0 0 0 1px var(--input-success-border);
+  border-color: var(--wysiwyg-input-success-border);
+  box-shadow: 0 0 0 1px var(--wysiwyg-input-success-border);
   z-index: 2;
 }
 
 .wrapper.has-warning {
-  border-color: var(--input-warning-border);
-  box-shadow: 0 0 0 1px var(--input-warning-border);
+  border-color: var(--wysiwyg-input-warning-border);
+  box-shadow: 0 0 0 1px var(--wysiwyg-input-warning-border);
   z-index: 2;
 }
 
 .wrapper.has-error {
-  border-color: var(--input-error-border);
-  box-shadow: 0 0 0 1px var(--input-error-border);
+  border-color: var(--wysiwyg-input-error-border);
+  box-shadow: 0 0 0 1px var(--wysiwyg-input-error-border);
   z-index: 2;
 }

--- a/src/components/wysiwygEditor/theme.css
+++ b/src/components/wysiwygEditor/theme.css
@@ -1,7 +1,3 @@
-@import '@teamleader/ui-colors';
-@import '@teamleader/ui-typography';
-@import '@teamleader/ui-animations';
-
 /**
  * Variables
  */

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,4 @@
+@import url('@teamleader/ui-colors');
+@import url('@teamleader/ui-utilities');
+@import url('@teamleader/ui-animations');
+@import url('@teamleader/ui-typography');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1441,6 +1441,11 @@
   dependencies:
     postcss-value-parser "^4.2.0"
 
+"@csstools/postcss-global-data@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@csstools/postcss-global-data/-/postcss-global-data-1.0.3.tgz#baa266a7ed2372d4f7d0996f9148809134d901af"
+  integrity sha512-x2fZOl7RJJtKC9ZfG+1bdrQKeRfP1a3Ff4uF2/fykNUKly8E8Q7lw7oegsEnqenSEDC1xjk6qXJ/fcJkTAdcNg==
+
 "@csstools/postcss-hwb-function@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@csstools/postcss-hwb-function/-/postcss-hwb-function-2.2.0.tgz#80ee5780b88994b1128ad67f98d468798413b7d7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3060,10 +3060,10 @@
   resolved "https://registry.yarnpkg.com/@teamleader/ui-animations/-/ui-animations-0.0.3.tgz#e80d91bff37cdf96e928c008cfca0add5c86d375"
   integrity sha512-gM+8TvZekcNcKWV3iZNXOXbLqpJytg33nYXcx7WgVQINbheeiPIv8Cj8XQZhHjwKP/TQJcNgiCTBjjo/dUu/EA==
 
-"@teamleader/ui-colors@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@teamleader/ui-colors/-/ui-colors-1.1.0.tgz#20565a527c16941b3cf1ed4dc7ef9e2bb625a8a1"
-  integrity sha512-0dxrzR3coPd5wXjqTAJZWMyR9VAj7VyXPcWHr+l1eD2kgj07bPq42piZLEKcAYFFrTlPFi9F7c+f8mqT/x9ZPw==
+"@teamleader/ui-colors@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@teamleader/ui-colors/-/ui-colors-2.0.0.tgz#d597a9feb3ef5e967cb2e7c656ad8e70bf922349"
+  integrity sha512-F8bVpEbzc9rVm63eSa60tWGyNvVYtXZjbAgTWB1FBf2XKYlWV9ZOBdulsQab047SAVPWMJY99zVwQTkmzwLtEg==
   dependencies:
     lodash.without "^4.4.0"
 


### PR DESCRIPTION
### Description

We noticed browser inspectors were becoming very slow. This was caused by the many imports of css variables (aka custom properties). In (almost) every css file we were importing the variables (colors, utilities, typography, animations), which was causing the variables being output in the css multiple times. 

Since `@teamleader/ui-colors@1.0.0` the colors were split in multiple variables, and has 5 variables for each colors, which seems to have been slowing down the inspector a lot, in combination with importing it so many times.

To fix this, I removed all variable imports in css files and disabled the `custom-properties` in the postcss config, so we will use custom properties "natively" instead of having them transpiled during the build process.

Because the variables are not imported in the css files anymore, you need to import them yourself. You can do that by importing them into your JS or CSS.

JS:
```js
import '@teamleader/ui/es/index.css';
```

CSS:
```css
@import url('@teamleader/ui/es/index.css');
```

I also removed/changed/refactored some css to make sure we don't have duplicate variable names for different components.

Using custom properties natively means that we can use them in a different way than we are used to. You can for example do something like this:

```css
.button {
  background: var(--button-color);
}

.primary  {
  --button-color: green;
}

.secondary  {
  --button-color: grey;
}
```

### Manual check

- run story book
- inspect a component
=> you should see almost no duplicate variables in the css inspector anymore. `ui-typography` and `ui-utilities` still seems to be duplicate, because they are both imported in js as well, which seems to add the variables to the css as well.

### Breaking changes


- [BREAKING]: CSS custom properties are not transpiled anymore. Before, the custom properties were replaced with the actual values in the built CSS, but now they are not replaced as we want to actually use custom properties natively. So you need to make sure that you import the variables into your project (e.g. `import '@teamleader/ui/es/index.css';` in JS or `@import url('@teamleader/ui/es/index.css)` in css). ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2620](https://github.com/teamleadercrm/ui/pull/2620))
- [BREAKING] `@teamleader/ui-colors` has been updated to version 2.0.0 which uses the newer comma-free syntax for hsl colors. This means that you need to update the syntax where you use the hsl value in combination with alhpa (e.g. `hsl(var(--color-teal), 50%)` should be changed to `hsl(var(--color-teal) /50%)`). ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2620](https://github.com/teamleadercrm/ui/pull/2620))

