### PR TITLE
[FRONT-117] Remove cjs build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,10 +2,6 @@
   "presets": ["@babel/preset-env", "@babel/preset-react", "@babel/preset-typescript"],
   "plugins": ["@babel/plugin-transform-runtime"],
   "env": {
-    "cjs": {
-      "plugins": ["transform-react-remove-prop-types"],
-      "ignore": ["**/*.stories.tsx", "**/*.spec.tsx", "**/*.spec.ts", "./src/static/**/*"]
-    },
     "es": {
       "plugins": ["transform-react-remove-prop-types"],
       "presets": [

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 es
-cjs
 coverage
 dist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### Changed
 
+- [BREAKING] The ES Modules build has been moved to the dist folder, so you now need update the css import to `@teamleader/ui/dist/index.css` ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2809](https://github.com/teamleadercrm/ui/pull/2809)
+
 ### Deprecated
 
 ### Removed
+
+- [BREAKING] The CommonJS build has been removed. We now only have an ES Modules build. ([@lowiebenoot](https://github.com/lowiebenoot)) in [#2809](https://github.com/teamleadercrm/ui/pull/2809)
 
 ## [23.2.0] - 2023-11-14
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,15 @@ ReactDOM.render(<Button label="Hello World!" />, document.getElementById('app'))
 Import the CSS into your project via JS or CSS.
 
 JS
+
 ```js
-import '@teamleader/ui/es/index.css';
+import '@teamleader/ui/dist/index.css';
 ```
 
 or CSS
+
 ```css
-@import url('@teamleader/ui/es/index.css');
+@import url('@teamleader/ui/dist/index.css');
 ```
 
 ## Browser support

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "Joren Saey <joren.saey@teamleader.eu>"
   ],
   "files": [
-    "es",
     "postcss.config.js",
     "dist"
   ],
@@ -160,7 +159,7 @@
     "ui"
   ],
   "license": "MIT",
-  "module": "es/index.js",
+  "module": "dist/index.js",
   "engines": {
     "node": "^14.15.0 || >=16"
   },
@@ -169,14 +168,13 @@
     "url": "git+https://github.com/teamleadercrm/ui.git"
   },
   "sideEffects": [
-    "es/**/*.css"
+    "dist/**/*.css"
   ],
   "browserslist": ">0.5%, not op_mini all",
   "scripts": {
-    "build:css": "postcss ./src/**/*.css --base src --dir ./es",
-    "build:js": "yarn build:es",
-    "build:es": "NODE_ENV=es babel src --extensions '.js,.ts,.tsx' --out-dir es",
-    "build": "rimraf es && rimraf ./dist/types && yarn build-types && yarn build:css && yarn build:js",
+    "build:css": "postcss ./src/**/*.css --base src --dir ./dist",
+    "build:js": "NODE_ENV=es babel src --extensions '.js,.ts,.tsx' --out-dir dist",
+    "build": "rimraf dist && yarn build-types && yarn build:css && yarn build:js",
     "compile": "storybook build -o dist",
     "lint:clean": "yarn lint && rimraf dist",
     "deploy:prod": "yarn lint:clean && NODE_ENV=production yarn compile",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "Joren Saey <joren.saey@teamleader.eu>"
   ],
   "files": [
-    "cjs",
     "es",
     "postcss.config.js",
     "dist"
@@ -161,7 +160,6 @@
     "ui"
   ],
   "license": "MIT",
-  "main": "cjs/index.js",
   "module": "es/index.js",
   "engines": {
     "node": "^14.15.0 || >=16"
@@ -171,16 +169,14 @@
     "url": "git+https://github.com/teamleadercrm/ui.git"
   },
   "sideEffects": [
-    "cjs/**/*.css",
     "es/**/*.css"
   ],
   "browserslist": ">0.5%, not op_mini all",
   "scripts": {
-    "build:css": "postcss ./src/**/*.css --base src --dir ./es && cp -R ./es ./cjs",
-    "build:js": "yarn build:es; yarn build:cjs",
-    "build:cjs": "NODE_ENV=cjs babel src --extensions '.js,.ts,.tsx' --out-dir cjs",
+    "build:css": "postcss ./src/**/*.css --base src --dir ./es",
+    "build:js": "yarn build:es",
     "build:es": "NODE_ENV=es babel src --extensions '.js,.ts,.tsx' --out-dir es",
-    "build": "rimraf es && rimraf cjs && rimraf ./dist/types && yarn build-types && yarn build:css && yarn build:js",
+    "build": "rimraf es && rimraf ./dist/types && yarn build-types && yarn build:css && yarn build:js",
     "compile": "storybook build -o dist",
     "lint:clean": "yarn lint && rimraf dist",
     "deploy:prod": "yarn lint:clean && NODE_ENV=production yarn compile",


### PR DESCRIPTION
### Description

Removed our common js build, as we don't use it anyway and only use esmodules.
So instead of having 2 builds in a es and cjs directory, the es build is now in the dist folder together with the types.


### Breaking changes

- The CommonJS build has been removed. We now only have an ES Modules build. 
- The ES Modules build has been moved to the dist folder, so you now need update the css import to `@teamleader/ui/dist/index.css` 

