### PR TITLE
[FRONT-370] support all Box props on the Flex component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- `Flex`: Added support for all `Box` props on the `Flex` component ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2660](https://github.com/teamleadercrm/ui/pull/2660))
+- `Flex`: Allow reverse flex directions as well ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2660](https://github.com/teamleadercrm/ui/pull/2660))
+
 ### Deprecated
 
 ### Removed

--- a/src/components/flex/Flex.tsx
+++ b/src/components/flex/Flex.tsx
@@ -9,7 +9,7 @@ type Gap = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 export interface FlexProps extends Omit<BoxProps, 'ref' | 'flexDirection'> {
   children?: React.ReactNode;
   gap?: Gap;
-  direction?: 'row' | 'column';
+  direction?: 'row' | 'row-reverse' | 'column' | 'column-reverse';
   /** A class name for the flex element to give custom styles. */
   className?: string;
 }

--- a/src/components/flex/Flex.tsx
+++ b/src/components/flex/Flex.tsx
@@ -1,39 +1,32 @@
 import cx from 'classnames';
-import React, { forwardRef, ReactNode } from 'react';
+import React, { forwardRef } from 'react';
 import { GenericComponent } from '../../@types/types';
+import { Box, BoxProps } from '../box';
 import theme from './theme.css';
 
 type Gap = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
-export type FlexProps = Partial<{
-  children: ReactNode;
-  direction: 'row' | 'column';
-  gap: Gap;
-  // Ideally CSSProperties should be used as the type.
-  // However because of the two-value sytnax of these properties the type includes (string & {}) which is not suitable for us.
-  // The library can be fixed with template literal types.
-  alignItems: 'center' | 'flex-start' | 'flex-end' | 'baseline' | 'stretch';
-  justifyContent: 'center' | 'flex-start' | 'flex-end' | 'space-around' | 'space-between' | 'space-evenly';
-  className: string;
-}>;
+export interface FlexProps extends Omit<BoxProps, 'ref' | 'flexDirection'> {
+  children?: React.ReactNode;
+  gap?: Gap;
+  direction?: 'row' | 'column';
+  /** A class name for the flex element to give custom styles. */
+  className?: string;
+}
 
 const Flex: GenericComponent<FlexProps> = forwardRef<HTMLDivElement, FlexProps>(
-  ({ children, direction = 'row', gap = 0, alignItems, justifyContent, className }, ref) => {
+  ({ children, direction = 'row', gap = 0, className, ...rest }, ref) => {
     const classNames = cx(
-      theme['flex'],
-      theme[`${direction}`],
       {
         [theme[`gap-${gap}`]]: gap > 0,
       },
       className,
     );
 
-    const flexStyles = { alignItems, justifyContent };
-
     return (
-      <div className={classNames} style={flexStyles} ref={ref}>
+      <Box display="flex" boxSizing="border-box" flexDirection={direction} className={classNames} ref={ref} {...rest}>
         {children}
-      </div>
+      </Box>
     );
   },
 );

--- a/src/components/flex/__tests__/__snapshots__/Flex.spec.tsx.snap
+++ b/src/components/flex/__tests__/__snapshots__/Flex.spec.tsx.snap
@@ -3,8 +3,8 @@
 exports[`Component - Flex renders 1`] = `
 <DocumentFragment>
   <div
-    class="flex row gap-2"
-    style="align-items: flex-end; justify-content: center;"
+    class="box align-items-flex-end display-flex flex-direction-row justify-content-center gap-2"
+    style="box-sizing: border-box;"
   >
     <div>
       Foo

--- a/src/components/flex/theme.css
+++ b/src/components/flex/theme.css
@@ -1,16 +1,3 @@
-.flex {
-  box-sizing: border-box;
-  display: flex;
-}
-
-.row {
-  flex-direction: row;
-}
-
-.column {
-  flex-direction: column;
-}
-
 /* prettier-ignore */
 @each
   $factor, $spacer in (1, 2, 3, 4, 5, 6, 7, 8), (var(--spacer-smallest), var(--spacer-smaller), var(--spacer-small), var(--spacer-regular), var(--spacer-medium), var(--spacer-big), var(--spacer-bigger), var(--spacer-biggest)) {

--- a/src/components/marketingDialog/__tests__/__snapshots__/MarketingDialog.spec.tsx.snap
+++ b/src/components/marketingDialog/__tests__/__snapshots__/MarketingDialog.spec.tsx.snap
@@ -93,8 +93,8 @@ exports[`Component - Dialog renders 1`] = `
                     foobar
                   </p>
                   <div
-                    class="flex column gap-3"
-                    style="align-items: center;"
+                    class="box align-items-center display-flex flex-direction-column gap-3"
+                    style="box-sizing: border-box;"
                   >
                     <button
                       class="box reset-box-sizing reset-font-smoothing button-base button primary medium has-icon-only is-full-width"


### PR DESCRIPTION
### Description

Added support for all `Box` props on the `Flex` component (except `flexDirection`, which is just `direction` on the `Flex` component). Also allowed the reverse flex directions as well.

