### PR TITLE
Menu: make sure that static Menu's inside a popover are full width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [21.0.1] - 2023-04-19
+
+### Fixed
+
+- `Menu`: Static menu's inside a popover should always be full width ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2632](https://github.com/teamleadercrm/ui/pull/2632))
+
 ## [21.0.0] - 2023-04-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "21.0.0",
+  "version": "21.0.1",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/src/components/menu/theme.css
+++ b/src/components/menu/theme.css
@@ -26,6 +26,10 @@
   }
 }
 
+[data-teamleader-ui="popover"] .menu.static {
+  width: 100%;
+}
+
 @keyframes fadein {
   0% {
     opacity: 0;


### PR DESCRIPTION
### Description

We often render `<Menu />`'s inside `<Popover />` components. If you wrap the menu with another Box, it is likely that the menu will not be full width (depending on the box and the content of the menu).

#### Screenshot before this PR

![Screenshot 2023-04-19 at 15 35 47](https://user-images.githubusercontent.com/330765/233002672-3c834efc-97cd-4185-97e5-60d0499047fe.png)


#### Screenshot after this PR
![Screenshot 2023-04-19 at 15 35 39](https://user-images.githubusercontent.com/330765/233002713-ff6604df-8c44-4101-9c01-4d18d92add74.png)

