### PR TITLE
Upgrade luxon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [22.3.3] - 2023-09-13
+
+- - `luxon`: Bump luxon from 3.0.3 to 3.4.3 ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2518](https://github.com/teamleadercrm/ui/pull/2764)
+
+### Dependency updates
+
 ## [22.3.2] - 2023-09-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash.pick": "^4.4.0",
     "lodash.throttle": "^4.1.1",
     "lodash.without": "^4.4.0",
-    "luxon": "^3.0.3",
+    "luxon": "^3.4.3",
     "prop-types": "^15.8.1",
     "react-day-picker": "^7.4.10",
     "react-draft-wysiwyg": "^1.14.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "22.3.2",
+  "version": "22.3.3",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9866,10 +9866,10 @@ lru-cache@^7.14.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.1.tgz#4716408dec51d5d0104732647f584d1f6738b109"
   integrity sha512-8/HcIENyQnfUTCDizRu9rrDyG6XG/21M4X7/YEGZeD76ZJilFPAUVb/2zysFf7VVO1LEjCDFyHp8pMMvozIrvg==
 
-luxon@^3.0.3:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.3.0.tgz#d73ab5b5d2b49a461c47cedbc7e73309b4805b48"
-  integrity sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==
+luxon@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.4.3.tgz#8ddf0358a9492267ffec6a13675fbaab5551315d"
+  integrity sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg==
 
 lz-string@^1.4.4, lz-string@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
### Description

Upgrading luxon because we're getting a warning when using the current version as a shared dependency in webpack-module-federation.