### PR TITLE
[FRONT-515] menu component portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ### Added
 
+- `Menu`: If the child is a `Fragment` element, the `onClick` event handler will be passed to its children. ([@farazatarodi](https://https://github.com/farazatarodi) in [#2618](https://github.com/teamleadercrm/ui/pull/2656))
+
 ### Changed
 
 - `Flex`: Added support for all `Box` props on the `Flex` component ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2660](https://github.com/teamleadercrm/ui/pull/2660))
 - `Flex`: Allow reverse flex directions as well ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2660](https://github.com/teamleadercrm/ui/pull/2660))
+- `Menu`: Menu is now rendered through a portal if the position is not static ([@farazatarodi](https://https://github.com/farazatarodi) in [#2618](https://github.com/teamleadercrm/ui/pull/2656))
 
 ### Deprecated
 
@@ -14,6 +17,7 @@
 ### Fixed
 
 - `Input`: Fix warning when using input as an uncontrolled component ([@lorgan3](https://https://github.com/lorgan3) in [#2652](https://github.com/teamleadercrm/ui/pull/2652))
+- `Menu`: the `onClick` event listener is passed to all children ([@farazatarodi](https://https://github.com/farazatarodi) in [#2618](https://github.com/teamleadercrm/ui/pull/2656))
 
 ### Dependency updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `Flex`: Added support for all `Box` props on the `Flex` component ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2660](https://github.com/teamleadercrm/ui/pull/2660))
 - `Flex`: Allow reverse flex directions as well ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2660](https://github.com/teamleadercrm/ui/pull/2660))
 - `Menu`: Menu is now rendered through a portal if the position is not static ([@farazatarodi](https://https://github.com/farazatarodi) in [#2661](https://github.com/teamleadercrm/ui/pull/2661))
+- `Menu`: Menu uses an overlay to detect clicks outside of it and to lock scroll, similar to `Popover` ([@farazatarodi](https://https://github.com/farazatarodi) in [#2661](https://github.com/teamleadercrm/ui/pull/2661))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ### Added
 
-- `Menu`: If the child is a `Fragment` element, the `onClick` event handler will be passed to its children. ([@farazatarodi](https://https://github.com/farazatarodi) in [#2618](https://github.com/teamleadercrm/ui/pull/2656))
+- `Menu`: If the child is a `Fragment` element, the `onClick` event handler will be passed to its children. ([@farazatarodi](https://https://github.com/farazatarodi) in [#2661](https://github.com/teamleadercrm/ui/pull/2661))
 
 ### Changed
 
 - `Flex`: Added support for all `Box` props on the `Flex` component ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2660](https://github.com/teamleadercrm/ui/pull/2660))
 - `Flex`: Allow reverse flex directions as well ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2660](https://github.com/teamleadercrm/ui/pull/2660))
-- `Menu`: Menu is now rendered through a portal if the position is not static ([@farazatarodi](https://https://github.com/farazatarodi) in [#2618](https://github.com/teamleadercrm/ui/pull/2656))
+- `Menu`: Menu is now rendered through a portal if the position is not static ([@farazatarodi](https://https://github.com/farazatarodi) in [#2661](https://github.com/teamleadercrm/ui/pull/2661))
 
 ### Deprecated
 
@@ -17,7 +17,7 @@
 ### Fixed
 
 - `Input`: Fix warning when using input as an uncontrolled component ([@lorgan3](https://https://github.com/lorgan3) in [#2652](https://github.com/teamleadercrm/ui/pull/2652))
-- `Menu`: the `onClick` event listener is passed to all children ([@farazatarodi](https://https://github.com/farazatarodi) in [#2618](https://github.com/teamleadercrm/ui/pull/2656))
+- `Menu`: the `onClick` event listener is passed to all children ([@farazatarodi](https://https://github.com/farazatarodi) in [#2661](https://github.com/teamleadercrm/ui/pull/2661))
 
 ### Dependency updates
 

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -247,6 +247,16 @@ const Menu = <S,>({
     }
   }, [calculatePosition, positionState, maxHeight]);
 
+  useEffect(() => {
+    if (active) {
+      document.body.style.overflow = 'hidden';
+    }
+
+    if (!active && document.querySelectorAll('[data-teamleader-ui="overlay"]').length === 0) {
+      document.body.style.overflow = '';
+    }
+  }, [active]);
+
   const menu = localActive ? (
     <Box data-teamleader-ui="menu" className={classNames} ref={menuRef} style={calculatedPosition} {...others}>
       <ul className={theme['menu-inner']} style={{ maxHeight }}>

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -5,7 +5,6 @@ import React, {
   ReactNode,
   SyntheticEvent,
   useCallback,
-  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -217,16 +216,6 @@ const Menu = <S,>({
       setCalculatedPosition(calculatePosition());
     }
   }, [calculatePosition, positionState, maxHeight]);
-
-  useEffect(() => {
-    if (active) {
-      document.body.style.overflow = 'hidden';
-    }
-
-    if (!active && document.querySelectorAll('[data-teamleader-ui="overlay"]').length === 0) {
-      document.body.style.overflow = '';
-    }
-  }, [active]);
 
   const menu = localActive ? (
     <div

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -1,5 +1,6 @@
 import cx from 'classnames';
 import React, {
+  Fragment,
   ReactElement,
   ReactNode,
   SyntheticEvent,
@@ -197,7 +198,21 @@ const Menu = <S,>({
           });
         }
 
-        return React.cloneElement(item);
+        if (isComponentOfType(Fragment, item)) {
+          const itemChildren = React.Children.toArray(item.props.children);
+          return React.Children.map(
+            itemChildren,
+            (child: ReactNode) =>
+              React.isValidElement(child) &&
+              React.cloneElement(child as ReactElement, {
+                onClick: (event: SyntheticEvent) => handleSelect(item, event),
+              }),
+          );
+        }
+
+        return React.cloneElement(item as ReactElement, {
+          onClick: (event: SyntheticEvent) => handleSelect(item, event),
+        });
       }
     });
   }, [children, handleSelect, selectable, selected]);

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -185,7 +185,7 @@ const Menu = <S,>({
             (child: ReactNode) =>
               React.isValidElement(child) &&
               React.cloneElement(child as ReactElement, {
-                onClick: (event: SyntheticEvent) => handleSelect(item, event),
+                onClick: (event: SyntheticEvent) => handleSelect(child, event),
               }),
           );
         }
@@ -228,11 +228,11 @@ const Menu = <S,>({
         onHide && onHide();
       }}
     >
-    <Box data-teamleader-ui="menu" className={classNames} ref={menuRef} style={calculatedPosition} {...others}>
-      <ul className={theme['menu-inner']} style={{ maxHeight }}>
-        {renderItems()}
-      </ul>
-    </Box>
+      <Box data-teamleader-ui="menu" className={classNames} ref={menuRef} style={calculatedPosition} {...others}>
+        <ul className={theme['menu-inner']} style={{ maxHeight }}>
+          {renderItems()}
+        </ul>
+      </Box>
     </div>
   ) : null;
 

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -84,25 +84,6 @@ const Menu = <S,>({
     className,
   );
 
-  const handleDocumentClick = useCallback(
-    (event: Event) => {
-      const clickedNode = event.target as HTMLElement;
-      const menuNode = menuRef.current;
-
-      if (
-        menuNode &&
-        menuNode !== clickedNode &&
-        !menuNode.contains(clickedNode) &&
-        anchorElement &&
-        anchorElement !== clickedNode &&
-        !anchorElement.contains(clickedNode)
-      ) {
-        onHide && onHide();
-      }
-    },
-    [anchorElement, onHide],
-  );
-
   const handleSelect = useCallback(
     (item: ReactElement, event: SyntheticEvent) => {
       const { value, onClick } = item.props;
@@ -216,16 +197,6 @@ const Menu = <S,>({
       }
     });
   }, [children, handleSelect, selectable, selected]);
-
-  useEffect(() => {
-    if (position !== POSITION.STATIC && active) {
-      document.documentElement.addEventListener('click', handleDocumentClick);
-
-      return () => {
-        document.documentElement.removeEventListener('click', handleDocumentClick);
-      };
-    }
-  }, [active, handleDocumentClick, position]);
 
   useLayoutEffect(() => {
     if (position === POSITION.AUTO && anchorElement && active) {

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -88,7 +88,14 @@ const Menu = <S,>({
       const clickedNode = event.target as HTMLElement;
       const menuNode = menuRef.current;
 
-      if (menuNode && menuNode !== clickedNode && anchorElement !== clickedNode && !menuNode.contains(clickedNode)) {
+      if (
+        menuNode &&
+        menuNode !== clickedNode &&
+        !menuNode.contains(clickedNode) &&
+        anchorElement &&
+        anchorElement !== clickedNode &&
+        !anchorElement.contains(clickedNode)
+      ) {
         onHide && onHide();
       }
     },

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -258,11 +258,22 @@ const Menu = <S,>({
   }, [active]);
 
   const menu = localActive ? (
+    <div
+      style={{
+        position: position === POSITION.STATIC ? 'relative' : 'absolute',
+      }}
+      className={theme['menu-overlay']}
+      onClick={(event) => {
+        event.stopPropagation();
+        onHide && onHide();
+      }}
+    >
     <Box data-teamleader-ui="menu" className={classNames} ref={menuRef} style={calculatedPosition} {...others}>
       <ul className={theme['menu-inner']} style={{ maxHeight }}>
         {renderItems()}
       </ul>
     </Box>
+    </div>
   ) : null;
 
   return position === POSITION.STATIC ? menu : createPortal(menu, document.body);

--- a/src/components/menu/__tests__/__snapshots__/Menu.spec.tsx.snap
+++ b/src/components/menu/__tests__/__snapshots__/Menu.spec.tsx.snap
@@ -3,91 +3,96 @@
 exports[`Component - Menu renders 1`] = `
 <DocumentFragment>
   <div
-    class="box menu static outline"
-    data-teamleader-ui="menu"
+    class="menu-overlay"
+    style="position: relative;"
   >
-    <ul
-      class="menu-inner"
+    <div
+      class="box menu static outline"
+      data-teamleader-ui="menu"
     >
-      <li
-        class="box display-flex"
-        data-teamleader-ui="menu-item"
+      <ul
+        class="menu-inner"
       >
-        <button
-          class="box align-items-center display-flex padding-bottom-2 padding-left-3 padding-right-3 padding-top-2 text-align-left menu-item"
-          style="flex: 1 1 auto;"
+        <li
+          class="box display-flex"
+          data-teamleader-ui="menu-item"
         >
-          <div
-            class="box"
+          <button
+            class="box align-items-center display-flex padding-bottom-2 padding-left-3 padding-right-3 padding-top-2 text-align-left menu-item"
             style="flex: 1 1 auto;"
           >
-            <p
-              class="box text text-body darkest teal"
-              data-teamleader-ui="text"
+            <div
+              class="box"
+              style="flex: 1 1 auto;"
             >
-              Michael Scofield
-            </p>
-          </div>
-        </button>
-      </li>
-      <li
-        class="box display-flex"
-        data-teamleader-ui="menu-item"
-      >
-        <button
-          class="box align-items-center display-flex padding-bottom-2 padding-left-3 padding-right-3 padding-top-2 text-align-left menu-item"
-          style="flex: 1 1 auto;"
+              <p
+                class="box text text-body darkest teal"
+                data-teamleader-ui="text"
+              >
+                Michael Scofield
+              </p>
+            </div>
+          </button>
+        </li>
+        <li
+          class="box display-flex"
+          data-teamleader-ui="menu-item"
         >
-          <div
-            class="box"
+          <button
+            class="box align-items-center display-flex padding-bottom-2 padding-left-3 padding-right-3 padding-top-2 text-align-left menu-item"
             style="flex: 1 1 auto;"
           >
-            <p
-              class="box text text-body darkest teal"
-              data-teamleader-ui="text"
+            <div
+              class="box"
+              style="flex: 1 1 auto;"
             >
-              Jim Halpert
-            </p>
-          </div>
-        </button>
-      </li>
-      <hr
-        class="divider"
-        data-teamleader-ui="menu-divider"
-      />
-      <div
-        class="box align-items-center display-flex padding-left-3 padding-right-3 title"
-        data-teamleader-ui="menu-title"
-      >
-        <h4
-          class="box heading heading-4 darkest teal"
-          data-teamleader-ui="heading"
+              <p
+                class="box text text-body darkest teal"
+                data-teamleader-ui="text"
+              >
+                Jim Halpert
+              </p>
+            </div>
+          </button>
+        </li>
+        <hr
+          class="divider"
+          data-teamleader-ui="menu-divider"
+        />
+        <div
+          class="box align-items-center display-flex padding-left-3 padding-right-3 title"
+          data-teamleader-ui="menu-title"
         >
-          Assistants
-        </h4>
-      </div>
-      <li
-        class="box display-flex"
-        data-teamleader-ui="menu-item"
-      >
-        <button
-          class="box align-items-center display-flex padding-bottom-2 padding-left-3 padding-right-3 padding-top-2 text-align-left menu-item"
-          style="flex: 1 1 auto;"
+          <h4
+            class="box heading heading-4 darkest teal"
+            data-teamleader-ui="heading"
+          >
+            Assistants
+          </h4>
+        </div>
+        <li
+          class="box display-flex"
+          data-teamleader-ui="menu-item"
         >
-          <div
-            class="box"
+          <button
+            class="box align-items-center display-flex padding-bottom-2 padding-left-3 padding-right-3 padding-top-2 text-align-left menu-item"
             style="flex: 1 1 auto;"
           >
-            <p
-              class="box text text-body darkest teal"
-              data-teamleader-ui="text"
+            <div
+              class="box"
+              style="flex: 1 1 auto;"
             >
-              Dwight Schrute
-            </p>
-          </div>
-        </button>
-      </li>
-    </ul>
+              <p
+                class="box text text-body darkest teal"
+                data-teamleader-ui="text"
+              >
+                Dwight Schrute
+              </p>
+            </div>
+          </button>
+        </li>
+      </ul>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/src/components/menu/theme.css
+++ b/src/components/menu/theme.css
@@ -6,8 +6,6 @@
 }
 
 .icon-menu {
-  display: inline-block;
-  position: relative;
   text-align: center;
 }
 
@@ -26,7 +24,7 @@
   }
 }
 
-[data-teamleader-ui="popover"] .menu.static {
+[data-teamleader-ui='popover'] .menu.static {
   width: 100%;
 }
 

--- a/src/components/menu/theme.css
+++ b/src/components/menu/theme.css
@@ -9,6 +9,14 @@
   text-align: center;
 }
 
+.menu-overlay {
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1000;
+}
+
 .menu {
   display: inline-block;
   position: relative;


### PR DESCRIPTION
OG PR: https://github.com/teamleadercrm/ui/pull/2656

### Description

With the new implementation of the Menu component, it is using absolute position to position it according to the anchor element. This requires that the menu and the anchor element be wrapped inside a container with a non-static position.
This container and the elements can have problems with stack context (z index) and overflow.
After research and prototypes, the best solution would be to render the Menu component with a portal.

Other approaches considered:
- Including the container in the Menu itself. This will limit the component and difficult to implement.
- Using the dialog HTML tag. The top layer element that the dialog is rendered in can not be styled. This causes issues with window size and overflow.

Due to the use of portals, the Menu component is no longer rendered as a sibling of its anchor element. This means that its position will not change if the page is scrolled. We can either implement a position listener for the anchor element or lock the scroll to solve this. Adding a listener proved difficult to implement and locking the scroll is chosen as the solution. Locking the scroll is only possible with an overlay as we do not know which element is scrollable.

### Screenshot before this PR

<img width="300" alt="image" src="https://github.com/teamleadercrm/ui/assets/78449551/5891a7e5-8ca1-4699-b3cf-176ea880f76d">


### Screenshot after this PR

<img width="310" alt="image" src="https://github.com/teamleadercrm/ui/assets/78449551/1f3c2c9a-bf1e-4222-adfa-9e244b744394">


