### PR TITLE
`Select`: make sure there is only one select-overlay element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Dependency updates
 
+## [22.3.5] - 2023-10-18
+
+### Fixed
+
+`Select`: only create 1 select-overlay element, even if you run multiple instances of @teamleader/ui ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2788](https://github.com/teamleadercrm/ui/pull/2788)
+
 ## [22.3.4] - 2023-10-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "22.3.4",
+  "version": "22.3.5",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -121,10 +121,9 @@ const ClearIndicator = <Option extends OptionType, IsMulti extends boolean>(
   );
 };
 
-export const selectOverlayNode = document.createElement('div');
+export const selectOverlayNode =
+  document.querySelector<HTMLDivElement>('div[data-teamleader-ui="select-overlay"]') || document.createElement('div');
 selectOverlayNode.setAttribute('data-teamleader-ui', 'select-overlay');
-
-let activeSelects = 0;
 
 function Select<Option extends OptionType, IsMulti extends boolean, IsClearable extends boolean>(
   {
@@ -147,18 +146,10 @@ function Select<Option extends OptionType, IsMulti extends boolean, IsClearable 
   ref: ForwardedRef<SelectRef<Option, IsMulti>>,
 ) {
   useEffect(() => {
-    activeSelects += 1;
     const isOverlayMounted = document.contains(selectOverlayNode);
     if (!isOverlayMounted) {
       document.body.appendChild(selectOverlayNode);
     }
-    return () => {
-      const isLastSelect = activeSelects <= 1;
-      if (isLastSelect && selectOverlayNode && document.body.contains(selectOverlayNode)) {
-        document.body.removeChild(selectOverlayNode);
-      }
-      activeSelects -= 1;
-    };
   }, []);
 
   const getControlStyles = (base: CSSObjectWithLabel, { isDisabled, isFocused }: ControlProps<Option>) => {


### PR DESCRIPTION
When you run multiple instances of @teamleaer/ui, it will also make multiple select-overlay elements, which is giving us some issues in tests. We opted for only creating one, and never unmounting it instead.

