### PR TITLE
Add back the data-teamleader-ui attribute on the Tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 - `Tooltip`: removed `horizontal` and `vertical` positions from the `tooltipPosition` options. Tooltips will still render to the opposite side in case there is not enough space on the chosen position. ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2796](https://github.com/teamleadercrm/ui/pull/2796)`
 
+## [23.0.1] - 2023-10-30
+
+### Fixed
+
+- `Tooltip`: added missing `data-teamleader-ui="tooltip"` attribute ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2799](https://github.com/teamleadercrm/ui/pull/2799)`
+
 ## [22.3.5] - 2023-10-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui",
   "description": "Teamleader UI library",
-  "version": "23.0.0",
+  "version": "23.0.1",
   "author": "Teamleader <development@teamleader.eu>",
   "bugs": {
     "url": "https://github.com/teamleadercrm/ui/issues"

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -1,13 +1,15 @@
-import uiUtilities from '@teamleader/ui-utilities';
-import cx from 'classnames';
 import * as RadixTooltip from '@radix-ui/react-tooltip';
-import omit from 'lodash.omit';
-import React, { MouseEventHandler, ReactNode, useEffect, useRef, useState } from 'react';
-import { GenericComponent } from '../../@types/types';
+
 import { COLORS, SIZES } from '../../constants';
+import React, { MouseEventHandler, ReactNode, useEffect, useRef, useState } from 'react';
+
 import Box from '../box';
 import { BoxProps } from '../box/Box';
+import { GenericComponent } from '../../@types/types';
+import cx from 'classnames';
+import omit from 'lodash.omit';
 import theme from './theme.css';
+import uiUtilities from '@teamleader/ui-utilities';
 
 type Position = 'bottom' | 'left' | 'right' | 'top';
 
@@ -175,6 +177,7 @@ const TooltippedComponent: GenericComponent<TooltippedComponentProps> = ({
             sideOffset={8}
             side={tooltipPosition}
             style={{ zIndex }}
+            data-teamleader-ui="tooltip"
           >
             <Box className={theme['inner']} {...SIZE_MAP[tooltipSize]}>
               {tooltipIcon && <div className={theme['icon']}>{tooltipIcon}</div>}


### PR DESCRIPTION
### Description

Accidentally removed the `data-teamleader-ui="tooltip"` attribute when implementing the new Tooltip, so added it back now.