### PR TITLE
22.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,7 @@
 
 ### Added
 
-- `Menu`: If the child is a `Fragment` element, the `onClick` event handler will be passed to its children. ([@farazatarodi](https://https://github.com/farazatarodi) in [#2661](https://github.com/teamleadercrm/ui/pull/2661))
-
 ### Changed
-
-- `Flex`: Added support for all `Box` props on the `Flex` component ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2660](https://github.com/teamleadercrm/ui/pull/2660))
-- `Flex`: Allow reverse flex directions as well ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2660](https://github.com/teamleadercrm/ui/pull/2660))
-- `Menu`: Menu is now rendered through a portal if the position is not static ([@farazatarodi](https://https://github.com/farazatarodi) in [#2661](https://github.com/teamleadercrm/ui/pull/2661))
-- `Menu`: Menu uses an overlay to detect clicks outside of it and to lock scroll, similar to `Popover` ([@farazatarodi](https://https://github.com/farazatarodi) in [#2661](https://github.com/teamleadercrm/ui/pull/2661))
 
 ### Deprecated
 
@@ -17,10 +10,25 @@
 
 ### Fixed
 
+### Dependency updates
+
+## [22.0.0] - 2023-05-31
+
+### Added
+
+- `Menu`: If the child is a `Fragment` element, the `onClick` event handler will be passed to its children. ([@farazatarodi](https://https://github.com/farazatarodi) in [#2661](https://github.com/teamleadercrm/ui/pull/2661))
+
+### Changed
+
+- `Flex`: Added support for all `Box` props on the `Flex` component ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2660](https://github.com/teamleadercrm/ui/pull/2660))
+- `Flex`: Allow reverse flex directions as well ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2660](https://github.com/teamleadercrm/ui/pull/2660))
+- [BREAKING] `Menu`: Menu is now rendered through a portal if the position is not static ([@farazatarodi](https://https://github.com/farazatarodi) in [#2661](https://github.com/teamleadercrm/ui/pull/2661))
+- `Menu`: Menu uses an overlay to detect clicks outside of it and to lock scroll, similar to `Popover` ([@farazatarodi](https://https://github.com/farazatarodi) in [#2661](https://github.com/teamleadercrm/ui/pull/2661))
+
+### Fixed
+
 - `Input`: Fix warning when using input as an uncontrolled component ([@lorgan3](https://https://github.com/lorgan3) in [#2652](https://github.com/teamleadercrm/ui/pull/2652))
 - `Menu`: the `onClick` event listener is passed to all children ([@farazatarodi](https://https://github.com/farazatarodi) in [#2661](https://github.com/teamleadercrm/ui/pull/2661))
-
-### Dependency updates
 
 ## [21.2.0] - 2023-05-11
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "21.2.0",
+  "version": "22.0.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [22.0.0] - 2023-05-31

### Added

- `Menu`: If the child is a `Fragment` element, the `onClick` event handler will be passed to its children. ([@farazatarodi](https://https://github.com/farazatarodi) in [#2661](https://github.com/teamleadercrm/ui/pull/2661))

### Changed

- `Flex`: Added support for all `Box` props on the `Flex` component ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2660](https://github.com/teamleadercrm/ui/pull/2660))
- `Flex`: Allow reverse flex directions as well ([@lowiebenoot](https://https://github.com/lowiebenoot) in [#2660](https://github.com/teamleadercrm/ui/pull/2660))
- [BREAKING] `Menu`: Menu is now rendered through a portal if the position is not static ([@farazatarodi](https://https://github.com/farazatarodi) in [#2661](https://github.com/teamleadercrm/ui/pull/2661))
- `Menu`: Menu uses an overlay to detect clicks outside of it and to lock scroll, similar to `Popover` ([@farazatarodi](https://https://github.com/farazatarodi) in [#2661](https://github.com/teamleadercrm/ui/pull/2661))

### Fixed

- `Input`: Fix warning when using input as an uncontrolled component ([@lorgan3](https://https://github.com/lorgan3) in [#2652](https://github.com/teamleadercrm/ui/pull/2652))
- `Menu`: the `onClick` event listener is passed to all children ([@farazatarodi](https://https://github.com/farazatarodi) in [#2661](https://github.com/teamleadercrm/ui/pull/2661))

