### PR TITLE
Change element of select remove button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 
 ### Removed
 
+### Fixed
+
+## [25.0.1]
+
+### Fixed
+
+- `Select`: Do not render buttons inside the select because they can get focussed when rendered in a label. ([@lorgan3](https://github.com/lorgan3)) in [#2824](https://github.com/teamleadercrm/ui/pull/2824)
+
 ## [25.0.0]
 
 ### Added

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -141,6 +141,7 @@ const MultiValue = <Option, IsMulti extends boolean, Group extends GroupBase<Opt
       onRemoveClick={onClick}
       onRemoveMouseDown={onMouseDown}
       onRemoveMouseUp={onMouseUp}
+      removeElement="div"
       {...rest}
     >
       {children}

--- a/src/components/tag/Tag.tsx
+++ b/src/components/tag/Tag.tsx
@@ -17,11 +17,24 @@ export interface TagProps extends Omit<BoxProps, 'className' | 'size'> {
   onRemoveClick?: React.MouseEventHandler;
   onRemoveMouseDown?: React.MouseEventHandler;
   onRemoveMouseUp?: React.MouseEventHandler;
+  removeElement?: React.ElementType;
   size?: TagSize;
 }
 
 const Tag: GenericComponent<TagProps> = forwardRef<HTMLElement, TagProps>(
-  ({ children, className, onRemoveClick, onRemoveMouseDown, onRemoveMouseUp, size = 'medium', ...others }, ref) => {
+  (
+    {
+      children,
+      className,
+      onRemoveClick,
+      onRemoveMouseDown,
+      onRemoveMouseUp,
+      removeElement,
+      size = 'medium',
+      ...others
+    },
+    ref,
+  ) => {
     const classNames = cx(theme[`is-${size}`], theme['wrapper'], className);
 
     const TextElement = size === 'small' ? UITextSmall : size === 'large' ? UITextDisplay : UITextBody;
@@ -40,6 +53,7 @@ const Tag: GenericComponent<TagProps> = forwardRef<HTMLElement, TagProps>(
         </TextElement>
         {onRemoveClick && (
           <IconButton
+            element={removeElement}
             className={theme['remove-button']}
             flexShrink={0}
             icon={<IconCloseSmallOutline />}


### PR DESCRIPTION
### Description

Rendering a select in a label element causes the first remove button to get triggered when clicking on said label.
As a solution we'll make the remove button just a div (equivalent with what it was before)
