### PR TITLE
Define default state value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `Input`: Fix warning when using input as an uncontrolled component ([@lorgan3](https://https://github.com/lorgan3) in [#2652](https://github.com/teamleadercrm/ui/pull/2652))
+
 ### Dependency updates
 
 ## [21.2.0] - 2023-05-11

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -17,7 +17,7 @@ export interface InputProps extends Omit<SingleLineInputBaseProps, 'onChange'> {
 
 const Input: GenericComponent<InputProps> = forwardRef<HTMLInputElement | HTMLTextAreaElement, InputProps>(
   ({ value, onChange, ...others }: InputProps, forwardedRef) => {
-    const [stateValue, setStateValue] = useState(value);
+    const [stateValue, setStateValue] = useState(value ?? '');
 
     const handleChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       setStateValue(event.currentTarget.value);


### PR DESCRIPTION
### Description

If you pass no value to an Input component it's uncontrolled at first but because the component uses state internally you get a warning about it becoming controlled when you start typing.

#### Screenshot before this PR

/

#### Screenshot after this PR

/

### Breaking changes

/
