### PR TITLE
Fix select width issue on firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [22.2.2] - 2023-08-22
+
+### Fixed
+
+`Select`: Fix that selecting long options causes the select to grow in firefox. ([@lorgan3](https://https://github.com/lorgan3) in [#2735](https://github.com/teamleadercrm/ui/pull/2735))
+
 ## [22.2.1] - 2023-07-13
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "22.2.1",
+  "version": "22.2.2",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -439,6 +439,7 @@ function Select<Option extends OptionType, IsMulti extends boolean, IsClearable 
       minHeight: minHeightBySizeMap[size] - 2,
       lineHeight: 'normal',
       padding: isMulti && hasValue && size !== 'large' ? 0 : '0 4px',
+      width: '0',
     };
   };
 

--- a/src/components/select/__tests__/__snapshots__/Select.spec.tsx.snap
+++ b/src/components/select/__tests__/__snapshots__/Select.spec.tsx.snap
@@ -23,7 +23,7 @@ exports[`Component - Select does not render a clear button when no value is prov
         class=" css-8v26ep-control"
       >
         <div
-          class=" css-1og2pl5-ValueContainer"
+          class=" css-wbqiiw-ValueContainer"
         >
           <div
             class=" css-crj073-placeholder"
@@ -107,7 +107,7 @@ exports[`Component - Select renders 1`] = `
         class=" css-8v26ep-control"
       >
         <div
-          class=" css-1og2pl5-ValueContainer"
+          class=" css-wbqiiw-ValueContainer"
         >
           <div
             class=" css-crj073-placeholder"
@@ -191,7 +191,7 @@ exports[`Component - Select renders a clear button when a value is provided 1`] 
         class=" css-8v26ep-control"
       >
         <div
-          class=" css-1og2pl5-ValueContainer"
+          class=" css-wbqiiw-ValueContainer"
         >
           <div
             class=" css-1i5bhiv-singleValue"
@@ -294,7 +294,7 @@ exports[`Component - Select renders a help text 1`] = `
         class=" css-8v26ep-control"
       >
         <div
-          class=" css-1og2pl5-ValueContainer"
+          class=" css-wbqiiw-ValueContainer"
         >
           <div
             class=" css-crj073-placeholder"
@@ -384,7 +384,7 @@ exports[`Component - Select renders a success message 1`] = `
         class=" css-1ecujp2-control"
       >
         <div
-          class=" css-1og2pl5-ValueContainer"
+          class=" css-wbqiiw-ValueContainer"
         >
           <div
             class=" css-crj073-placeholder"
@@ -476,7 +476,7 @@ exports[`Component - Select renders a warning message 1`] = `
         class=" css-1qn4nre-control"
       >
         <div
-          class=" css-1og2pl5-ValueContainer"
+          class=" css-wbqiiw-ValueContainer"
         >
           <div
             class=" css-crj073-placeholder"
@@ -568,7 +568,7 @@ exports[`Component - Select renders an error message 1`] = `
         class=" css-153luwj-control"
       >
         <div
-          class=" css-1og2pl5-ValueContainer"
+          class=" css-wbqiiw-ValueContainer"
         >
           <div
             class=" css-crj073-placeholder"


### PR DESCRIPTION
### Description

This fixes an issue that on firefox the select grows larger than allowed when a long option is selected

Testing setup in case you want to check this for yourself:
Select basic story:
```
export const basic: ComponentStory<typeof Select> = (args) => (
  <Flex>
    <Box flex={1}>
      <Select {...args} />
    </Box>
    <Box flex={1} />
  </Flex>
);
```

#### Screenshot before this PR


https://github.com/teamleadercrm/ui/assets/1833617/dd73f8df-cb69-4ac1-b216-db4610e03b6c


#### Screenshot after this PR


https://github.com/teamleadercrm/ui/assets/1833617/97b50cf0-a046-4a50-a59d-8e2e28bf021e


### Breaking changes

N/a
