### PR TITLE
`Select` - Fix clear indicator styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,7 @@
 
 ### Added
 
-- `IconMenu`: Added a `title` prop and pass it to the IconButton ([@driesd](https://https://github.com/driesd) in [#2648](https://github.com/teamleadercrm/ui/pull/2648))
-
 ### Changed
-
-- `IconMenu`: Spread all other props instead of only spreading the box props ([@driesd](https://https://github.com/driesd) in [#2648](https://github.com/teamleadercrm/ui/pull/2648))
 
 ### Deprecated
 
@@ -15,6 +11,20 @@
 ### Fixed
 
 ### Dependency updates
+
+## [21.2.0] - 2023-05-11
+
+### Added
+
+- `IconMenu`: Added a `title` prop and pass it to the IconButton ([@driesd](https://https://github.com/driesd) in [#2648](https://github.com/teamleadercrm/ui/pull/2648))
+
+### Changed
+
+- `IconMenu`: Spread all other props instead of only spreading the box props ([@driesd](https://https://github.com/driesd) in [#2648](https://github.com/teamleadercrm/ui/pull/2648))
+
+### Fixed
+
+- `Select`: Fixed clear indicator styles ([@BeirlaenAaron](https://https://github.com/BeirlaenAaron) in [#2649](https://github.com/teamleadercrm/ui/pull/2649))
 
 ## [21.1.0] - 2023-05-08
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "21.1.0",
+  "version": "21.2.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -114,6 +114,7 @@ const ClearIndicator = <Option extends OptionType, IsMulti extends boolean>(
       color={inverse ? 'teal' : 'neutral'}
       display="flex"
       tint={inverse ? 'lightest' : 'darkest'}
+      className={cx(theme['clear-indicator'], { [theme['clear-indicator--inverse']]: inverse })}
     >
       <IconCloseBadgedSmallFilled />
     </Icon>
@@ -159,21 +160,6 @@ function Select<Option extends OptionType, IsMulti extends boolean, IsClearable 
       activeSelects -= 1;
     };
   }, []);
-
-  const getClearIndicatorStyles = (base: CSSObjectWithLabel) => {
-    return {
-      ...base,
-      color: inverse ? COLOR.TEAL.LIGHTEST : COLOR.TEAL.DARK,
-      '&:hover': {
-        color: inverse ? COLOR.NEUTRAL.LIGHTEST : COLOR.TEAL.DARKEST,
-      },
-      cursor: 'pointer',
-      svg: {
-        height: '14px',
-        width: '14px',
-      },
-    };
-  };
 
   const getControlStyles = (base: CSSObjectWithLabel, { isDisabled, isFocused }: ControlProps<Option>) => {
     const commonStyles: CSSObjectWithLabel = {
@@ -457,7 +443,6 @@ function Select<Option extends OptionType, IsMulti extends boolean, IsClearable 
   };
 
   const getStyles = (): StylesConfig<Option> => ({
-    clearIndicator: getClearIndicatorStyles,
     control: getControlStyles,
     group: getGroupStyles,
     groupHeading: getGroupHeadingStyles,

--- a/src/components/select/__tests__/__snapshots__/Select.spec.tsx.snap
+++ b/src/components/select/__tests__/__snapshots__/Select.spec.tsx.snap
@@ -225,7 +225,7 @@ exports[`Component - Select renders a clear button when a value is provided 1`] 
         >
           <span
             aria-hidden="true"
-            class="box align-items-center display-flex neutral darkest"
+            class="box align-items-center display-flex neutral darkest clear-indicator"
             data-teamleader-ui="icon"
           >
             <svg

--- a/src/components/select/theme.css
+++ b/src/components/select/theme.css
@@ -9,6 +9,20 @@
   width: 30px;
 }
 
+.clear-indicator {
+  cursor: pointer;
+
+  &:hover {
+    color: var(--color-teal-darkest);
+  }
+
+  &--inverse {
+    &:hover {
+      color: var(--color-neutral-lightest);
+    }
+  }
+}
+
 .is-large .dropdown-indicator {
   width: 36px;
 }


### PR DESCRIPTION
### Description

Removed `getClearIndicatorStyles` because it actually didn't work as we have a custom component for the clear indicator, these styles only work on the native react select components. Added the styling to the custom component

#### Screenshot before this PR

[Screencast from 11-05-23 09:25:17.webm](https://github.com/teamleadercrm/ui/assets/55881661/fc08d0c0-2342-413d-9084-ab8d52ccf70d)


#### Screenshot after this PR

[Screencast from 11-05-23 09:24:41.webm](https://github.com/teamleadercrm/ui/assets/55881661/187faeaa-eceb-4041-b77b-a38ede96f790)


### Breaking changes

N/A
