### PR TITLE
[FRAF-1946] - Popover is not visible when its height is bigger than viewport

### DIFF
--- a/src/components/popover/positionCalculation.ts
+++ b/src/components/popover/positionCalculation.ts
@@ -219,14 +219,17 @@ const getDirection = (direction: Direction, anchorPosition: PositionValues, popo
     popoverDimensions,
   );
 
+  const isVisibleInAtLeastOneDirection = inputDirectionRendersOnScreen || oppositeDirectionRendersOnScreen;
+
   if (!inputDirectionRendersOnScreen) {
     if (oppositeDirectionRendersOnScreen) {
       return getOppositeDirection(direction);
     }
-    if (clockwise90DegreeDirectionRendersOnScreen) {
+    if (isVisibleInAtLeastOneDirection && clockwise90DegreeDirectionRendersOnScreen) {
       return getClockwise90DegreeDirection(direction);
     }
-    if (clockwise270DegreeDirectionRendersOnScreen) {
+
+    if (isVisibleInAtLeastOneDirection && clockwise270DegreeDirectionRendersOnScreen) {
       return getClockwise270DegreeDirection(direction);
     }
   }


### PR DESCRIPTION
### Link to issue

https://teamleader.atlassian.net/browse/FRAF-1946

### Description

When the height of popover exceeds the viewport height, the current behaviour rotates it to **90 degrees clockwise**.
 
I added a check which only applies for vertical (south & north) to just return the initial direction if popover height is bigger than the viewport itself.

#### Screenshot before this PR

![SCR-20230412-lwz](https://user-images.githubusercontent.com/41387389/232355361-571ba1d7-dd86-441d-86b2-10659e315579.png)


#### Screenshot after this PR

[add screenshot here]

### Breaking changes

- breaking change 1
- breaking change 2
- ...
