### PR TITLE
Fix removing toasts sometimes causing toasts to appear twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [22.1.1] - 2023-06-14
+
+### Fixed
+
+- `ToastContainer`: Fixed all toasts being re-added when removing a toast in the middle of the stack. ([@lorgan3](https://https://github.com/lorgan3) in [#2682](https://github.com/teamleadercrm/ui/pull/2682))
+
 ## [22.1.0] - 2023-06-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "22.1.0",
+  "version": "22.1.1",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/src/components/toast/ToastContainer.tsx
+++ b/src/components/toast/ToastContainer.tsx
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import React, { CSSProperties, ReactChild, ReactElement, ReactFragment, ReactNode, ReactPortal } from 'react';
+import React, { CSSProperties, ReactElement, ReactFragment, ReactNode, ReactPortal } from 'react';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { GenericComponent } from '../../@types/types';
 import theme from './theme.css';
@@ -13,7 +13,7 @@ export interface ToastContainerProps {
   style?: CSSProperties;
 }
 
-type AllowedChildrenTypes = ReactChild | ReactFragment | ReactPortal | boolean;
+type AllowedChildrenTypes = ReactElement | ReactFragment | ReactPortal;
 
 const ToastContainer: GenericComponent<ToastContainerProps> = ({ children, className, style }) => {
   const classNames = cx(theme['container'], className);
@@ -29,7 +29,7 @@ const ToastContainer: GenericComponent<ToastContainerProps> = ({ children, class
           return (
             <CSSTransition
               timeout={1000}
-              key={index}
+              key={'key' in child ? child.key : index}
               classNames={{
                 appear: cx(theme['appear']),
                 appearActive: cx(theme['appear-active']),


### PR DESCRIPTION
### Description

Because we were using the index as the key it was causing all toasts to update when a toast in the middle was removed. This in turn caused the transition group to remove all toasts and re-add the ones that shouldn't have been removed.

Fixed by just reusing the key on the toasts. This required a small type change which is technically a breaking change, but since you should only be adding toasts to the toast container anyways I just made it a `fix`. Let me know if you disagree.

Regarding the 'laggy' animation when the toast is removed: it turns out there is no animation at all, once the toast is completely removed the other toasts just snap into position. This seems like expected behaviour of the library ([same behaviour in their example](http://reactcommunity.org/react-transition-group/transition-group))
