### PR TITLE
Allow tooltipped menu items in split buttons

### DIFF
--- a/src/components/splitButton/SplitButton.tsx
+++ b/src/components/splitButton/SplitButton.tsx
@@ -119,11 +119,11 @@ const SplitButton: GenericComponent<SplitButtonProps> = ({
       >
         <Menu>
           {React.Children.map(children, (child) => {
-            if (
-              !React.isValidElement(child) ||
-              !isComponentOfType(MenuItem, child) ||
-              child.props.label === buttonLabel
-            ) {
+            if (!React.isValidElement(child) || !isComponentOfType(MenuItem, child)) {
+              return child;
+            }
+
+            if (child.props.label === buttonLabel) {
               return null;
             }
 

--- a/src/components/splitButton/splitButton.stories.tsx
+++ b/src/components/splitButton/splitButton.stories.tsx
@@ -4,6 +4,9 @@ import SplitButton from './SplitButton';
 import MenuDivider from '../menu/MenuDivider';
 import MenuItem from '../menu/MenuItem';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
+import Tooltip from '../tooltip';
+import Box from '../box';
+import { TextBody } from '../typography';
 
 const handleButtonClick = () => {
   console.log('clicked main button');
@@ -31,5 +34,16 @@ export const WithPopoverOverrides: ComponentStory<typeof SplitButton> = (args) =
   <SplitButton {...args} popoverProps={{ direction: 'north' }} onButtonClick={handleButtonClick}>
     <MenuItem onClick={handleMenuItemClick} label="Main action" />
     <MenuItem onClick={handleMenuItemClick} label="I appear above the button" />
+  </SplitButton>
+);
+
+const TooltippedBox = Tooltip(Box);
+
+export const WithTooltip: ComponentStory<typeof SplitButton> = (args) => (
+  <SplitButton {...args} onButtonClick={handleButtonClick}>
+    <MenuItem onClick={handleMenuItemClick} label="Main action" />
+    <TooltippedBox tooltip={<TextBody>I am disabled</TextBody>}>
+      <MenuItem onClick={handleMenuItemClick} label="Disabled action" disabled />
+    </TooltippedBox>
   </SplitButton>
 );


### PR DESCRIPTION
### Description

Since the TypeScript conversion we're not rendering react components that aren't MenuItems in SplitButtons. As a result tooltipped MenuItems also weren't being displayed anymore.
I've fixed it so that only the selected MenuItem is not shown.

#### Screenshot before this PR

<img width="261" alt="image" src="https://user-images.githubusercontent.com/1833617/234040944-0c0b4639-6059-4ab7-8192-ea2b918d2f31.png">

#### Screenshot after this PR

<img width="253" alt="image" src="https://user-images.githubusercontent.com/1833617/234040809-6575cdf0-e936-4c7e-b988-d1a09ee65fc0.png">


