### PR TITLE
22.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### Added
 
-- `Menu`: Added option to keep menu open after clicking the child. ([@farazatarodi](https://https://github.com/farazatarodi) in [#2669](https://github.com/teamleadercrm/ui/pull/2669))
-
 ### Changed
 
 ### Deprecated
@@ -13,6 +11,12 @@
 ### Fixed
 
 ### Dependency updates
+
+## [22.1.0] - 2023-06-01
+
+### Added
+
+- `Menu`: Added option to keep menu open after clicking the child. ([@farazatarodi](https://https://github.com/farazatarodi) in [#2669](https://github.com/teamleadercrm/ui/pull/2669))
 
 ## [22.0.0] - 2023-05-31
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "22.0.0",
+  "version": "22.1.0",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"


### PR DESCRIPTION
## [22.1.0] - 2023-06-01

### Added

- `Menu`: Added option to keep menu open after clicking the child. ([@farazatarodi](https://https://github.com/farazatarodi) in [#2669](https://github.com/teamleadercrm/ui/pull/2669))

